### PR TITLE
Add variant_analysis_agent with AgentSkills plugin, fix va_agent.py browser import

### DIFF
--- a/skills/test-skill/SKILL.md
+++ b/skills/test-skill/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: test-skill
+description: A simple test skill that instructs the agent to summarize a CVE ID in exactly 3 bullet points
+allowed-tools: python_repl
+---
+
+# Test Skill: CVE Summary
+
+When this skill is activated, respond to the user's CVE query with exactly 3 bullet points:
+
+1. **What it is**: One sentence describing the vulnerability type.
+2. **What is affected**: The software name and version range.
+3. **Severity**: The CVSS score or severity rating if known, otherwise say "Unknown".
+
+Use `python_repl` only if you need to compute or look something up. Otherwise respond directly from your knowledge.

--- a/va_agent.py
+++ b/va_agent.py
@@ -14,28 +14,14 @@ os.environ["BYPASS_TOOL_CONSENT"] = "True"
 # Add the src directory to Python path
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-# Patch use_browser for better error handling (must be before importing use_browser)
-from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
-apply_comprehensive_patch()
-
 # Import Strands SDK and required tools
 from strands import Agent
-from strands_tools import current_time, use_browser
-from manus_use.tools.python_repl import python_repl
-from manus_use.tools.http_request import http_request
-# Import specific tool functions directly
-import manus_use.tools.get_nvd_data as get_nvd_data
-import manus_use.tools.search_for_exploits as search_for_exploits
-import manus_use.tools.get_cwe_details as get_cwe_details
-import manus_use.tools.search_exploit_db as search_exploit_db
-import manus_use.tools.search_packetstorm as search_packetstorm
-import manus_use.tools.create_lark_document as create_lark_document
-import manus_use.tools.query_threat_intelligence_feeds as query_threat_intelligence_feeds
-import manus_use.tools.get_github_advisory as get_github_advisory
-import manus_use.tools.check_cisa_kev as check_cisa_kev
-import manus_use.tools.get_otx_cve_details as get_otx_cve_details
-import manus_use.tools.verify_exploit as verify_exploit
-#import manus_use.tools.browser_agent_tool as browser_agent_tool
+from strands_tools import current_time
+from strands_tools.browser import LocalChromiumBrowser
+from manus_use.tools.get_github_advisory import get_github_advisory
+
+use_browser = LocalChromiumBrowser().browser
+
 
 class VulnerabilityIntelligenceAgent:
     """Agent that performs vulnerability analysis using a sequential, tool-based approach."""
@@ -185,20 +171,20 @@ class VulnerabilityIntelligenceAgent:
             # model=bedrock,
             system_prompt=self.system_prompt,
             tools=[
-                http_request,
-                python_repl,
+                "strands_tools.http_request",
+                "manus_use.tools.python_repl",
                 current_time,
-                create_lark_document,
-                get_nvd_data,
-                search_for_exploits,
-                get_cwe_details,
-                search_exploit_db,
-                search_packetstorm,
-                check_cisa_kev,
-                get_otx_cve_details,
-                query_threat_intelligence_feeds,
+                "manus_use.tools.create_lark_document",
+                "manus_use.tools.get_nvd_data",
+                "manus_use.tools.search_for_exploits",
+                "manus_use.tools.get_cwe_details",
+                "manus_use.tools.search_exploit_db",
+                "manus_use.tools.search_packetstorm",
+                "manus_use.tools.check_cisa_kev",
+                "manus_use.tools.get_otx_cve_details",
+                "manus_use.tools.query_threat_intelligence_feeds",
                 get_github_advisory,
-                verify_exploit,
+                "manus_use.tools.verify_exploit",
                 use_browser,
             ]
         )

--- a/variant_analysis_agent.py
+++ b/variant_analysis_agent.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""
+Variant Analysis Agent — minimal test of the Strands AgentSkills plugin.
+
+Demonstrates:
+  - AgentSkills plugin with a filesystem-based skill
+  - Progressive disclosure (skill metadata in system prompt, full instructions loaded on demand)
+  - Agent activating a skill via tool call during execution
+
+Usage:
+  python variant_analysis_agent.py [CVE-ID]
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+from strands import Agent, AgentSkills
+from strands.models import BedrockModel
+
+
+def main():
+    cve_id = sys.argv[1] if len(sys.argv) > 1 else "CVE-2024-3094"
+
+    model = BedrockModel(
+        model_id="us.anthropic.claude-sonnet-4-20250514-v1:0",
+        region_name="us-west-2",
+        max_tokens=4096,
+    )
+
+    skills_dir = Path(__file__).parent / "skills"
+    plugin = AgentSkills(skills=str(skills_dir))
+
+    agent = Agent(
+        model=model,
+        plugins=[plugin],
+        system_prompt=(
+            "You are a vulnerability analyst assistant. "
+            "You have skills available — activate the relevant skill before answering. "
+            "After activating, follow the skill instructions exactly."
+        ),
+        tools=["manus_use.tools.python_repl"],
+    )
+
+    print(f"=== Variant Analysis Agent (AgentSkills test) ===")
+    print(f"Query: {cve_id}\n")
+
+    result = agent(f"Analyze {cve_id}")
+    print(result)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `variant_analysis_agent.py` — a minimal agent demonstrating the Strands `AgentSkills` plugin with progressive skill disclosure via `skills/test-skill/`
- Fixes `va_agent.py` for `strands-agents-tools 0.5.x`: replaces the removed `strands_tools.use_browser` with `LocalChromiumBrowser().browser` and removes the obsolete `use_browser_patch`
- Uses string-based tool registration (e.g. `"manus_use.tools.get_nvd_data"`) which is the idiomatic Strands approach and avoids `__init__.py` shadowing issues

## Test plan

- [x] `variant_analysis_agent.py` runs end-to-end: agent discovers skill, activates it via tool call, follows instructions
- [x] `va_agent.py` constructs successfully with all 15 tools registered (no warnings)
- [x] No strands-agents upgrade required (`AgentSkills` available in current `1.39.0`)