### PR TITLE
Feat/workflow orchestrator

### DIFF
--- a/demo_new_orchestrator.py
+++ b/demo_new_orchestrator.py
@@ -1,0 +1,116 @@
+import asyncio
+import logging
+import os
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Ensure the script can find the src module.
+# This might be necessary if running from the root directory.
+import sys
+# Add the project root to the Python path
+# This assumes the script is run from the project root.
+# Adjust if necessary based on your project structure.
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '.'))
+sys.path.insert(0, project_root)
+# Attempt to add src to path more robustly if needed, though direct import should work if in root
+# sys.path.insert(0, os.path.join(project_root, 'src'))
+
+
+from src.manus_use.multi_agents.new_orchestrator import NewOrchestrator
+from src.manus_use.config import Config # To potentially pre-load/check config
+
+async def main():
+    logging.info("Starting NewOrchestrator demo...")
+
+    # Optional: Pre-load and display part of the config to verify it's loading
+    try:
+        config = Config.from_file()
+        logging.info(f"Loaded configuration. LLM provider: {config.llm.provider}, Model: {config.llm.model}")
+        # Check browser-use specific LLM config if any
+        if config.browser_use.provider:
+            logging.info(f"BrowserUseAgent LLM provider: {config.browser_use.provider}, Model: {config.browser_use.model}")
+        else:
+            logging.info("BrowserUseAgent will use main LLM settings.")
+
+        # Crucial check for BrowserUseAgent dependencies
+        # This doesn't run the agent, just checks if the import within would fail
+        try:
+            from browser_use import Agent as BrowserUseCheck # Attempt the critical import
+            logging.info("'browser-use' package seems to be available.")
+        except ImportError:
+            logging.warning("'browser-use' package is NOT available. BrowserUseAgent will not work.")
+            logging.warning("Install it via: pip install browser-use")
+        
+        # Check for Langchain LLM support packages needed by BrowserUseAgent
+        try:
+            from langchain_aws import ChatBedrock
+            logging.info("'langchain-aws' (for Bedrock) is available.")
+        except ImportError:
+            logging.warning("'langchain-aws' (for Bedrock) is NOT available. BrowserUseAgent with Bedrock will fail.")
+        try:
+            from langchain_openai import ChatOpenAI
+            logging.info("'langchain-openai' (for OpenAI) is available.")
+        except ImportError:
+            logging.warning("'langchain-openai' (for OpenAI) is NOT available. BrowserUseAgent with OpenAI will fail.")
+
+
+    except Exception as e:
+        logging.error(f"Error loading configuration or checking dependencies: {e}")
+        return
+
+    orchestrator = NewOrchestrator()
+    logging.info("NewOrchestrator instantiated.")
+
+    # --- Test Case 1: Query likely for ManusAgent ---
+    query1 = "What is the capital of France and can you write a short python script to print numbers from 1 to 5?"
+    logging.info(f"\nRunning query 1: '{query1}'")
+    try:
+        response1 = await orchestrator(query1) # Use await if orchestrator call is async
+        # response1 = orchestrator(query1) # If orchestrator call is sync (Strands Agent __call__ can be sync or async)
+        # Strands Agent __call__ returns a coroutine if called from async context, else blocks.
+        # So, await is correct here.
+        logging.info(f"Response from orchestrator for query 1:\n{response1}")
+    except Exception as e:
+        logging.error(f"Error during query 1: {e}", exc_info=True)
+
+    # --- Test Case 2: Query likely for BrowserUseAgent ---
+    query2 = "What are the current top headlines on BBC News (bbc.com/news)?"
+    logging.info(f"\nRunning query 2: '{query2}'")
+    try:
+        response2 = await orchestrator(query2)
+        logging.info(f"Response from orchestrator for query 2:\n{response2}")
+    except Exception as e:
+        logging.error(f"Error during query 2: {e}", exc_info=True)
+        
+    # --- Test Case 3: Query likely for Orchestrator itself (simple) ---
+    query3 = "Hello, how are you today?"
+    logging.info(f"\nRunning query 3: '{query3}'")
+    try:
+        response3 = await orchestrator(query3)
+        logging.info(f"Response from orchestrator for query 3:\n{response3}")
+    except Exception as e:
+        logging.error(f"Error during query 3: {e}", exc_info=True)
+        
+    # --- Test Case 4: Query that might involve BrowserUseAgent failing due to missing deps ---
+    # This is more of an implicit test if 'browser-use' is not installed.
+    # The browser_agent_tool_wrapper should catch the ImportError and return a message.
+    query4 = "Find the main product listed on example.com."
+    logging.info(f"\nRunning query 4 (potential browser task): '{query4}'")
+    try:
+        response4 = await orchestrator(query4)
+        logging.info(f"Response from orchestrator for query 4:\n{response4}")
+    except Exception as e:
+        logging.error(f"Error during query 4: {e}", exc_info=True)
+
+
+if __name__ == "__main__":
+    # Ensure OPENAI_API_KEY is set if using OpenAI, or AWS credentials for Bedrock
+    # e.g., os.environ["OPENAI_API_KEY"] = "your_key_here" 
+    # (do not hardcode keys in production code)
+    
+    # On Windows, selector event loop policy might be needed for asyncio with Playwright
+    # if sys.platform == "win32" and "playwright" in sys.modules: # Check if playwright is relevant
+    #     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+        
+    asyncio.run(main())

