### PR TITLE
Add remediation_agent, fix use_browser warning, bump strands deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents>=0.1.9",
-    "strands-agents-tools>=0.1.7",
+    "strands-agents>=1.0.0",
+    "strands-agents-tools>=0.5.0",
     "aiofiles>=24.1.0",
     "docker>=7.1.0",
+    "nest_asyncio>=1.5.0",
     "playwright>=1.49.1",
     "pydantic>=2.0.0",
     "toml>=0.10.2",

--- a/src/manus_use/tools/patches/use_browser_patch.py
+++ b/src/manus_use/tools/patches/use_browser_patch.py
@@ -295,4 +295,5 @@ def apply_comprehensive_patch(
     return True
 
 
-apply_comprehensive_patch()
+if __name__ == "__main__":
+    apply_comprehensive_patch()


### PR DESCRIPTION
## Summary

- Add `remediation_agent.py` demonstrating single-skill `AgentSkills` usage (loads only `test-skill` instead of the full directory)
- Fix spurious `Could not patch use_browser` warning that fired on every `import manus_use` — guarded the module-level `apply_comprehensive_patch()` call since `BrowserUseAgent` already calls it explicitly
- Bump `strands-agents` to `>=1.0.0` (required for `AgentSkills` plugin) and `strands-agents-tools` to `>=0.5.0` (required for `LocalChromiumBrowser`)
- Add `nest_asyncio` dependency required by `strands_tools.browser`

## Test plan

- [x] `remediation_agent.py` runs clean — agent discovers only `test-skill`, activates it, follows instructions
- [x] `va_agent.py` constructs with all 15 tools, no warnings
- [x] `import manus_use` no longer prints the `Could not patch use_browser` warning