### PR TITLE
Fix fork-safety in python_repl, improve http_request truncation, bump…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents>=1.0.0",
-    "strands-agents-tools>=0.5.0",
+    "strands-agents>=1.38.0",
+    "strands-agents-tools>=0.5.2",
     "aiofiles>=24.1.0",
     "docker>=7.1.0",
     "nest_asyncio>=1.5.0",

--- a/src/manus_use/tools/http_request.py
+++ b/src/manus_use/tools/http_request.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Wrapper around strands_tools.http_request with output truncation."""
 
+import os
 from typing import Any
 
 from strands.types.tools import ToolResult, ToolUse
-from strands_tools.http_request import http_request as _http_request
+from strands_tools.http_request import TOOL_SPEC, http_request as _http_request
 from manus_use.tools.tool_output_logger import log_tool_output_size
 
-MAX_OUTPUT_CHARS = 100_000
+# Truncation limits — override via environment variables if needed.
+# Per-item limit: max chars for a single content item (e.g. response body).
+MAX_OUTPUT_CHARS = int(os.environ.get("HTTP_REQUEST_MAX_OUTPUT_CHARS", 20_000))
+# Total limit: max chars across all content items combined.
+MAX_TOTAL_OUTPUT_CHARS = int(os.environ.get("HTTP_REQUEST_MAX_TOTAL_OUTPUT_CHARS", 30_000))
 
 
 def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
@@ -22,17 +27,41 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         if total_before:
             print(f"[http_request] Output size before truncation: {total_before} chars")
 
+        # Phase 1: truncate individual items that exceed per-item limit
         truncated_any = False
         truncated_content = []
         for item in content:
             if isinstance(item, dict) and isinstance(item.get("text"), str):
                 text = item["text"]
                 if len(text) > MAX_OUTPUT_CHARS:
-                    text = text[:MAX_OUTPUT_CHARS] + "\n[truncated]"
+                    removed = len(text) - MAX_OUTPUT_CHARS
+                    text = text[:MAX_OUTPUT_CHARS] + f"\n[truncated: {removed} chars removed]"
                     truncated_any = True
                 truncated_content.append({**item, "text": text})
             else:
                 truncated_content.append(item)
+
+        # Phase 2: if total still exceeds total limit, proportionally reduce items
+        total_after = sum(
+            len(item.get("text", ""))
+            for item in truncated_content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        )
+        if total_after > MAX_TOTAL_OUTPUT_CHARS:
+            ratio = MAX_TOTAL_OUTPUT_CHARS / total_after
+            final_content = []
+            for item in truncated_content:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    text = item["text"]
+                    item_limit = max(int(len(text) * ratio), 0)
+                    if len(text) > item_limit:
+                        removed = len(text) - item_limit
+                        text = text[:item_limit] + f"\n[truncated: {removed} chars removed]"
+                        truncated_any = True
+                    final_content.append({**item, "text": text})
+                else:
+                    final_content.append(item)
+            truncated_content = final_content
 
         total_after = sum(
             len(item.get("text", ""))

--- a/src/manus_use/tools/python_repl.py
+++ b/src/manus_use/tools/python_repl.py
@@ -1,14 +1,16 @@
 """
-Fixed python_repl wrapper that addresses PTY cleanup and status handling bugs.
+Fixed python_repl wrapper that addresses PTY cleanup, status handling, and fork-safety bugs.
 
 This module wraps strands_tools.python_repl with fixes for:
 1. Proper exit status checking using WIFEXITED/WEXITSTATUS instead of raw status comparison
 2. Safe PTY cleanup that avoids sending signals to already-reaped processes