--- a/demo_workflow_orchestrator.py
+++ b/demo_workflow_orchestrator.py
@@ -1,0 +1,104 @@
+import asyncio
+import logging
+import os
+import sys
+
+# Configure basic logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+# Ensure the script can find the src module
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '.'))
+sys.path.insert(0, project_root)
+
+from src.manus_use.multi_agents.workflow_orchestrator import WorkflowOrchestrator
+from src.manus_use.config import Config # For pre-flight checks
+
+async def main():
+    logging.info("Starting WorkflowOrchestrator demo...")
+
+    # --- Pre-flight checks (similar to demo_new_orchestrator.py) ---
+    try:
+        config = Config.from_file()
+        logging.info(f"Loaded configuration. LLM provider: {config.llm.provider}, Model: {config.llm.model}")
+        if config.browser_use.provider:
+            logging.info(f"BrowserUseAgent LLM provider: {config.browser_use.provider}, Model: {config.browser_use.model}")
+        else:
+            logging.info("BrowserUseAgent will use main LLM settings if its specific config is not set.")
+
+        # Check for BrowserUseAgent's critical dependencies
+        try:
+            from browser_use import Agent as BrowserUseCheck
+            logging.info("'browser-use' package seems to be available.")
+        except ImportError:
+            logging.warning("'browser-use' package is NOT available. BrowserUseAgent tasks in workflow will fail.")
+            logging.warning("Install it via: pip install browser-use")
+        
+        # Check for Langchain LLM support packages (if using BrowserUseAgent with these)
+        try:
+            from langchain_aws import ChatBedrock
+            logging.info("'langchain-aws' (for Bedrock) is available.")
+        except ImportError:
+            logging.warning("'langchain-aws' (for Bedrock) is NOT available.")
+        try:
+            from langchain_openai import ChatOpenAI
+            logging.info("'langchain-openai' (for OpenAI) is available.")
+        except ImportError:
+            logging.warning("'langchain-openai' (for OpenAI) is NOT available.")
+
+    except Exception as e:
+        logging.error(f"Error during configuration loading or dependency check: {e}")
+        logging.warning("Proceeding with demo, but some functionalities might be affected.")
+    # --- End of Pre-flight checks ---
+
+    # Instantiate the orchestrator
+    # The WorkflowOrchestrator's __init__ loads its own config via get_workflow_config()
+    # if not provided, so passing config here is optional but can ensure consistency.
+    orchestrator = WorkflowOrchestrator(config=config if 'config' in locals() else None)
+    logging.info("WorkflowOrchestrator instantiated.")
+
+    # Define a complex query that would benefit from a workflow
+    # Example 1: Search and then write to file
+    # query = "What is the current weather in London, UK? Then, write this weather information into a file named 'london_weather.txt'."
+    
+    # Example 2: A task that might primarily use ManusAgent (e.g., coding, simple search)
+    # query = "Write a python script to list files in the current directory and save the list to 'file_list.txt'. Then print the content of 'file_list.txt'."
+
+    # Example 3: A task that might primarily use BrowserUseAgent
+    query = "Find the main headline on the BBC News website (bbc.com/news) and then summarize it in one sentence."
+
+    logging.info(f"\nRunning workflow for query: '{query}'")
+    
+    final_result = None
+    try:
+        # run_workflow_for_request is an async method
+        final_result = await orchestrator.run_workflow_for_request(query)
+        logging.info("\n--- Workflow Execution Result ---")
+        if final_result:
+            logging.info(f"Status: {final_result.get('workflow_status', 'N/A')}")
+            logging.info(f"Output/Message: {final_result.get('output', final_result.get('message', 'No detailed output/message'))}")
+            
+            tasks_info = final_result.get('tasks', [])
+            if tasks_info:
+                logging.info("\nTasks Summary:")
+                for i, task_status in enumerate(tasks_info):
+                    logging.info(
+                        f"  Task {i+1} (ID: {task_status.get('task_id', 'N/A')}): "
+                        f"Status: {task_status.get('status', 'N/A')}, "
+                        f"Description: {task_status.get('description', 'N/A')[:50]}..., "
+                        f"Result/Error: {str(task_status.get('result', task_status.get('error', 'N/A')))[:100]}..."
+                    )
+            else:
+                # Fallback for older workflow status format or if tasks details are missing
+                logging.info(f"Full Result Object: {final_result}")
+
+        else:
+            logging.warning("Workflow execution returned no result.")
+
+    except Exception as e:
+        logging.error(f"An error occurred while running the workflow demo: {e}", exc_info=True)
+
+if __name__ == "__main__":
+    # Ensure necessary environment variables (like OPENAI_API_KEY or AWS credentials) are set.
+    # Example: os.environ["OPENAI_API_KEY"] = "your_key_here" (do not hardcode in production)
+    
+    asyncio.run(main())

