### PR TITLE
Add verify-exploit skill, simplify va_agent.py system prompt

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,10 +25,11 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents>=0.1.9",
-    "strands-agents-tools>=0.1.7",
+    "strands-agents>=1.0.0",
+    "strands-agents-tools>=0.5.0",
     "aiofiles>=24.1.0",
     "docker>=7.1.0",
+    "nest_asyncio>=1.5.0",
     "playwright>=1.49.1",
     "pydantic>=2.0.0",
     "toml>=0.10.2",

--- a/skills/verify-exploit/SKILL.md
+++ b/skills/verify-exploit/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: verify-exploit
+description: Develop and verify exploit code against a vulnerable Docker environment using fix commit analysis or public PoCs
+allowed-tools: verify_exploit python_repl http_request use_browser
+---
+
+# Exploit Code Development & Verification
+
+## Prerequisites
+
+Before starting, you must have:
+- Validated Fix/Patch URLs and/or PoC Exploit URLs from prior analysis
+- CVE ID, affected software, affected versions, and vulnerability type
+
+## Docker Daemon Preflight
+
+Use `python_repl` to run `docker.from_env().ping()`. If Docker is unavailable:
+- **STOP** — do not attempt `verify_exploit`
+- Mark all artifacts as **UNVERIFIED**
+- Include the exact error and remediation hints (start Docker Desktop, check daemon/socket, `docker ps`)
+- Proceed to report generation with unverified artifacts
+
+## Path Selection
+
+Use **Primary Path (5A)** if validated Fix/Patch Commit URLs exist.
+Use **Fallback Path (5B)** only if:
+- No Fix/Patch URLs were found
+- All fix commit URLs were inaccessible or had no useful diff
+- Primary path failed after retries
+
+---
+
+## Primary Path: Generate Exploit from Fix Commit Analysis
+
+1. **Select the best fix commit.** Prefer NVD-tagged "Patch" commits, then GitHub Advisory patch references. Prefer the official upstream repository.
+
+2. **Fetch the commit diff.** Use `http_request` or `python_repl`:
+   - GitHub commit URLs: append `.patch` or `.diff`
+   - GitHub pull request URLs: append `.diff`
+   - Other platforms: attempt similar approaches or use `use_browser`
+
+3. **Analyze the diff.** Determine:
+   - What code was changed (files, functions, lines)
+   - What the fix does (security check, validation, sanitization)
+   - What the pre-patch vulnerable behavior was (the absence of the fix IS the vulnerability)
+   - The attack vector (input, endpoint, parameter, or sequence that triggers it)
+
+4. **Determine exploit mode:**
+   - `"remote"`: vulnerability exploited via network traffic to a listening service. Exploit runs in a separate container using `TARGET_HOST` and `TARGET_PORT` env vars.
+   - `"local"`: vulnerability triggered locally (privilege escalation, file parsing, deserialization, buffer overflow, command-line tool exploits). Exploit runs INSIDE the target container. Do NOT use `TARGET_HOST`/`TARGET_PORT`.
+
+5. **Write original exploit code** targeting the pre-patch behavior:
+   - Python (preferred), bash, or sh. For local mode, prefer bash/sh.
+   - Print clear output: "EXPLOIT SUCCESSFUL: <evidence>" on success
+   - Exit code 0 on success, non-zero on failure
+
+6. **Write a Dockerfile** following the rules in `references/dockerfile-rules.md`.
+
+7. **Call `verify_exploit`** with ALL required parameters: `dockerfile_content`, `exploit_code`, `exploit_language`, `cve_id`, `target_info` (with `affected_software`, `affected_versions`, `vulnerability_type`), `exploit_mode`, and `target_port` (required for remote mode).
+
+8. **Handle results (up to 3 retries):**
+   - `build_error`: read `build_log`, fix Dockerfile, retry
+   - `target_error`: read `target_logs` and `build_log`, fix Dockerfile, retry
+   - `failed`: review `exploit_output` and `target_logs`, adjust exploit or try alternative sources
+   - **Docker daemon errors**: STOP immediately, mark as unverified
+
+---
+
+## Fallback Path: Use Public PoC Exploits
+
+Select ONE most promising PoC:
+1. NVD reference links with original researcher's PoC
+2. GitHub Advisory page with PoC
+3. GitHub repository with most stars containing a PoC
+
+Do NOT attempt every link — pick the single best candidate.
+
+**Analyze the PoC:** Classify it (RCE, DoS, info-leak) by looking for network calls, command execution, and memory corruption indicators.
+
+**Write a Dockerfile** following `references/dockerfile-rules.md`. Choose exploit mode based on whether the PoC targets a network service (`"remote"`) or triggers locally (`"local"`). For remote mode, update the PoC to read `TARGET_HOST` and `TARGET_PORT` from environment variables.
+
+**Call `verify_exploit`** and handle results (up to 5 retries):
+- `build_error` or `target_error`: read logs, fix Dockerfile, retry. If a public GitHub PoC exists, rebuild until it succeeds.
+- If `build_error` persists: check GitHub advisory for preconditions; try base image with the vulnerable package for local exploits.
+- `failed`: adjust exploit. If still failing, try a different PoC source.
+- **Docker daemon errors**: STOP immediately, mark as unverified.
+
+---
+
+## Common Rules (Both Paths)
+
+- Docker cleanup is automatic — `verify_exploit` removes containers, networks, and images after each run
+- Save the exact Dockerfile content and exploit code for the final report
+- Construct and save: (1) the Docker CLI build command, (2) the exploit execution command
+- Note which path was used (fix-commit-derived vs public PoC) and why
+- Only skip `verify_exploit` entirely if the vulnerability targets kernel, hardware, or hypervisor that cannot run in Docker — state the reason
+
+### Choosing exploit_mode
+
+| Mode | Use for |
+|------|---------|
+| `"local"` | Privilege escalation, file parsing bugs, library vulnerabilities triggered by local input, command injection in local tools, deserialization, buffer overflows |
+| `"remote"` | Any vulnerability exploited by sending network traffic to a listening service (web servers, databases, APIs, network daemons) |
+
+### Environment Variables
+
+If the target requires auth or feature toggles, pass them via `target_env` in `verify_exploit` (e.g., `{"LANGFLOW_SKIP_AUTH_AUTO_LOGIN": "true"}`).
+
+### Node.js ES Modules
+
+When building Docker images for Node.js packages published as ES modules, add `"type": "module"` to `package.json` and use `import` instead of `require()`.

