### PR TITLE
Fix/browseruseagent stuck on completion

### DIFF
--- a/src/manus_use/agents/browser_use_agent.py
+++ b/src/manus_use/agents/browser_use_agent.py
@@ -267,15 +267,19 @@ class BrowserUseAgent(Agent):
             if self.output_model and hasattr(result, 'final_result') and callable(result.final_result):
                 # If output_model is used, final_result() gives JSON string
                 final_json_string = result.final_result()
+                logging.info("Exiting _run_browser_task with final_json_string.")
                 return final_json_string if final_json_string is not None else ""
 
             if hasattr(result, 'extracted_content') and callable(result.extracted_content):
                 extracted_items = result.extracted_content()
                 if isinstance(extracted_items, list):
+                    logging.info("Exiting _run_browser_task with joined extracted_items.")
                     return "\n".join(str(item) for item in extracted_items)
                 elif extracted_items is not None:
+                    logging.info("Exiting _run_browser_task with str(extracted_items).")
                     return str(extracted_items)
                 else:
+                    logging.info("Exiting _run_browser_task with empty string as extracted_content was None.")
                     logging.info("BrowserUseAgent: result.extracted_content() returned None.")
                     return ""
             else:
@@ -283,6 +287,7 @@ class BrowserUseAgent(Agent):
                     "BrowserUseAgent: Could not find 'extracted_content' method on result or it's not callable. "
                     f"Falling back to str(result). Result type: {type(result)}, Result: {result}"
                 )
+                logging.info("Exiting _run_browser_task with str(result) as fallback.")
                 return str(result)
         finally:
             if browser_use_agent_instance and hasattr(browser_use_agent_instance, 'close'):
@@ -300,6 +305,7 @@ class BrowserUseAgent(Agent):
                         logging.info(f"Successfully closed browser_use agent instance in _run_browser_task. keep_alive: {self.keep_alive}")
                 except Exception as e_close:
                     logging.error(f"Error closing browser_use_agent_instance in _run_browser_task (keep_alive: {self.keep_alive}): {e_close}", exc_info=True)
+        logging.warning("Reached supposedly unreachable return in _run_browser_task's finally block.")
         return "" # Should be unreachable if try block returns
 
     def __call__(
@@ -451,10 +457,12 @@ class BrowserUseAgent(Agent):
                     break
                 yield item
                 queue.task_done()
+            logging.info("Exited stream_async main event processing loop.")
             
             # Await the background task to ensure it finishes and to catch any exceptions
             if run_task_bg: # Check if task was created
                  await run_task_bg
+                 logging.info("Finished awaiting run_task_bg in stream_async within try block.")
 
         except Exception as e:
             logging.error(f"Error during BrowserUseAgent stream_async execution: {e}", exc_info=True)
@@ -488,6 +496,7 @@ class BrowserUseAgent(Agent):
                         logging.info(f"Successfully closed browser_use agent instance in stream_async. keep_alive: {self.keep_alive}")
                 except Exception as e_close:
                     logging.error(f"Error closing browser_use_agent_instance in stream_async (keep_alive: {self.keep_alive}): {e_close}", exc_info=True)
+            logging.info("stream_async method is completing its execution (end of finally block).")
 
     async def cleanup(self):
         """


### PR DESCRIPTION
Fix: Ensure workflow correctly captures string results from agents
This commit addresses an issue where results from agents returning plain strings were not correctly reflected in the workflow's task results, often appearing as an empty list.

The `ManusWorkflowManager.execute_task` method in `src/manus_use/tools/workflow_tool.py` has been updated to:
- Robustly handle different types of results returned by agents after execution (including after coroutines are run to completion).
- Specifically, if an agent returns a plain string, this string is now wrapped into the expected format (e.g., `[{"text": "string_result"}]`) for the `content` field of the task result.
- Continue to correctly process results that are dictionary-like or objects with a `.content` attribute.
- Include logging for how different result types are being processed.

This ensures that data produced by any agent, regardless of whether it returns a string, a dictionary, or an object with a content attribute, is properly captured and structured within the workflow's state. This directly fixes the problem of seeing `result: []` for tasks that did produce output.