--- a/src/manus_use/multi_agents/new_orchestrator.py
+++ b/src/manus_use/multi_agents/new_orchestrator.py
@@ -1,0 +1,72 @@
+import asyncio
+from typing import Optional
+
+from strands import Agent, tool
+
+from src.manus_use.agents.browser_use_agent import BrowserUseAgent
+from src.manus_use.agents.manus import ManusAgent
+from src.manus_use.config import Config
+
+config_cache: Optional[Config] = None
+
+
+def get_config() -> Config:
+    """
+    Retrieves the configuration, caching it to avoid multiple file reads.
+    """
+    global config_cache
+    if config_cache is None:
+        config_cache = Config.from_file()
+    return config_cache
+
+
+@tool
+def manus_agent_tool_wrapper(query: str) -> str:
+    """
+    Use this agent for general tasks, coding, file operations, and web searching that doesn't require complex browser interaction or session persistence. Input is a natural language query.
+    """
+    try:
+        config_instance = get_config()
+        manus_agent_instance = ManusAgent(config=config_instance)
+        response = manus_agent_instance(query)
+        return str(response)
+    except Exception as e:
+        return f"Error during ManusAgent execution: {e}"
+
+
+@tool
+def browser_agent_tool_wrapper(query: str) -> str:
+    """
+    Use this agent for tasks requiring web browser interaction, such as navigating web pages, extracting structured information from complex sites, or when session persistence across multiple web steps is needed. Input is a natural language query describing the web task.
+    """
+    try:
+        config_instance = get_config()
+        browser_agent_instance = BrowserUseAgent(config=config_instance)
+        response = browser_agent_instance(query)
+        if asyncio.iscoroutine(response):
+            response = asyncio.run(response)
+        return str(response)
+    except ImportError:
+        return "BrowserUseAgent is not available due to missing dependencies. Please ensure 'browser-use' and its LLM support packages are installed."
+    except Exception as e:
+        return f"Error during BrowserUseAgent execution: {e}"
+
+
+class NewOrchestrator(Agent):
+    def __init__(self, config: Optional[Config] = None):
+        config_instance = config if config is not None else get_config()
+
+        system_prompt = """You are an orchestrator agent. Your role is to understand user requests and delegate them to the appropriate specialized agent. You have two specialized agents available as tools:
+
+- `manus_agent_tool_wrapper`: Use this agent for general tasks, coding, file operations, and web searching that doesn't require complex browser interaction or session persistence.
+- `browser_agent_tool_wrapper`: Use this agent for tasks requiring web browser interaction, such as navigating web pages, extracting structured information from complex sites, or when session persistence across multiple web steps is needed.
+
+Analyze the user's query and determine which agent is best suited. If the query is simple and doesn't require specialized tools (e.g., a simple greeting or a very basic question you can answer directly), you can answer it yourself. Otherwise, invoke the appropriate agent tool.
+
+If a task might require a sequence of interactions, like browsing to find information and then processing that information (e.g. writing it to a file), prefer to break it down if the tools allow, or route to the agent that can handle the sequence if one is clearly more appropriate for the overall goal. For instance, if it's mostly browsing with a final file write, `browser_agent_tool_wrapper` might be able to extract information, and then a subsequent call to `manus_agent_tool_wrapper` could handle the file writing if the browser agent cannot. If unsure, state what you can do.
+"""
+        super().__init__(
+            model=config_instance.get_model(),
+            tools=[manus_agent_tool_wrapper, browser_agent_tool_wrapper],
+            system_prompt=system_prompt,
+        )