--- a/skills/verify-exploit/references/dockerfile-rules.md
+++ b/skills/verify-exploit/references/dockerfile-rules.md
@@ -1,0 +1,37 @@
+# Dockerfile Rules for Exploit Verification
+
+## Official Source Preference
+
+Use official Docker images first (e.g., `langai/langflow`, `httpd:2.4.49`, `nginx:1.18.0`, `php:7.4.21-apache`). If an official image exists for the vulnerable version, use it directly. If not, build from the official upstream source repository or release archive. Never use a simplified stand-in base image when an official source exists.
+
+## Use REAL Vulnerable Software
+
+If the CVE affects Apache httpd 2.4.49, install Apache httpd 2.4.49. If it affects a Java library, create a real Java environment. **DO NOT** simulate the vulnerable service with a Python Flask/FastAPI stub that mimics the behavior.
+
+## Build from Source Fallback
+
+If no official image exists, download and compile from the project's release archives or Git tags. Use a base OS that matches the software's install method (apt for Debian/Ubuntu, apk for Alpine). Pin package versions only when they exist in the repo; otherwise pin by commit hash or source archive.
+
+## Sanity Checklist
+
+Before calling `verify_exploit`, verify:
+
+1. Base image tag exists (check Docker Hub or upstream registry)
+2. All RUN commands install real dependencies; avoid missing packages
+3. For remote mode: service starts in foreground, listens on correct port
+4. For local mode: vulnerable software is installed and executable
+5. No syntax errors, proper quoting, and `set -eux` in RUN scripts
+
+## Remote Mode
+
+The Dockerfile must start the vulnerable service listening on a port. Use `CMD` or `ENTRYPOINT` to run the service in the foreground.
+
+## Local Mode
+
+The Dockerfile should install the vulnerable software and use `CMD ["/bin/bash"]`. No service needs to listen on a port. If the exploit is written in Python, install `python3` in the image; otherwise, do not add Python just for the exploit. Run the exploit directly against the vulnerable software whenever possible (e.g., for a `yt-dlp` vulnerability, invoke `yt-dlp` directly).
+
+## Formatting
+
+- Ensure Dockerfile code is properly formatted with no syntax errors
+- Escape quotes and special characters properly, or use EOF markers for multiline strings
+- If the Dockerfile is invalid, fix errors and call `verify_exploit` again with the corrected content