+3. Fork-safe execution using subprocess.Popen instead of os.fork() (avoids crashes on macOS)
 """
 
 import os
-import signal
+import subprocess
 import sys
+import tempfile
 import time
 import traceback
 from typing import Any, Callable, List, Optional
@@ -39,17 +41,19 @@ except ImportError:
 
 
 class FixedPtyManager:
-    """PTY manager with proper process lifecycle handling."""
+    """PTY manager using subprocess.Popen for fork-safe process lifecycle handling.
+
+    Uses subprocess.Popen (which calls posix_spawn on macOS) instead of os.fork()
+    to avoid crashes when forking in a multithreaded process on macOS.
+    """
 
     def __init__(self, callback: Optional[Callable] = None):
+        self.process: Optional[subprocess.Popen] = None
         self.supervisor_fd = -1
-        self.worker_fd = -1
-        self.pid = -1
         self.output_buffer: List[str] = []
-        self.input_buffer: List[str] = []
-        self.stop_event = False
         self.callback = callback
         self._child_exited = False
+        self._code_file: Optional[str] = None
 
     def start(self, code: str) -> None:
         import fcntl
@@ -57,46 +61,42 @@ class FixedPtyManager:
         import struct
         import termios
         import threading
-        
-        self.supervisor_fd, self.worker_fd = pty.openpty()
+
+        master_fd, slave_fd = pty.openpty()
         term_size = struct.pack("HHHH", 24, 80, 0, 0)
-        fcntl.ioctl(self.worker_fd, termios.TIOCSWINSZ, term_size)
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, term_size)
 
-        self.pid = os.fork()
+        # Write code to a temp file so subprocess can execute it
+        fd, code_path = tempfile.mkstemp(suffix=".py", prefix="repl_")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(code)
+        except Exception:
+            os.close(fd)
+            raise
+        self._code_file = code_path
 
-        if self.pid == 0:
-            try:
-                os.close(self.supervisor_fd)
-                os.dup2(self.worker_fd, 0)
-                os.dup2(self.worker_fd, 1)
-                os.dup2(self.worker_fd, 2)
-                os.close(self.worker_fd)
-                
-                namespace = repl_state.get_namespace()
-                exec(code, namespace)
-                os._exit(0)
-            except Exception:
-                traceback.print_exc(file=sys.stderr)
-                os._exit(1)
-        else:
-            os.close(self.worker_fd)
-            
-            reader = threading.Thread(target=self._read_output)
-            reader.daemon = True
-            reader.start()
+        self.process = subprocess.Popen(
+            [sys.executable, "-u", code_path],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        self.supervisor_fd = master_fd
 
-            input_handler = threading.Thread(target=self._handle_input)
-            input_handler.daemon = True
-            input_handler.start()
+        reader = threading.Thread(target=self._read_output)
+        reader.daemon = True
+        reader.start()
 
     def _read_output(self) -> None:
         import select
-        import sys
-        
+
         buffer = ""
         incomplete_bytes = b""
 
-        while not self.stop_event:
+        while not self._child_exited:
             try:
                 if self.supervisor_fd < 0:
                     break
@@ -167,34 +167,6 @@ class FixedPtyManager:
             except Exception:
                 pass
 
-    def _handle_input(self) -> None:
-        import select
-        import sys
-        
-        while not self.stop_event:
-            try:
-                r, _, _ = select.select([sys.stdin], [], [], 0.1)
-                if sys.stdin in r:
-                    input_data = ""
-                    while True:
-                        char = sys.stdin.read(1)
-                        if not char or char == "\n":
-                            input_data += "\n"
-                            break
-                        input_data += char
-
-                    if input_data:
-                        if input_data not in self.input_buffer:
-                            self.input_buffer.append(input_data)
-                            if self.supervisor_fd >= 0:
-                                try:
-                                    os.write(self.supervisor_fd, input_data.encode())
-                                except (OSError, ValueError):
-                                    break
-
-            except (OSError, IOError):
-                break
-
     def get_output(self) -> str:
         raw = "".join(self.output_buffer)
         clean = clean_ansi(raw)
@@ -205,25 +177,19 @@ class FixedPtyManager:
         return clean
 
     def stop(self) -> None:
-        self.stop_event = True
-
-        if self.pid > 0 and not self._child_exited:
+        if self.process is not None and not self._child_exited:
             try:
-                pid, _ = os.waitpid(self.pid, os.WNOHANG)
-                if pid == 0:
-                    os.kill(self.pid, signal.SIGTERM)
-                    time.sleep(0.1)
+                if self.process.poll() is None:
+                    self.process.terminate()
                     try:
-                        pid, _ = os.waitpid(self.pid, os.WNOHANG)
-                        if pid == 0:
-                            os.kill(self.pid, signal.SIGKILL)
-                            os.waitpid(self.pid, 0)
-                    except OSError:
-                        pass
+                        self.process.wait(timeout=0.5)
+                    except subprocess.TimeoutExpired:
+                        self.process.kill()
+                        self.process.wait(timeout=1)
             except (OSError, ProcessLookupError):
                 pass
             finally:
-                self.pid = -1
+                self._child_exited = True
 
         if self.supervisor_fd >= 0:
             try:
@@ -232,6 +198,14 @@ class FixedPtyManager:
                 pass
             finally:
                 self.supervisor_fd = -1
+
+        if self._code_file and os.path.exists(self._code_file):
+            try:
+                os.unlink(self._code_file)
+            except OSError:
+                pass
+            finally:
+                self._code_file = None
 
 
 def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
@@ -324,19 +298,12 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
                 exit_code = None
                 while True:
-                    try:
-                        pid, status = os.waitpid(pty_mgr.pid, os.WNOHANG)
-                        if pid != 0:
-                            if os.WIFEXITED(status):
-                                exit_code = os.WEXITSTATUS(status)
-                            elif os.WIFSIGNALED(status):
-                                exit_code = 128 + os.WTERMSIG(status)
-                            else:
-                                exit_code = status
-                            pty_mgr._child_exited = True
-                            break
-                    except OSError:
+                    ret = pty_mgr.process.poll()
+                    if ret is not None:
+                        exit_code = ret
+                        pty_mgr._child_exited = True
                         break
+                    time.sleep(0.05)
 
                 output = pty_mgr.get_output()
                 pty_mgr.stop()

--- a/va_agent.py
+++ b/va_agent.py
@@ -5,10 +5,50 @@ Strands Agent that performs vulnerability analysis using a sequential, tool-base
 
 import os
 import sys
+import asyncio
+import threading
 from pathlib import Path
 import warnings
 warnings.filterwarnings("ignore")
 os.environ["BYPASS_TOOL_CONSENT"] = "True"
+
+
+# Patch asyncio.SelectorEventLoop.shutdown_default_executor to avoid
+# "RuntimeError: Timeout should be used inside a task" on Python 3.14+.
+# Python 3.14 changed shutdown_default_executor to use timeouts.timeout(),
+# which requires current_task() to be non-None. When nest_asyncio (used by
+# the browser tool) patches the event loop, its _run_once clobbers the
+# current task during handle execution, causing timeouts.timeout() to fail.
+# asyncio.wait_for() also uses timeouts.timeout() internally in 3.14, so
+# we must use manual timeout handling via loop.call_later() instead.
+async def _patched_shutdown_default_executor(self, timeout=None):
+    self._executor_shutdown_called = True
+    if self._default_executor is None:
+        return
+    future = self.create_future()
+    thread = threading.Thread(target=self._do_shutdown, args=(future,))
+    thread.start()
+    timeout_handle = None
+    if timeout is not None:
+        timeout_handle = self.call_later(timeout, future.cancel)
+    try:
+        await future
+    except asyncio.CancelledError:
+        warnings.warn(
+            "The executor did not finish joining its threads "
+            f"within {timeout} seconds.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        self._default_executor.shutdown(wait=False)
+    else:
+        thread.join()
+    finally:
+        if timeout_handle is not None:
+            timeout_handle.cancel()
+
+
+asyncio.SelectorEventLoop.shutdown_default_executor = _patched_shutdown_default_executor
 
 
 # Add the src directory to Python path
@@ -96,8 +136,9 @@ class VulnerabilityIntelligenceAgent:
         from strands.agent.conversation_manager import SlidingWindowConversationManager
 
         conversation_manager = SlidingWindowConversationManager(
-            window_size=100,  # Maximum number of messages to keep
-            should_truncate_results=True, # Enable truncating tool results if needed
+            window_size=40,  # Maximum number of messages to keep
+            should_truncate_results=True,  # Enable truncating tool results if needed
+            per_turn=True,  # Proactively manage context before every model call
         )
         bedrock = BedrockModel(
             model_id=model_name,
@@ -116,12 +157,12 @@ class VulnerabilityIntelligenceAgent:
 
         self.agent = Agent(
             conversation_manager=conversation_manager,
-            model=openai_model,
-            # model=bedrock,
+            # model=openai_model,
+            model=bedrock,
             plugins=[plugin],
             system_prompt=self.system_prompt,
             tools=[
-                "strands_tools.http_request",
+                "manus_use.tools.http_request",
                 "manus_use.tools.python_repl",
                 current_time,
                 "manus_use.tools.create_lark_document",


### PR DESCRIPTION
… strands deps

- Replace os.fork() with subprocess.Popen in python_repl to avoid crashes on macOS when forking in a multithreaded process
- Add two-phase output truncation in http_request (per-item + total limit) with configurable env vars (HTTP_REQUEST_MAX_OUTPUT_CHARS, HTTP_REQUEST_MAX_TOTAL_OUTPUT_CHARS)
- Patch asyncio shutdown_default_executor for Python 3.14+ compatibility with nest_asyncio
- Reduce conversation window_size to 40, enable per_turn context management
- Switch va_agent to Bedrock model and manus_use.tools.http_request
- Bump strands-agents>=1.38.0, strands-agents-tools>=0.5.2