--- a/src/manus_use/multi_agents/workflow_orchestrator.py
+++ b/src/manus_use/multi_agents/workflow_orchestrator.py
@@ -1,0 +1,250 @@
+import asyncio
+import hashlib # Added
+import logging
+from typing import Any, Dict, Optional, List # Added List
+
+from strands import Agent as StrandsAgent
+from strands_tools.workflow import workflow # Added
+
+from src.manus_use.agents.manus import ManusAgent
+from src.manus_use.agents.browser_use_agent import BrowserUseAgent
+from src.manus_use.config import Config
+from src.manus_use.multi_agents.planning_agent import create_task_plan_tool, AgentType # Added
+
+
+# Global config cache to avoid reloading config.toml multiple times
+config_cache: Optional[Config] = None
+
+def get_workflow_config() -> Config:
+    """Retrieves and caches the global configuration for workflow tasks."""
+    global config_cache
+    if config_cache is None:
+        logging.info("Loading configuration for workflow tasks...")
+        config_cache = Config.from_file()
+        if config_cache:
+            logging.info(f"Config loaded. LLM provider: {config_cache.llm.provider}")
+        else:
+            logging.error("Failed to load configuration. Default config will be used by agents if they support it.")
+            config_cache = Config() 
+    return config_cache
+
+def run_manus_agent_task(query: str, task_inputs: Optional[Dict[str, Any]] = None) -> str:
+    """
+    Callable function to execute a ManusAgent task.
+    """
+    logging.info(f"Executing ManusAgent task with query: {query}")
+    if task_inputs:
+        logging.info(f"Additional task inputs: {task_inputs}")
+        # query = query.format(**task_inputs) # Example if query is a template
+
+    try:
+        cfg = get_workflow_config()
+        manus_agent = ManusAgent(config=cfg) 
+        response = manus_agent(query)
+        
+        if asyncio.iscoroutine(response):
+            try:
+                loop = asyncio.get_running_loop()
+                response_str = loop.run_until_complete(response)
+            except RuntimeError: 
+                response_str = asyncio.run(response)
+        else:
+            response_str = str(response)
+
+        logging.info(f"ManusAgent task completed. Result: {response_str[:200]}...")
+        return response_str
+    except Exception as e:
+        logging.error(f"Error during ManusAgent task execution: {e}", exc_info=True)
+        return f"Error in ManusAgent: {str(e)}"
+
+def run_browser_agent_task(query: str, task_inputs: Optional[Dict[str, Any]] = None) -> str:
+    """
+    Callable function to execute a BrowserUseAgent task.
+    """
+    logging.info(f"Executing BrowserUseAgent task with query: {query}")
+    if task_inputs:
+        logging.info(f"Additional task inputs: {task_inputs}")
+        # query = query.format(**task_inputs)
+
+    try:
+        cfg = get_workflow_config()
+        browser_agent = BrowserUseAgent(config=cfg)
+        response = browser_agent(query)
+
+        if asyncio.iscoroutine(response):
+            try:
+                loop = asyncio.get_running_loop()
+                response_str = loop.run_until_complete(response)
+            except RuntimeError: 
+                response_str = asyncio.run(response)
+        else:
+            response_str = str(response)
+
+        logging.info(f"BrowserUseAgent task completed. Result: {response_str[:200]}...")
+        return response_str
+    except ImportError as e:
+        logging.error(f"ImportError for BrowserUseAgent: {e}. 'browser-use' or its LLM dependencies might be missing.")
+        return f"BrowserUseAgent is not available due to missing dependencies: {str(e)}"
+    except Exception as e:
+        logging.error(f"Error during BrowserUseAgent task execution: {e}", exc_info=True)
+        return f"Error in BrowserUseAgent: {str(e)}"
+
+
+class WorkflowOrchestrator(StrandsAgent):
+    """
+    Orchestrates multi-agent workflows using a planning agent to generate tasks
+    and the Strands Workflow tool to execute them.
+    Tasks are mapped to specific Python functions (run_manus_agent_task, run_browser_agent_task).
+    """
+
+    def __init__(self, config: Optional[Config] = None, **kwargs: Any):
+        """
+        Initialize WorkflowOrchestrator.
+
+        Args:
+            config: Configuration object. If None, loaded via get_workflow_config().
+            **kwargs: Additional arguments for the base StrandsAgent.
+        """
+        self.config = config or get_workflow_config()
+        
+        agent_tools = [create_task_plan_tool, workflow]
+
+        system_prompt = (
+            "You are a workflow orchestrator. Your primary role is to take a user request, "
+            "use the 'create_task_plan_tool' to generate a detailed plan of tasks, "
+            "and then use the 'workflow' tool to execute this plan. "
+            "Ensure the plan is created first, then initiate the workflow."
+        )
+
+        super().__init__(
+            model=self.config.get_model(), 
+            tools=agent_tools,
+            system_prompt=system_prompt,
+            **kwargs
+        )
+
+    def _adapt_planned_tasks_for_workflow(self, planned_tasks: List[Dict]) -> List[Dict]:
+        """
+        Adapts tasks from create_task_plan_tool to be compatible with a workflow
+        tool that can execute specified Python callables.
+        """
+        adapted_tasks = []
+        for task in planned_tasks:
+            agent_type_str = task.get("agent_type", AgentType.MANUS.value) 
+            description = task.get("description", "")
+            
+            callable_path = ""
+            if agent_type_str == AgentType.MANUS.value:
+                callable_path = "src.manus_use.multi_agents.workflow_orchestrator.run_manus_agent_task"
+            elif agent_type_str == AgentType.BROWSER.value:
+                callable_path = "src.manus_use.multi_agents.workflow_orchestrator.run_browser_agent_task"
+            else:
+                logging.warning(f"Unsupported agent_type '{agent_type_str}' for task '{task.get('task_id')}'. Skipping.")
+                continue
+
+            adapted_task = {
+                "task_id": task.get("task_id", f"task_{hashlib.md5(description.encode()).hexdigest()[:6]}"),
+                "description": description, 
+                "dependencies": task.get("dependencies", []),
+                "priority": task.get("priority", 1),
+                "metadata": task.get("metadata", {}),
+                "callable_path": callable_path,
+                "arguments": { 
+                    "query": description, 
+                }
+            }
+            adapted_tasks.append(adapted_task)
+        return adapted_tasks
+
+    async def run_workflow_for_request(self, user_request: str) -> Dict[str, Any]:
+        """
+        Processes a user request by generating a task plan and executing it as a workflow.
+        """
+        logging.info(f"WorkflowOrchestrator: Received request: {user_request}")
+        
+        logging.info("Generating task plan directly using create_task_plan_tool...")
+        # Directly call the tool function for planning for reliability
+        raw_planned_tasks: List[Dict] = create_task_plan_tool(request=user_request)
+
+        if not raw_planned_tasks:
+            logging.error("Planning phase did not return any tasks.")
+            return {"status": "error", "message": "No tasks generated by the planning phase."}
+        
+        logging.info(f"Raw planned tasks: {raw_planned_tasks}")
+
+        adapted_tasks = self._adapt_planned_tasks_for_workflow(raw_planned_tasks)
+
+        if not adapted_tasks:
+            logging.error("No tasks could be adapted for workflow execution.")
+            return {"status": "error", "message": "Failed to adapt planned tasks for workflow."}
+        
+        logging.info(f"Adapted tasks for workflow: {adapted_tasks}")
+
+        workflow_id = "wf_" + hashlib.md5(user_request.encode()).hexdigest()[:10]
+        
+        create_workflow_input = {
+            "action": "create",
+            "workflow_id": workflow_id,
+            "tasks": adapted_tasks
+        }
+        logging.info(f"Creating workflow '{workflow_id}' with tasks: {adapted_tasks}")
+        
+        # Directly call the workflow tool function
+        create_response = workflow(tool={"toolUseId": "tool_create_wf", "input": create_workflow_input})
+        if asyncio.iscoroutine(create_response):
+            create_response = await create_response
+            
+        logging.info(f"Workflow creation response: {create_response}")
+
+        # Check for errors in creation response (simplified check)
+        # The actual structure of create_response from workflow tool might vary.
+        # This assumes a dict with "status" or looks for known error indicators.
+        if isinstance(create_response, dict) and (create_response.get("status") == "error" or "error" in str(create_response).lower()):
+             # More robust error extraction if create_response is a list of content items
+            error_message = "Unknown error during workflow creation"
+            if isinstance(create_response.get("content"), list) and create_response["content"]:
+                error_details = create_response["content"][0].get("text", error_message)
+                if isinstance(error_details, dict): # If text itself is a dict
+                    error_message = error_details.get("message", str(error_details))
+                else:
+                    error_message = str(error_details)
+            elif "message" in create_response:
+                 error_message = create_response["message"]
+            logging.error(f"Failed to create workflow: {error_message}")
+            return {"status": "error", "message": f"Workflow creation failed: {error_message}"}
+        elif not isinstance(create_response, dict) or not create_response.get("workflow_id"): # Simple check for success
+            logging.error(f"Workflow creation did not return expected success response: {create_response}")
+            return {"status": "error", "message": "Workflow creation failed or returned unexpected response."}
+
+
+        start_workflow_input = {
+            "action": "start",
+            "workflow_id": workflow_id
+        }
+        logging.info(f"Starting workflow '{workflow_id}'")
+        
+        run_response = workflow(tool={"toolUseId": "tool_start_wf", "input": start_workflow_input})
+        if asyncio.iscoroutine(run_response):
+            run_response = await run_response
+            
+        logging.info(f"Workflow run response: {run_response}")
+        
+        return run_response
+
+
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    print("WorkflowOrchestrator class defined. Callable task functions also defined.")
+    print("Run this file directly with uncommented examples in main to test (requires setup).")
+    
+    # Example of how to test run_workflow_for_request (requires async context and setup)
+    # async def test_orchestrator():
+    #     orchestrator = WorkflowOrchestrator()
+    #     test_request = "Research the capital of Germany and then find a good recipe for Black Forest cake."
+    #     result = await orchestrator.run_workflow_for_request(test_request)
+    #     print("\n--- WorkflowOrchestrator Test ---")
+    #     print(f"Request: {test_request}")
+    #     print(f"Result: {result}")
+
+    # if True: # Set to true to run the test
+    #    asyncio.run(test_orchestrator())