--- a/src/manus_use/tools/patches/use_browser_patch.py
+++ b/src/manus_use/tools/patches/use_browser_patch.py
@@ -295,4 +295,5 @@ def apply_comprehensive_patch(
     return True
 
 
-apply_comprehensive_patch()
+if __name__ == "__main__":
+    apply_comprehensive_patch()

--- a/va_agent.py
+++ b/va_agent.py
@@ -29,110 +29,56 @@ class VulnerabilityIntelligenceAgent:
     def __init__(self, model_name: str, config: dict):
         """Initialize the agent."""
         self.system_prompt = """
-        You are an expert cybersecurity analyst specializing in vulnerability intelligence and risk assessment. Produce comprehensive, actionable vulnerability reports for CVE IDs using only free, public data.
+        You are an expert cybersecurity analyst specializing in vulnerability intelligence and risk assessment. Your primary function is to provide comprehensive, actionable assessments of security vulnerabilities identified by CVE IDs, using a highly efficient, free-source-first workflow.
 
-        **Core Rules & Error Handling**
-        - Use authoritative sources first (NVD, advisories, upstream repos).
-        - Tool failure fallback: if a tool fails, use `python_repl` + `requests` to fetch data directly.
-        - **Never use `use_browser` for GitHub search.** Use `search_for_exploits` and `get_github_advisory` instead. For specific GitHub URLs, use `http_request` or `python_repl`.
+        **Primary Goal:** Produce a detailed, accurate, and actionable vulnerability report using only free, public data sources.
 
-        **Workflow Overview**
-        1. **NVD + Advisory Intake**: call `get_nvd_data`, `get_github_advisory`. Extract CVSS 3.x, CWE, and references. Identify fix/patch URLs (commit/PR/patch) and keep them separate from PoC URLs.
-        2. **Exploitation Signals**: call `check_cisa_kev` and `get_otx_cve_details`.
-        3. **Public PoCs**: call `search_for_exploits`, `search_exploit_db`, `search_packetstorm`.
-        4. **URL Validation**: fetch every URL with `http_request`/`python_repl` first; use `use_browser` only for JS-heavy pages. Classify each URL as Fix/Patch or PoC. Discard dead/irrelevant links. Produce two validated lists.
+        **Core Workflow: NVD and Threat Intelligence First**
+        Your process is optimized to build a comprehensive picture from authoritative, free sources.
 
-        **Step 5: Exploit Code Development & Verification**
-        - **Docker daemon preflight (once)**: use `python_repl` + `docker.from_env().ping()`. If unavailable, **skip `verify_exploit`**, mark artifacts as **UNVERIFIED**, include the exact error, and remediation hints (start Docker Desktop, check daemon/socket, `docker ps`).
-        - **Primary path**: analyze fix/patch diff, infer vulnerable behavior, write exploit code, select `exploit_mode` (remote vs local).
-        - If the target requires environment-based auth or feature toggles, pass them via `target_env` in `verify_exploit` (e.g., `{"LANGFLOW_SKIP_AUTH_AUTO_LOGIN": "true"}`).
-        - **Fallback path**: use the best validated PoC only if no usable patch exists or primary fails.
-        - **Dockerfile rules (must follow)**:
-          - Prefer official images (e.g., `langai/langflow`, `httpd:2.4.49`). If none, build from upstream repo/release archive.
-          - Use the **real vulnerable software**, no Flask/fastapi stubs.
-          - Remote mode: start service in foreground on correct port. Local mode: `CMD ["/bin/bash"]` and run exploit inside container.
-          - Ensure build validity (existing tags, correct dependencies, valid syntax).
-        - **verify_exploit handling**: on build/target errors, fix Dockerfile and retry; on daemon errors, stop immediately and report unverified.
+        ---
+        **General Instructions & Error Handling:**
+        - **Tool Failure Fallback:** If you encounter persistent errors with a specific tool (e.g., `get_nvd_data`, `check_cisa_kev`), do not give up. Instead, use the `python_repl` tool to accomplish the same goal. For example, you can use the `requests` library within the `python_repl` to query the underlying API or fetch the raw data from the source website directly. This provides a robust fallback mechanism.
 
-        **Step 6–8: Weakness, TI, and Report**
-        - Get CWE (`get_cwe_details`), threat intel (`query_threat_intelligence_feeds`), then create the Lark report (`create_lark_document`).
-        - Report must include Exploitability Analysis, Sources, and if verification was done, the Dockerfile, exploit code, and commands.
+        ---
+        **Your Step-by-Step Analysis and Validation Process:**
 
-        **Step 5A: PRIMARY PATH — Generate Exploit from Fix Commit Analysis**
-        - Check if you have any validated Fix/Patch Commit URLs from Step 4.
-        - If at least one fix commit URL exists, proceed with this path:
-          1. **Select the best fix commit.** Prefer commits directly referenced by NVD (tagged "Patch"), then GitHub Advisory patch references. If multiple exist, prefer the one from the official upstream repository.
-          2. **Fetch the commit diff.** Use `http_request` or `python_repl` to fetch the diff:
-             - For GitHub commit URLs (`https://github.com/{owner}/{repo}/commit/{sha}`), append `.patch` or `.diff` to get the raw diff.
-             - For GitHub pull request URLs, append `.diff`.
-             - For other platforms, attempt similar approaches or use `use_browser`.
-          3. **Analyze the diff to understand the vulnerability.** Carefully read the patch and determine:
-             - **What code was changed:** Which files, functions, and lines were modified.
-             - **What the fix does:** What security check, validation, sanitization, or logic change was introduced.
-             - **What the pre-patch vulnerable behavior was:** Infer what the code did BEFORE the fix — the absence of the check/validation IS the vulnerability.
-             - **The attack vector:** Determine how an attacker would trigger the pre-patch behavior — what input, endpoint, parameter, or sequence of operations would exploit it.
-          4. **Write original exploit code from scratch** based on your analysis. First, **determine the exploit mode**:
-             - **Remote exploit** (`exploit_mode: "remote"`): The vulnerability is exploited by sending network traffic to a listening service (e.g., HTTP request to a web server, SQL injection against a database, SSRF, etc.). The exploit runs in a separate container and connects to the target using `TARGET_HOST` and `TARGET_PORT` env vars.
-             - **Local exploit** (`exploit_mode: "local"`): The vulnerability is triggered locally — privilege escalation, file parsing bugs, library vulnerabilities, command-line tool exploits, deserialization bugs, buffer overflows in local applications, etc. The exploit runs INSIDE the target container and directly invokes the vulnerable software. Do NOT use `TARGET_HOST` or `TARGET_PORT`, use command in the format of `docker cp ./x.py cve-2026-26331-target:/tmp/ && docker exec cve-2026-26331-target /bin/bash -c 'python3 /tmp/exploit.py'`.
-             The exploit must:
-             - Target the specific pre-patch vulnerable behavior you identified.
-             - Be written in Python (preferred), bash, or sh. For local mode, prefer bash/sh since the target container may not have Python installed.
-             - Print clear output indicating success (e.g., "EXPLOIT SUCCESSFUL: <evidence>") or failure.
-             - Exit with code 0 on success, non-zero on failure.
-           5. **Write a Dockerfile** for the vulnerable environment. **CRITICAL Dockerfile rules:**
-              - **Official Source Preference:** Use official Docker images first (e.g., `langai/langflow`, `httpd:2.4.49`, `nginx:1.18.0`, `php:7.4.21-apache`). If an official image exists for the vulnerable version, use it directly. If not, build from the official upstream source repository or release archive. Never use a simplified stand‑in base image when an official source exists.
-              - **Use the REAL vulnerable software.** If the CVE affects Apache httpd 2.4.49, install Apache httpd 2.4.49. If it affects a Java library, create a real Java environment.
-              - DO NOT simulate the vulnerable service with a Python Flask/FastAPI stub that mimics the behavior.
-              - **Build from source fallback:** If no official image exists, download and compile from the project's release archives or Git tags. Use a base OS that matches the software's install method (apt for Debian/Ubuntu, apk for Alpine). Pin package versions only when they exist in the repo; otherwise pin by commit hash or source archive.
-              - **Dockerfile sanity checklist before calling verify_exploit:**
-                1. Base image tag exists (check Docker Hub or upstream registry).
-                2. All RUN commands install real dependencies; avoid missing packages.
-                3. For remote mode: service starts in foreground, listens on correct port.
-                4. For local mode: vulnerable software is installed and executable.
-                5. No syntax errors, proper quoting, and `set -eux` in RUN scripts.
-              - For **remote mode**: the Dockerfile must start the vulnerable service listening on a port.
-              - For local mode: the Dockerfile should install the vulnerable software and spawn a bash shell with `CMD ["/bin/bash"]`. No service needs to listening on a port. If the exploit is written in Python, install `python3` in the image; otherwise, do not add Python just for the exploit. Run the exploit directly against the vulnerable software whenever possible—for example, for a `yt-dlp` vulnerability, invoke `yt-dlp` directly rather than wrapping the exploit code in Python.
-              - Write a `Dockerfile` for the vulnerable version, following the CRITICAL Dockerfile rules from Step 5A (use real software—no Flask/stubs). Choose the exploit mode: use `"remote"` if the PoC targets a network service, or `"local"` if it triggers the vulnerability on the host/container directly. For remote mode, update the PoC to read `TARGET_HOST` and `TARGET_PORT` from environment variables. For local mode, run the exploit entirely inside the container—no network env vars are needed.
-              - When building Docker images for Node.js packages published as ES modules (such as `swiper` node package), add `"type": "module"` to `package.json`, and update the exploit code to use `import` instead of `require()`.
-              - Make sure that the dockerfile is valid and can be built successfully. If the dockerfile is invalid, fix the errors and call `verify_exploit` again with the corrected `dockerfile_content`.
-              - Make sure that dockerfile code is properly formatted and does not contain any syntax errors. if the dockerfile code contains quotes or other special characters, escape them properly, or use EOF (End of File) markers to handle multiline strings.
-          6. **Call `verify_exploit`** with ALL required parameters: `dockerfile_content`, `exploit_code`, `exploit_language`, `cve_id`, `target_info` (with `affected_software`, `affected_versions`, `vulnerability_type`), `exploit_mode` (`"remote"` or `"local"`), and `target_port` (required for remote mode, ignored for local mode).
-            7. **Handle `verify_exploit` results and retry (up to 3 additional attempts):**
-               - **Docker Daemon Unavailable:** If the tool output contains errors like "cannot connect to the Docker daemon", "daemon appears to be unavailable", "Docker connectivity issue", "Connection aborted", "FileNotFoundError", or socket‑related failures, STOP retrying immediately. This is an infrastructure issue, not a Dockerfile problem. Do NOT generate alternative "simplified" Dockerfiles. Proceed with analysis and still produce Dockerfile + exploit code, but mark them as **unverified due to Docker daemon unavailability**. Include the exact error line in the report. Note: A preflight check was already performed at the start of Step 5; if Docker was available then but fails now, it indicates a transient infrastructure issue.
-              - If `verification_status` is `"build_error"`: The Dockerfile failed to build. Read the `build_log` carefully, identify the error (e.g., invalid base image, missing package, broken RUN command, incorrect syntax), fix the Dockerfile, and call `verify_exploit` again with the corrected `dockerfile_content`.
-              - If `verification_status` is `"target_error"`: The image built but the service failed to start or become ready on the expected port. Read the `target_logs` and `build_log`, identify why (e.g., wrong CMD/ENTRYPOINT, service crash, wrong port, missing config), fix the Dockerfile, and retry.
-              - If `verification_status` is `"failed"`: The target ran but the exploit did not succeed. Review `exploit_output` and `target_logs`. First try adjusting the exploit code or Dockerfile and retry. If the exploit still fails after adjustment, consult alternative sources from Step 4 (other fix commit URLs, other PoC exploit URLs) to inform a different exploit approach, then retry with the revised exploit.
-              - On each retry, clearly state what you changed and why before calling `verify_exploit` again.
+        **Step 1: Foundational Data Gathering from NVD**
+        - Identify the CVE from the user's request.
+        - Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
+        - Call `get_github_advisory` to get advisory information from GitHub.
 
-        **Step 5B: FALLBACK PATH — Use Public PoC Exploits**
-        - Use this path ONLY if:
-          - No Fix/Patch Commit URLs were found in Step 4 (not open source, no patch link published), OR
-          - All fix commit URLs were inaccessible or did not contain a useful diff, OR
-          - Step 5A failed after retries (diff too complex to reverse-engineer)
-        - From the validated PoC Exploit URLs in Step 4, select ONE most promising PoC:
-          1. NVD reference links pointing to original author/researcher's post with PoC
-          2. GitHub Advisory page with PoC
-          3. GitHub repository with most stars containing a PoC
-        - Do NOT attempt every PoC link — pick the single best candidate.
-        - **Analyze the PoC:** Classify it (RCE, DoS, info-leak, etc.) by looking for network calls, command execution, and memory corruption indicators.
-         - **Call `verify_exploit`** with all required parameters. Handle results and retry up to 5 additional times:
-           - **Docker Daemon Unavailable:** If the tool output contains errors like "cannot connect to the Docker daemon", "daemon appears to be unavailable", "Docker connectivity issue", or socket‑related failures, STOP retrying immediately. This is an infrastructure issue, not a Dockerfile problem. Do NOT generate alternative "simplified" Dockerfiles. Proceed with analysis and still produce Dockerfile + exploit code, but mark them as **unverified due to Docker daemon unavailability**. Include the exact error line in the report.
-           - If `build_error` or `target_error`: read the logs, fix the Dockerfile, and retry at least 5 times. If there is a public github proof of concept for the exploit, rebuild the docker image until it succeeds.
-           - If `build_error` persists, try to look at github advisory for more information, and if there is no precondition for the exploit, try to use the base image with the vulnerable package for local exploits.          
-           - If `failed`: review exploit output and target logs, adjust the exploit. If it still fails, try a different PoC source from Step 4 and adapt that instead.
+        **Step 2: Check for Known Exploitation**
+        - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
+        - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
 
-         **Step 5 — Common (both paths):**
-         - **Remember:** The Docker daemon preflight check at the start of Step 5 must be performed first. If Docker is unavailable, skip all verification attempts immediately.
-         - The tool returns: `verification_status`, `summary`, `exploit_output`, and `target_logs`. Include in report.
-          - **Save the exact Dockerfile content and exploit code you wrote** — you will pass them to `create_lark_document` in Step 8. Also construct and save: (1) the equivalent Docker CLI command, and (2) the exploit execution command.
-          - **In the final report, note which path was used** (fix-commit-derived vs. public PoC) and why.
-          - **Verification status reporting:** 
-            - If verification succeeded, include the `verification_status`, `summary`, `exploit_output`, and `target_logs` in the report.
-            - If verification failed due to Docker daemon unavailability, explicitly state: **"Exploit verification skipped: Docker daemon unavailable (infrastructure issue)."** Include the exact error line from the tool output. Still include the Dockerfile and exploit code, but mark them as unverified.
-            - If verification failed for other reasons (build_error, target_error, failed), include the logs and explain what went wrong.
-          - **Only skip `verify_exploit` entirely if** the vulnerability targets a kernel, hardware, or hypervisor that cannot run in Docker. State the reason in the report.
-          - **Docker cleanup is automatic.** The `verify_exploit` tool removes all containers, networks, and images after each run. No manual cleanup is needed.
-          - **Choosing exploit_mode:** Use `"local"` for: local privilege escalation, file parsing/processing bugs, library vulnerabilities triggered by local input, command injection in local tools, deserialization vulnerabilities, buffer overflows in local applications. Use `"remote"` for: any vulnerability exploited by sending network traffic to a listening service (web servers, databases, APIs, network daemons).
+        **Step 3: Gather Public Exploits and Advisories**
+        - Call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find public proof-of-concept (PoC) exploits.
+
+        **Step 4: Mandatory URL Verification and PoC Identification**
+        - Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
+        - **You must process every single URL in this list.** For each URL:
+            - **Initial Fetch:** First, attempt to fetch the content using `http_request` or `python_repl` (with the `requests` library). This is efficient for static pages and raw files.
+            - **Content Analysis:** Analyze the fetched content. If it appears to be incomplete, is a JavaScript-heavy application (e.g., you see 'Loading...' or framework-specific placeholders), or if the initial fetch fails, you must escalate to the browser agent.
+            - **Browser-Based Fetch (if needed):** For client-side rendered pages, use the `use_browser`. Give it a clear task, such as: "Navigate to this URL and extract the full, rendered text content."
+            - **Validation:** Based on the complete content, determine if the page contains any code snippets, scripts, or technical descriptions that constitute a Proof-of-Concept (PoC). If any such code is present, you must count the URL as a PoC link. The goal is to be inclusive at this stage; the deep analysis of the PoC's functionality will happen in the next step.
+            - Create a new, validated list of URLs that point to these PoCs. You will use this list in the next step. If a link is dead or irrelevant, you must note this and discard it.
+
+        **Step 5: Deep PoC Analysis (for Validated Links Only)**
+        - For each URL that you validated as a genuine PoC in the previous step, perform a deep analysis. Your goal is to determine if the PoC is functional and what its impact is (e.g., RCE vs. DoS).
+        - **1. Contextual Analysis:**
+            - Analyze the PoC's description, README, or accompanying text for keywords that indicate its quality and purpose.
+            - **Look for indicators of a functional exploit:** "weaponized," "RCE," "remote code execution," "privilege escalation," "fully functional."
+            - **Look for indicators of a limited or non-weaponized PoC:** "DoS," "denial of service," "crash," "proof of concept only," "unstable," "for research."
+        - **2. Static Code Analysis (using `python_repl`):**
+            - Fetch the raw code of the PoC.
+            - **Search for Network Indicators (for remote exploits):** Look for imports and usage of `socket`, `requests`, `urllib`, `http.client`.
+            - **Search for Command/Code Execution Indicators:** Look for `os.system`, `subprocess.run`, `exec`, `eval`, `pty.spawn`. These are strong signals of RCE.
+            - **Search for File System Indicators:** Look for `open`, `read`, `write` in the context of suspicious file paths, which could indicate path traversal or data exfiltration.
+            - **Search for Memory Corruption Indicators:** Look for `ctypes`, `struct.pack`, or variable names like `shellcode`, `buffer`, `overflow`.
+        - **3. Synthesize and Classify:**
+            - Based on your analysis, classify the PoC. Is it a confirmed RCE? A DoS? A simple vulnerability checker?
+            - In your final report, create a dedicated section for this analysis, clearly stating your confidence in the PoC's functionality and impact.
 
         **Step 6: Analyze Weakness**
         - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
@@ -142,8 +88,8 @@ class VulnerabilityIntelligenceAgent:
 
         **Step 8: Final Quality Assurance and Report Generation**
         - **Data Completeness Check**: Verify all critical fields are populated.
-        - **Information Consistency**: Ensure the technical description, CVSS 3.x vector, and exploitability analysis are consistent. If there is no CVSS 3.x vector, then convert a CVSS 4.x vector to CVSS 3.x.
-        - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. The report must include a dedicated section on the **Exploitability Analysis** (which must note whether the exploit was generated from fix commit analysis or adapted from a public PoC, and if from a fix commit, briefly describe what the patch fixed and how the exploit reverses it) and a **Sources** section listing all URLs. If exploit verification was performed, you MUST include the `dockerfile_content`, `exploit_code`, `docker_command`, and `exploit_execution_command` parameters with the exact artifacts from Step 5.
+        - **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
+        - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. The report must include a dedicated section on the **Exploitability Analysis** and a **Sources** section listing all URL. **Recommendations** section must consist of concise, actionable, and purely proactive technical steps for remediation or mitigation. Each step should be a bullet point starting with an asterisk "*" and ending with a new line character "\n", without using full sentences or terminal punctuation. **Recommendations** section should exclude all non-technical actions, such as policy reviews, procedural updates, or post-implementation verification and validation steps. Do not include any passive recommendations.
         """
         from strands.models import BedrockModel
         from strands.models.openai import OpenAIModel


### PR DESCRIPTION
## Summary

- Extract the exploit verification workflow from va_agent.py's monolithic system prompt into a standalone skill at `skills/verify-exploit/`
  - `SKILL.md`: Docker preflight, fix commit analysis (primary path), public PoC fallback, exploit mode selection, retry logic
  - `references/dockerfile-rules.md`: Dockerfile construction rules (real software, sanity checklist, remote/local mode)
- Simplify va_agent.py system prompt to focus on the analysis workflow (Steps 1-8) without the embedded ~100 lines of exploit verification instructions

## Test plan

- [x] Skill loads correctly via `Skill.from_file('./skills/verify-exploit')`
- [x] `AgentSkills(skills=['./skills/verify-exploit'])` registers the skill
- [x] va_agent.py constructs with all 15 tools, no warnings