### PR TITLE
Wire up verify-exploit skill in va_agent.py, optional via --verify flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dev = [
 ]
 browser = [
     "playwright>=1.49.1",
-    "browser-use>=1.0.27",
+    "browser-use>=0.12.0",
     "markdownify>=0.12.1",
     "langchain-aws>=0.2.11",
 ]

--- a/va_agent.py
+++ b/va_agent.py
@@ -15,7 +15,7 @@ os.environ["BYPASS_TOOL_CONSENT"] = "True"
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 # Import Strands SDK and required tools
-from strands import Agent
+from strands import Agent, AgentSkills
 from strands_tools import current_time
 from strands_tools.browser import LocalChromiumBrowser
 from manus_use.tools.get_github_advisory import get_github_advisory
@@ -111,10 +111,14 @@ class VulnerabilityIntelligenceAgent:
             },
             model_id=config['llm']['model'], max_tokens=config['llm']['max_tokens'],  # use whatever model name your endpoint expects
         )
+        skills_dir = str(Path(__file__).parent / "skills" / "verify-exploit")
+        plugin = AgentSkills(skills=[skills_dir])
+
         self.agent = Agent(
             conversation_manager=conversation_manager,
             model=openai_model,
             # model=bedrock,
+            plugins=[plugin],
             system_prompt=self.system_prompt,
             tools=[
                 "strands_tools.http_request",
@@ -132,7 +136,7 @@ class VulnerabilityIntelligenceAgent:
                 get_github_advisory,
                 "manus_use.tools.verify_exploit",
                 use_browser,
-            ]
+            ],
         )
 
     def handle_request(self, request: str) -> str:
@@ -143,35 +147,47 @@ class VulnerabilityIntelligenceAgent:
 
 # --- Main Execution Block ---
 def main():
-    """Example of using the simplified VulnerabilityIntelligenceAgent."""
+    """Example of using the simplified VulnerabilityIntelligenceAgent.
+
+    Usage:
+      python va_agent.py CVE-2024-3094            # analysis only
+      python va_agent.py CVE-2024-3094 --verify   # analysis + exploit verification
+    """
     print("=== Vulnerability Intelligence Assessment Agent ===")
+
+    args = sys.argv[1:]
+    verify = "--verify" in args
+    args = [a for a in args if a != "--verify"]
 
     # Simplified and robust configuration handling
     try:
         from manus_use.config import Config
         config = Config.from_file()
-        # Use a specific, powerful model suitable for orchestration
         model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-        # print(f"Using configured model: {model_name}")
     except Exception as e:
-        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"  # A sensible default
-        # print(f"Could not load config ({e}), using default model: {model_name}")
+        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
     # Create the agent
     config_dict = config.model_dump()
     vi_agent = VulnerabilityIntelligenceAgent(model_name=model_name, config=config_dict)
 
     # Get CVE from command-line arguments or use an example for demonstration
-    if len(sys.argv) > 1:
-        cve_id = sys.argv[1]
-    else:
-        cve_id = "CVE-2025-6554"
+    cve_id = args[0] if args else "CVE-2025-6554"
+    if not args:
         print(f"No CVE provided. Using example: {cve_id}")
 
-    # The request is a high-level instruction to the agent.
-    analysis_request = f"""
+    if verify:
+        print("Exploit verification: ENABLED")
+        analysis_request = f"""
     Please perform a comprehensive vulnerability intelligence analysis for {cve_id}.
     Follow your sequential process and create a Lark document with the final report.
+    Additionally, activate the `verify-exploit` skill to develop and verify exploit code in Docker.
+    """
+    else:
+        analysis_request = f"""
+    Please perform a comprehensive vulnerability intelligence analysis for {cve_id}.
+    Follow your sequential process and create a Lark document with the final report.
+    Do NOT perform exploit verification.
     """
 
     print(f"\n--- Sending analysis request to agent for: {cve_id} ---")


### PR DESCRIPTION
## Summary

- Load `verify-exploit` skill via `AgentSkills` plugin in `va_agent.py`
- Skill is always available but only activated when the user prompt requests it
- `--verify` CLI flag controls the user prompt, not the code path:
  - Without flag: prompt says "Do NOT perform exploit verification"
  - With flag: prompt says "activate the verify-exploit skill"

## Usage

```bash
python va_agent.py CVE-2024-3094            # analysis only
python va_agent.py CVE-2024-3094 --verify   # analysis + exploit verification
```

## Test plan

- [x] Agent constructs with 16 tools (15 + skills tool from plugin)
- [x] `verify-exploit` skill is listed in available skills
- [x] Without `--verify`: agent skips exploit verification
- [x] With `--verify`: agent activates skill and follows its instructions