--- a/src/manus_use/multi_agents/workflow_orchestrator.py
+++ b/src/manus_use/multi_agents/workflow_orchestrator.py
@@ -1,15 +1,16 @@
 import asyncio
-import hashlib # Added
+import hashlib
+import json
 import logging
-from typing import Any, Dict, Optional, List # Added List
+import re # Added
+from typing import Any, Dict, Optional, List
 
 from strands import Agent as StrandsAgent
-from strands_tools.workflow import workflow # Added
+from strands_tools.workflow import workflow
 
 from src.manus_use.agents.manus import ManusAgent
 from src.manus_use.agents.browser_use_agent import BrowserUseAgent
 from src.manus_use.config import Config
-from src.manus_use.multi_agents.planning_agent import create_task_plan_tool, AgentType # Added
 
 
 # Global config cache to avoid reloading config.toml multiple times
@@ -35,7 +36,6 @@ def run_manus_agent_task(query: str, task_inputs: Optional[Dict[str, Any]] = Non
     logging.info(f"Executing ManusAgent task with query: {query}")
     if task_inputs:
         logging.info(f"Additional task inputs: {task_inputs}")
-        # query = query.format(**task_inputs) # Example if query is a template
 
     try:
         cfg = get_workflow_config()
@@ -64,7 +64,6 @@ def run_browser_agent_task(query: str, task_inputs: Optional[Dict[str, Any]] = N
     logging.info(f"Executing BrowserUseAgent task with query: {query}")
     if task_inputs:
         logging.info(f"Additional task inputs: {task_inputs}")
-        # query = query.format(**task_inputs)
 
     try:
         cfg = get_workflow_config()
@@ -92,7 +91,7 @@ def run_browser_agent_task(query: str, task_inputs: Optional[Dict[str, Any]] = N
 
 class WorkflowOrchestrator(StrandsAgent):
     """
-    Orchestrates multi-agent workflows using a planning agent to generate tasks
+    Orchestrates multi-agent workflows by using its own LLM to generate a task plan
     and the Strands Workflow tool to execute them.
     Tasks are mapped to specific Python functions (run_manus_agent_task, run_browser_agent_task).
     """
@@ -107,13 +106,37 @@ class WorkflowOrchestrator(StrandsAgent):
         """
         self.config = config or get_workflow_config()
         
-        agent_tools = [create_task_plan_tool, workflow]
+        agent_tools = [workflow] 
 
         system_prompt = (
-            "You are a workflow orchestrator. Your primary role is to take a user request, "
-            "use the 'create_task_plan_tool' to generate a detailed plan of tasks, "
-            "and then use the 'workflow' tool to execute this plan. "
-            "Ensure the plan is created first, then initiate the workflow."
+            "You are an expert planning agent. Your role is to analyze a user's request and decompose it "
+            "into a sequence of tasks. These tasks can be executed by one of two types of specialized agents:\n"
+            "- 'manus': for general tasks, coding, file operations, complex reasoning, or simple web lookups that don't require session persistence.\n"
+            "- 'browser': for tasks requiring web browser interaction, such as navigating web pages, extracting structured information from complex sites, or when session persistence across multiple web steps is needed.\n\n"
+            "For each task, you must define:\n"
+            "- 'task_id': A unique string identifier for the task (e.g., 'task_1', 'fetch_data').\n"
+            "- 'description': A clear and concise natural language query or instruction for the assigned agent. This description can use outputs from previous tasks using the template '{{dependency_task_id.output}}'. For example, if task 'task_1' fetches data, a subsequent task could have a description like 'Process the data found: {{task_1.output}} and save it to a file.'\n"
+            "- 'agent_type': A string, either 'manus' or 'browser'.\n"
+            "- 'dependencies': A list of string task_ids that this task depends on. If there are no dependencies, provide an empty list [].\n\n"
+            "You must output ONLY a valid JSON list of these task objects. Do not include any other text, explanations, or markdown formatting outside the JSON list itself.\n"
+            "Example JSON output format:\n"
+            "```json\n"
+            "[\n"
+            "  {\n"
+            "    \"task_id\": \"task1_unique_id\",\n"
+            "    \"description\": \"Query for the first agent (e.g., search for something)\",\n"
+            "    \"agent_type\": \"browser\",\n"
+            "    \"dependencies\": []\n"
+            "  },\n"
+            "  {\n"
+            "    \"task_id\": \"task2_another_id\",\n"
+            "    \"description\": \"Process output from task1: {{task1_unique_id.output}} and save to file\",\n"
+            "    \"agent_type\": \"manus\",\n"
+            "    \"dependencies\": [\"task1_unique_id\"]\n"
+            "  }\n"
+            "]\n"
+            "```\n"
+            "Ensure your response is solely this JSON array."
         )
 
         super().__init__(
@@ -125,22 +148,21 @@ class WorkflowOrchestrator(StrandsAgent):
 
     def _adapt_planned_tasks_for_workflow(self, planned_tasks: List[Dict]) -> List[Dict]:
         """
-        Adapts tasks from create_task_plan_tool to be compatible with a workflow
-        tool that can execute specified Python callables.
+        Adapts tasks from the LLM's JSON plan to be compatible with the workflow tool.
         """
         adapted_tasks = []
         for task in planned_tasks:
-            agent_type_str = task.get("agent_type", AgentType.MANUS.value) 
+            agent_type_str = task.get("agent_type", "manus").lower() 
             description = task.get("description", "")
             
             callable_path = ""
-            if agent_type_str == AgentType.MANUS.value:
+            if agent_type_str == "manus":
                 callable_path = "src.manus_use.multi_agents.workflow_orchestrator.run_manus_agent_task"
-            elif agent_type_str == AgentType.BROWSER.value:
+            elif agent_type_str == "browser":
                 callable_path = "src.manus_use.multi_agents.workflow_orchestrator.run_browser_agent_task"
             else:
-                logging.warning(f"Unsupported agent_type '{agent_type_str}' for task '{task.get('task_id')}'. Skipping.")
-                continue
+                logging.warning(f"Unsupported agent_type '{agent_type_str}' for task '{task.get('task_id', 'N/A')}'. Defaulting to 'manus'. Consider revising the plan or prompt.")
+                callable_path = "src.manus_use.multi_agents.workflow_orchestrator.run_manus_agent_task"
 
             adapted_task = {
                 "task_id": task.get("task_id", f"task_{hashlib.md5(description.encode()).hexdigest()[:6]}"),
@@ -158,25 +180,108 @@ class WorkflowOrchestrator(StrandsAgent):
 
     async def run_workflow_for_request(self, user_request: str) -> Dict[str, Any]:
         """
-        Processes a user request by generating a task plan and executing it as a workflow.
+        Processes a user request by generating a task plan using its own LLM and executing it as a workflow.
         """
         logging.info(f"WorkflowOrchestrator: Received request: {user_request}")
         
-        logging.info("Generating task plan directly using create_task_plan_tool...")
-        # Directly call the tool function for planning for reliability
-        raw_planned_tasks: List[Dict] = create_task_plan_tool(request=user_request)
-
-        if not raw_planned_tasks:
-            logging.error("Planning phase did not return any tasks.")
-            return {"status": "error", "message": "No tasks generated by the planning phase."}
+        logging.info("Generating task plan using internal LLM...")
         
-        logging.info(f"Raw planned tasks: {raw_planned_tasks}")
+        llm_response_obj = await self(user_request) # LLM call
+        
+        raw_planned_tasks = None
+        llm_had_direct_json = False
+        llm_response_content_str = "" # Initialize to ensure it's always defined
+
+        if isinstance(llm_response_obj, (list, dict)):
+            logging.info("LLM response is already a list/dict. Using directly.")
+            raw_planned_tasks = llm_response_obj
+            llm_had_direct_json = True
+        elif hasattr(llm_response_obj, 'content'):
+            if isinstance(llm_response_obj.content, (list, dict)):
+                logging.info("LLM response object's 'content' attribute is a list/dict. Using directly.")
+                raw_planned_tasks = llm_response_obj.content
+                llm_had_direct_json = True
+            elif isinstance(llm_response_obj.content, str):
+                llm_response_content_str = llm_response_obj.content
+                logging.info(f"LLM response content is a string. Attempting to parse: {llm_response_content_str[:500]}")
+            else:
+                logging.warning(f"LLM response content is of unexpected type: {type(llm_response_obj.content)}. Attempting to stringify.")
+                llm_response_content_str = str(llm_response_obj.content)
+        elif isinstance(llm_response_obj, str):
+            llm_response_content_str = llm_response_obj
+            logging.info(f"LLM response is a string. Attempting to parse: {llm_response_content_str[:500]}")
+        else:
+            logging.error(f"Unexpected LLM response type: {type(llm_response_obj)}. Cannot extract JSON plan.")
+            return {"status": "error", "message": f"Unexpected LLM response type: {type(llm_response_obj)}"}
+
+        if not llm_had_direct_json:
+            if not llm_response_content_str or not llm_response_content_str.strip():
+                logging.error("LLM returned empty or whitespace-only content for the plan.")
+                return {"status": "error", "message": "LLM returned empty content for the plan."}
+            try:
+                # Try direct parsing first
+                raw_planned_tasks = json.loads(llm_response_content_str)
+            except json.JSONDecodeError:
+                logging.warning("Direct JSON parsing failed. Attempting to extract JSON from markdown code block...")
+                # Attempt to extract JSON from ```json ... ``` or ``` ... ```
+                match = re.search(r"```(?:json)?\s*([\s\S]*?)\s*```", llm_response_content_str, re.MULTILINE)
+                if match:
+                    extracted_json_str = match.group(1).strip()
+                    logging.info(f"Extracted JSON string from markdown: {extracted_json_str[:500]}")
+                    try:
+                        raw_planned_tasks = json.loads(extracted_json_str)
+                    except json.JSONDecodeError as e:
+                        logging.error(f"Failed to parse extracted JSON: {e}. Original content was: {llm_response_content_str[:500]}")
+                        return {"status": "error", "message": f"Failed to parse JSON plan from LLM after extraction: {e}"}
+                else:
+                    # Fallback: if no markdown, try to find first '{' or '['
+                    logging.warning("No JSON markdown code block found. Trying to find start of JSON object/array.")
+                    json_start_object = llm_response_content_str.find('{')
+                    json_start_array = llm_response_content_str.find('[')
+
+                    if json_start_array != -1 and (json_start_object == -1 or json_start_array < json_start_object) :
+                        potential_json_str = llm_response_content_str[json_start_array:]
+                    elif json_start_object != -1 and (json_start_array == -1 or json_start_object < json_start_array) :
+                        potential_json_str = llm_response_content_str[json_start_object:]
+                    else:
+                        potential_json_str = None
+                    
+                    if potential_json_str:
+                        logging.info(f"Attempting to parse from potential JSON start: {potential_json_str[:500]}")
+                        try:
+                            raw_planned_tasks = json.loads(potential_json_str)
+                        except json.JSONDecodeError as e:
+                            logging.error(f"Failed to parse JSON plan from LLM (even after trying to find start): {e}. Original content was: {llm_response_content_str[:500]}")
+                            return {"status": "error", "message": f"Failed to parse JSON plan from LLM (final attempt): {e}"}
+                    else:
+                        logging.error(f"Could not find any JSON structure in LLM response: {llm_response_content_str[:500]}")
+                        return {"status": "error", "message": "No JSON structure found in LLM response."}
+
+        # Ensure raw_planned_tasks is a list, as expected by _adapt_planned_tasks_for_workflow
+        if raw_planned_tasks is None: # If all parsing attempts failed and it was not direct JSON
+            logging.error("All parsing attempts for LLM response failed. Plan is None.")
+            return {"status": "error", "message": "Failed to obtain a valid plan from LLM after all parsing attempts."}
+
+        if not isinstance(raw_planned_tasks, list):
+            logging.error(f"LLM plan is not a list as expected. Type: {type(raw_planned_tasks)}, Content: {str(raw_planned_tasks)[:500]}")
+            if isinstance(raw_planned_tasks, dict) and all(k in raw_planned_tasks for k in ['task_id', 'description', 'agent_type']):
+                logging.warning("LLM plan was a single dictionary, wrapping it in a list.")
+                raw_planned_tasks = [raw_planned_tasks]
+            else:
+                return {"status": "error", "message": "LLM plan is not a list of tasks or a single task dictionary."}
+
+
+        if not raw_planned_tasks: # This check is now after ensuring it's a list
+            logging.error("Planning phase (LLM) did not return any tasks or parsing resulted in empty list.")
+            return {"status": "error", "message": "No tasks generated or parsed from the LLM planning phase."}
+        
+        logging.info(f"Raw planned tasks from LLM: {raw_planned_tasks}")
 
         adapted_tasks = self._adapt_planned_tasks_for_workflow(raw_planned_tasks)
 
         if not adapted_tasks:
             logging.error("No tasks could be adapted for workflow execution.")
-            return {"status": "error", "message": "Failed to adapt planned tasks for workflow."}
+            return {"status": "error", "message": "Failed to adapt LLM-planned tasks for workflow."}
         
         logging.info(f"Adapted tasks for workflow: {adapted_tasks}")
 
@@ -189,33 +294,23 @@ class WorkflowOrchestrator(StrandsAgent):
         }
         logging.info(f"Creating workflow '{workflow_id}' with tasks: {adapted_tasks}")
         
-        # Directly call the workflow tool function
         create_response = workflow(tool={"toolUseId": "tool_create_wf", "input": create_workflow_input})
-        if asyncio.iscoroutine(create_response):
+        if asyncio.iscoroutine(create_response): 
             create_response = await create_response
             
         logging.info(f"Workflow creation response: {create_response}")
 
-        # Check for errors in creation response (simplified check)
-        # The actual structure of create_response from workflow tool might vary.
-        # This assumes a dict with "status" or looks for known error indicators.
         if isinstance(create_response, dict) and (create_response.get("status") == "error" or "error" in str(create_response).lower()):
-             # More robust error extraction if create_response is a list of content items
-            error_message = "Unknown error during workflow creation"
+            error_message = create_response.get("message", "Unknown error during workflow creation")
             if isinstance(create_response.get("content"), list) and create_response["content"]:
-                error_details = create_response["content"][0].get("text", error_message)
-                if isinstance(error_details, dict): # If text itself is a dict
-                    error_message = error_details.get("message", str(error_details))
-                else:
-                    error_message = str(error_details)
-            elif "message" in create_response:
-                 error_message = create_response["message"]
+                 error_details = create_response["content"][0].get("text", error_message)
+                 if isinstance(error_details, dict): error_message = error_details.get("message", str(error_details))
+                 else: error_message = str(error_details)
             logging.error(f"Failed to create workflow: {error_message}")
             return {"status": "error", "message": f"Workflow creation failed: {error_message}"}
-        elif not isinstance(create_response, dict) or not create_response.get("workflow_id"): # Simple check for success
+        elif not isinstance(create_response, dict) or not create_response.get("workflow_id"):
             logging.error(f"Workflow creation did not return expected success response: {create_response}")
             return {"status": "error", "message": "Workflow creation failed or returned unexpected response."}
-
 
         start_workflow_input = {
             "action": "start",
@@ -224,7 +319,7 @@ class WorkflowOrchestrator(StrandsAgent):
         logging.info(f"Starting workflow '{workflow_id}'")
         
         run_response = workflow(tool={"toolUseId": "tool_start_wf", "input": start_workflow_input})
-        if asyncio.iscoroutine(run_response):
+        if asyncio.iscoroutine(run_response): 
             run_response = await run_response
             
         logging.info(f"Workflow run response: {run_response}")
@@ -240,11 +335,11 @@ if __name__ == '__main__':
     # Example of how to test run_workflow_for_request (requires async context and setup)
     # async def test_orchestrator():
     #     orchestrator = WorkflowOrchestrator()
-    #     test_request = "Research the capital of Germany and then find a good recipe for Black Forest cake."
+    #     test_request = "What is the current weather in London, UK? Then, write this weather information into a file named 'london_weather.txt'."
     #     result = await orchestrator.run_workflow_for_request(test_request)
     #     print("\n--- WorkflowOrchestrator Test ---")
     #     print(f"Request: {test_request}")
-    #     print(f"Result: {result}")
+    #     print(f"Result: {json.dumps(result, indent=2)}")
 
-    # if True: # Set to true to run the test
+    # if True: 
     #    asyncio.run(test_orchestrator())


### PR DESCRIPTION
Key changes:
- I updated my internal logic:
    - I now first check if the language model's response is already a Python list or dictionary. If so, I use it directly as the plan.
    - If the language model response is a string, I attempt to parse it. This includes trying a direct `json.loads()` and, if that fails, attempting to extract JSON from markdown code blocks (e.g., ```json ... ```).
    - I've added fallback logic to find the start of a JSON object/array if no markdown block is found.
    - I've added a check to ensure the parsed plan is a list, and will wrap a single dictionary task in a list if necessary.
    - I've enhanced my error reporting for JSON parsing failures.
- My system prompt continues to instruct the language model to output only valid JSON.
- No changes were made to configuration regarding explicit JSON mode, as no such general parameters were identified in the available codebase. Reliance remains on strong prompting and parsing.