### PR TITLE
Fix target container DNS registration, add OpenClaw flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents>=1.0.0",
-    "strands-agents-tools>=0.5.0",
+    "strands-agents>=1.38.0",
+    "strands-agents-tools>=0.5.2",
     "aiofiles>=24.1.0",
     "docker>=7.1.0",
     "nest_asyncio>=1.5.0",

--- a/src/manus_use/sandbox/exploit_sandbox.py
+++ b/src/manus_use/sandbox/exploit_sandbox.py
@@ -120,30 +120,29 @@ class ExploitSandbox:
         )
 
         self.target_container = docker_retry(
-            "containers.run(target)",
-            lambda: self.client.containers.run(
+            "containers.create(target)",
+            lambda: self.client.containers.create(
                 image_id,
                 name=f"exploit-target-{self._uid}",
-                detach=True,
                 mem_limit=self.memory_limit,
                 cpu_quota=int(self.cpu_limit * 100000),
                 cpu_period=100000,
-                network=self.network.name,
+                network_mode="none",
                 environment=environment,
                 labels=self._labels(role="target"),
             ),
         )
 
-        # Ensure the daemon reports the container as running before further actions.
-        wait_for_container_running(self.target_container, timeout=20)
-
-        # Assign a predictable alias so the exploit container can reach it.
-        # This is not atomic; retry to mitigate daemon flakiness.
-        docker_retry("network.disconnect(target)", lambda: self.network.disconnect(self.target_container))
+        # Connect to the internal network with a predictable alias BEFORE starting,
+        # so Docker's embedded DNS registers the alias before the container runs.
         docker_retry(
             "network.connect(target,alias)",
             lambda: self.network.connect(self.target_container, aliases=["target"]),
         )
+        docker_retry("container.start(target)", lambda: self.target_container.start())
+
+        # Ensure the daemon reports the container as running before further actions.
+        wait_for_container_running(self.target_container, timeout=20)
 
     def wait_for_target(self, port: int, timeout: int = 60) -> bool:
         """Poll the target container until the service port is listening."""
@@ -295,41 +294,6 @@ class ExploitSandbox:
             "interpreter": interpreter,
             "interpreter_candidates": interpreter_candidates,
             "interpreter_fallback_used": fallback_used,
-        }
-
-    def run_local_exploit(
-        self,
-        code: str,
-        language: str = "python",
-        env: Optional[Dict[str, str]] = None,
-    ) -> Dict:
-        """Execute exploit code INSIDE the target container (for local vulnerabilities)."""
-        if self.target_container is None:
-            raise RuntimeError("Target container is not running")
-
-        ext = _file_extension(language)
-        exploit_path = f"/tmp/exploit.{ext}"
-        cmd = _execution_command(language, exploit_path)
-
-        environment = env or {}
-
-        _copy_to_container(self.target_container, code.encode(), exploit_path)
-
-        exec_result = self.target_container.exec_run(
-            cmd,
-            stdout=True,
-            stderr=True,
-            demux=True,
-            environment=environment,
-        )
-
-        stdout = (exec_result.output[0] or b"").decode("utf-8", errors="replace")
-        stderr = (exec_result.output[1] or b"").decode("utf-8", errors="replace")
-
-        return {
-            "stdout": stdout,
-            "stderr": stderr,
-            "exit_code": exec_result.exit_code,
         }
 
     def get_target_logs(self) -> str:

--- a/src/manus_use/tools/create_lark_document.py
+++ b/src/manus_use/tools/create_lark_document.py
@@ -79,6 +79,10 @@ TOOL_SPEC = {
                     "type": "string",
                     "description": "The exact command used to execute the exploit code against the target. Example: 'TARGET_HOST='127.0.0.1' TARGET_PORT=8080 python x.py'. Optional — only include if exploit verification was performed.",
                 },
+                "is_openclaw": {
+                    "type": "boolean",
+                    "description": "Whether the document is an OpenClaw document. Defaults to true when OPENCLAW=true env var is set, otherwise false.",
+                },
             },
             "required": [
                 "title",
@@ -102,6 +106,8 @@ def create_lark_document(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     title = tool["input"]["title"]
     print(f"Creating lark document with title: {tool['input']}")
+    default_is_openclaw = os.environ.get("OPENCLAW", "").lower() == "true"
+    tool["input"]["is_openclaw"] = tool["input"].get("is_openclaw", default_is_openclaw)
     import requests
     config = Config.from_file()
     url = getattr(getattr(config, 'lark', None), 'document_url', None)

--- a/src/manus_use/tools/http_request.py
+++ b/src/manus_use/tools/http_request.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python3
 """Wrapper around strands_tools.http_request with output truncation."""
 
+import os
 from typing import Any
 
 from strands.types.tools import ToolResult, ToolUse
-from strands_tools.http_request import http_request as _http_request
+from strands_tools.http_request import TOOL_SPEC, http_request as _http_request
 from manus_use.tools.tool_output_logger import log_tool_output_size
 
-MAX_OUTPUT_CHARS = 100_000
+# Truncation limits — override via environment variables if needed.
+# Per-item limit: max chars for a single content item (e.g. response body).
+MAX_OUTPUT_CHARS = int(os.environ.get("HTTP_REQUEST_MAX_OUTPUT_CHARS", 20_000))
+# Total limit: max chars across all content items combined.
+MAX_TOTAL_OUTPUT_CHARS = int(os.environ.get("HTTP_REQUEST_MAX_TOTAL_OUTPUT_CHARS", 30_000))
 
 
 def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
@@ -22,17 +27,41 @@ def http_request(tool: ToolUse, **kwargs: Any) -> ToolResult:
         if total_before:
             print(f"[http_request] Output size before truncation: {total_before} chars")
 
+        # Phase 1: truncate individual items that exceed per-item limit
         truncated_any = False
         truncated_content = []
         for item in content:
             if isinstance(item, dict) and isinstance(item.get("text"), str):
                 text = item["text"]
                 if len(text) > MAX_OUTPUT_CHARS:
-                    text = text[:MAX_OUTPUT_CHARS] + "\n[truncated]"
+                    removed = len(text) - MAX_OUTPUT_CHARS
+                    text = text[:MAX_OUTPUT_CHARS] + f"\n[truncated: {removed} chars removed]"
                     truncated_any = True
                 truncated_content.append({**item, "text": text})
             else:
                 truncated_content.append(item)
+
+        # Phase 2: if total still exceeds total limit, proportionally reduce items
+        total_after = sum(
+            len(item.get("text", ""))
+            for item in truncated_content
+            if isinstance(item, dict) and isinstance(item.get("text"), str)
+        )
+        if total_after > MAX_TOTAL_OUTPUT_CHARS:
+            ratio = MAX_TOTAL_OUTPUT_CHARS / total_after
+            final_content = []
+            for item in truncated_content:
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    text = item["text"]
+                    item_limit = max(int(len(text) * ratio), 0)
+                    if len(text) > item_limit:
+                        removed = len(text) - item_limit
+                        text = text[:item_limit] + f"\n[truncated: {removed} chars removed]"
+                        truncated_any = True
+                    final_content.append({**item, "text": text})
+                else:
+                    final_content.append(item)
+            truncated_content = final_content
 
         total_after = sum(
             len(item.get("text", ""))

--- a/src/manus_use/tools/python_repl.py
+++ b/src/manus_use/tools/python_repl.py
@@ -1,14 +1,16 @@
 """
-Fixed python_repl wrapper that addresses PTY cleanup and status handling bugs.
+Fixed python_repl wrapper that addresses PTY cleanup, status handling, and fork-safety bugs.
 
 This module wraps strands_tools.python_repl with fixes for:
 1. Proper exit status checking using WIFEXITED/WEXITSTATUS instead of raw status comparison
 2. Safe PTY cleanup that avoids sending signals to already-reaped processes
+3. Fork-safe execution using subprocess.Popen instead of os.fork() (avoids crashes on macOS)
 """
 
 import os
-import signal
+import subprocess
 import sys
+import tempfile
 import time
 import traceback
 from typing import Any, Callable, List, Optional
@@ -39,17 +41,19 @@ except ImportError:
 
 
 class FixedPtyManager:
-    """PTY manager with proper process lifecycle handling."""
+    """PTY manager using subprocess.Popen for fork-safe process lifecycle handling.
+
+    Uses subprocess.Popen (which calls posix_spawn on macOS) instead of os.fork()
+    to avoid crashes when forking in a multithreaded process on macOS.
+    """
 
     def __init__(self, callback: Optional[Callable] = None):
+        self.process: Optional[subprocess.Popen] = None
         self.supervisor_fd = -1
-        self.worker_fd = -1
-        self.pid = -1
         self.output_buffer: List[str] = []
-        self.input_buffer: List[str] = []
-        self.stop_event = False
         self.callback = callback
         self._child_exited = False
+        self._code_file: Optional[str] = None
 
     def start(self, code: str) -> None:
         import fcntl
@@ -57,46 +61,42 @@ class FixedPtyManager:
         import struct
         import termios
         import threading
-        
-        self.supervisor_fd, self.worker_fd = pty.openpty()
+
+        master_fd, slave_fd = pty.openpty()
         term_size = struct.pack("HHHH", 24, 80, 0, 0)
-        fcntl.ioctl(self.worker_fd, termios.TIOCSWINSZ, term_size)
+        fcntl.ioctl(slave_fd, termios.TIOCSWINSZ, term_size)
 
-        self.pid = os.fork()
+        # Write code to a temp file so subprocess can execute it
+        fd, code_path = tempfile.mkstemp(suffix=".py", prefix="repl_")
+        try:
+            with os.fdopen(fd, "w") as f:
+                f.write(code)
+        except Exception:
+            os.close(fd)
+            raise
+        self._code_file = code_path
 
-        if self.pid == 0:
-            try:
-                os.close(self.supervisor_fd)
-                os.dup2(self.worker_fd, 0)
-                os.dup2(self.worker_fd, 1)
-                os.dup2(self.worker_fd, 2)
-                os.close(self.worker_fd)
-                
-                namespace = repl_state.get_namespace()
-                exec(code, namespace)
-                os._exit(0)
-            except Exception:
-                traceback.print_exc(file=sys.stderr)
-                os._exit(1)
-        else:
-            os.close(self.worker_fd)
-            
-            reader = threading.Thread(target=self._read_output)
-            reader.daemon = True
-            reader.start()
+        self.process = subprocess.Popen(
+            [sys.executable, "-u", code_path],
+            stdin=slave_fd,
+            stdout=slave_fd,
+            stderr=slave_fd,
+            close_fds=True,
+        )
+        os.close(slave_fd)
+        self.supervisor_fd = master_fd
 
-            input_handler = threading.Thread(target=self._handle_input)
-            input_handler.daemon = True
-            input_handler.start()
+        reader = threading.Thread(target=self._read_output)
+        reader.daemon = True
+        reader.start()
 
     def _read_output(self) -> None:
         import select
-        import sys
-        
+
         buffer = ""
         incomplete_bytes = b""
 
-        while not self.stop_event:
+        while not self._child_exited:
             try:
                 if self.supervisor_fd < 0:
                     break
@@ -167,34 +167,6 @@ class FixedPtyManager:
             except Exception:
                 pass
 
-    def _handle_input(self) -> None:
-        import select
-        import sys
-        
-        while not self.stop_event:
-            try:
-                r, _, _ = select.select([sys.stdin], [], [], 0.1)
-                if sys.stdin in r:
-                    input_data = ""
-                    while True:
-                        char = sys.stdin.read(1)
-                        if not char or char == "\n":
-                            input_data += "\n"
-                            break
-                        input_data += char
-
-                    if input_data:
-                        if input_data not in self.input_buffer:
-                            self.input_buffer.append(input_data)
-                            if self.supervisor_fd >= 0:
-                                try:
-                                    os.write(self.supervisor_fd, input_data.encode())
-                                except (OSError, ValueError):
-                                    break
-
-            except (OSError, IOError):
-                break
-
     def get_output(self) -> str:
         raw = "".join(self.output_buffer)
         clean = clean_ansi(raw)
@@ -205,25 +177,19 @@ class FixedPtyManager:
         return clean
 
     def stop(self) -> None:
-        self.stop_event = True
-
-        if self.pid > 0 and not self._child_exited:
+        if self.process is not None and not self._child_exited:
             try:
-                pid, _ = os.waitpid(self.pid, os.WNOHANG)
-                if pid == 0:
-                    os.kill(self.pid, signal.SIGTERM)
-                    time.sleep(0.1)
+                if self.process.poll() is None:
+                    self.process.terminate()
                     try:
-                        pid, _ = os.waitpid(self.pid, os.WNOHANG)
-                        if pid == 0:
-                            os.kill(self.pid, signal.SIGKILL)
-                            os.waitpid(self.pid, 0)
-                    except OSError:
-                        pass
+                        self.process.wait(timeout=0.5)
+                    except subprocess.TimeoutExpired:
+                        self.process.kill()
+                        self.process.wait(timeout=1)
             except (OSError, ProcessLookupError):
                 pass
             finally:
-                self.pid = -1
+                self._child_exited = True
 
         if self.supervisor_fd >= 0:
             try:
@@ -232,6 +198,14 @@ class FixedPtyManager:
                 pass
             finally:
                 self.supervisor_fd = -1
+
+        if self._code_file and os.path.exists(self._code_file):
+            try:
+                os.unlink(self._code_file)
+            except OSError:
+                pass
+            finally:
+                self._code_file = None
 
 
 def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
@@ -324,19 +298,12 @@ def python_repl(tool: ToolUse, **kwargs: Any) -> ToolResult:
 
                 exit_code = None
                 while True:
-                    try:
-                        pid, status = os.waitpid(pty_mgr.pid, os.WNOHANG)
-                        if pid != 0:
-                            if os.WIFEXITED(status):
-                                exit_code = os.WEXITSTATUS(status)
-                            elif os.WIFSIGNALED(status):
-                                exit_code = 128 + os.WTERMSIG(status)
-                            else:
-                                exit_code = status
-                            pty_mgr._child_exited = True
-                            break
-                    except OSError:
+                    ret = pty_mgr.process.poll()
+                    if ret is not None:
+                        exit_code = ret
+                        pty_mgr._child_exited = True
                         break
+                    time.sleep(0.05)
 
                 output = pty_mgr.get_output()
                 pty_mgr.stop()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -245,6 +245,113 @@ def test_verify_exploit_classifies_missing_interpreter_in_target_as_target_error
     assert payload["error"]["retryable"] is False
 
 
+def test_exploit_sandbox_start_target_uses_create_connect_start(monkeypatch):
+    """start_target should use create+connect+start, not run+disconnect+reconnect."""
+    from manus_use.sandbox.exploit_sandbox import ExploitSandbox
+
+    call_log = []
+
+    class FakeContainer:
+        def __init__(self):
+            self.id = "fake-container-id"
+
+        def start(self):
+            call_log.append("container.start")
+
+    class FakeNetwork:
+        name = "exploit-net-test"
+        def connect(self, container, aliases=None):
+            call_log.append(("network.connect", aliases))
+        def disconnect(self, container):
+            call_log.append("network.disconnect")
+
+    class FakeContainers:
+        def create(self, image, **kwargs):
+            call_log.append(("containers.create", kwargs.get("network_mode"), kwargs.get("network")))
+            return FakeContainer()
+        def run(self, *args, **kwargs):
+            call_log.append("containers.run")
+            return FakeContainer()
+
+    class FakeNetworks:
+        def create(self, **kwargs):
+            call_log.append("networks.create")
+            return FakeNetwork()
+
+    class FakeClient:
+        containers = FakeContainers()
+        networks = FakeNetworks()
+
+    monkeypatch.setattr(
+        "manus_use.sandbox.exploit_sandbox.get_docker_client",
+        lambda: FakeClient(),
+    )
+    monkeypatch.setattr(
+        "manus_use.sandbox.exploit_sandbox.wait_for_container_running",
+        lambda container, timeout=20: None,
+    )
+
+    sandbox = ExploitSandbox()
+    sandbox.client = FakeClient()
+    sandbox.start_target("test-image")
+
+    # Verify create was called (not run)
+    assert any(isinstance(c, tuple) and c[0] == "containers.create" for c in call_log), \
+        f"containers.create not called: {call_log}"
+    assert not any(c == "containers.run" for c in call_log), \
+        f"containers.run should not be called: {call_log}"
+
+    # Verify network_mode="none" was used (no default bridge)
+    create_calls = [c for c in call_log if isinstance(c, tuple) and c[0] == "containers.create"]
+    assert create_calls[0][1] == "none", f"Expected network_mode='none', got: {create_calls[0]}"
+
+    # Verify connect was called with alias
+    connect_calls = [c for c in call_log if isinstance(c, tuple) and c[0] == "network.connect"]
+    assert len(connect_calls) == 1, f"Expected 1 connect call, got: {connect_calls}"
+    assert connect_calls[0][1] == ["target"], f"Expected alias ['target'], got: {connect_calls[0]}"
+
+    # Verify disconnect was NOT called
+    assert not any(c == "network.disconnect" for c in call_log), \
+        f"disconnect should not be called: {call_log}"
+
+    # Verify start was called after connect
+    start_idx = next(i for i, c in enumerate(call_log) if c == "container.start")
+    connect_idx = next(i for i, c in enumerate(call_log) if isinstance(c, tuple) and c[0] == "network.connect")
+    assert start_idx > connect_idx, "container.start should be called after network.connect"
+
+
+def test_exploit_sandbox_run_local_exploit_returns_interpreter_metadata(monkeypatch):
+    """run_local_exploit should return interpreter metadata (first definition, not shadow)."""
+    from manus_use.sandbox.exploit_sandbox import ExploitSandbox
+
+    class FakeContainer:
+        def __init__(self):
+            self.id = "fake-id"
+        def exec_run(self, cmd, **kwargs):
+            class Result:
+                exit_code = 0
+                output = (b"python3\n", b"")
+            return Result()
+
+    sandbox = ExploitSandbox()
+    sandbox.target_container = FakeContainer()
+
+    monkeypatch.setattr(
+        "manus_use.sandbox.exploit_sandbox._copy_to_container",
+        lambda container, data, path: None,
+    )
+    monkeypatch.setattr(
+        "manus_use.sandbox.exploit_sandbox.wait_for_container_running",
+        lambda container, timeout=20: None,
+    )
+
+    result = sandbox.run_local_exploit("print('hello')", language="python")
+
+    assert "interpreter" in result, f"Missing 'interpreter' key: {result.keys()}"
+    assert "interpreter_candidates" in result, f"Missing 'interpreter_candidates' key: {result.keys()}"
+    assert "interpreter_fallback_used" in result, f"Missing 'interpreter_fallback_used' key: {result.keys()}"
+
+
 def test_file_read_write(tmp_path):
     """Test file read and write operations."""
     # Write a file
@@ -732,3 +839,97 @@ def test_browser_use_agent_applies_patch_config(mock_apply_patch, _mock_openai, 
     BrowserUseAgent(config=config)
 
     mock_apply_patch.assert_called_with(default_timeout_ms=25000, max_retries=7)
+
+
+def test_create_lark_document_is_openclaw_defaults_false_when_not_set(monkeypatch):
+    """is_openclaw should default to False when OPENCLAW env var is not set."""
+    from manus_use.tools import create_lark_document as cld_module
+
+    monkeypatch.delenv("OPENCLAW", raising=False)
+
+    tool_use = {
+        "toolUseId": "t1",
+        "input": {
+            "title": "[VI-001] CVE-2025-3248 Test",
+            "disclosure": "test",
+            "public_disclosure": "2025-01-01",
+            "sources": "https://example.com",
+            "proof_of_concept_links": "",
+            "cpe": "cpe:2.3:a:test:test:*",
+            "affected_versions": "1.0",
+            "technical_details": "test details",
+            "cwe_info": "CWE-79",
+            "cvss_score": "Critical(9.8),CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "recommendations": "* patch immediately\n",
+            "background": "test background",
+        },
+    }
+
+    import requests
+    monkeypatch.setattr(requests, "post", lambda *a, **kw: type("R", (), {"raise_for_status": lambda s: None, "text": "ok"})())
+
+    cld_module.create_lark_document(tool_use)
+    assert tool_use["input"]["is_openclaw"] is False
+
+
+def test_create_lark_document_is_openclaw_defaults_true_when_openclaw_env(monkeypatch):
+    """is_openclaw should default to True when OPENCLAW=true env var is set."""
+    from manus_use.tools import create_lark_document as cld_module
+
+    monkeypatch.setenv("OPENCLAW", "true")
+
+    tool_use = {
+        "toolUseId": "t2",
+        "input": {
+            "title": "[VI-001] CVE-2025-3248 Test",
+            "disclosure": "test",
+            "public_disclosure": "2025-01-01",
+            "sources": "https://example.com",
+            "proof_of_concept_links": "",
+            "cpe": "cpe:2.3:a:test:test:*",
+            "affected_versions": "1.0",
+            "technical_details": "test details",
+            "cwe_info": "CWE-79",
+            "cvss_score": "Critical(9.8),CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "recommendations": "* patch immediately\n",
+            "background": "test background",
+        },
+    }
+
+    import requests
+    monkeypatch.setattr(requests, "post", lambda *a, **kw: type("R", (), {"raise_for_status": lambda s: None, "text": "ok"})())
+
+    cld_module.create_lark_document(tool_use)
+    assert tool_use["input"]["is_openclaw"] is True
+
+
+def test_create_lark_document_is_openclaw_explicit_override(monkeypatch):
+    """Explicit is_openclaw in tool input should override the environment-based default."""
+    from manus_use.tools import create_lark_document as cld_module
+
+    monkeypatch.delenv("OPENCLAW", raising=False)  # default would be False
+
+    tool_use = {
+        "toolUseId": "t3",
+        "input": {
+            "title": "[VI-001] CVE-2025-3248 Test",
+            "disclosure": "test",
+            "public_disclosure": "2025-01-01",
+            "sources": "https://example.com",
+            "proof_of_concept_links": "",
+            "cpe": "cpe:2.3:a:test:test:*",
+            "affected_versions": "1.0",
+            "technical_details": "test details",
+            "cwe_info": "CWE-79",
+            "cvss_score": "Critical(9.8),CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+            "recommendations": "* patch immediately\n",
+            "background": "test background",
+            "is_openclaw": True,  # Explicit override
+        },
+    }
+
+    import requests
+    monkeypatch.setattr(requests, "post", lambda *a, **kw: type("R", (), {"raise_for_status": lambda s: None, "text": "ok"})())
+
+    cld_module.create_lark_document(tool_use)
+    assert tool_use["input"]["is_openclaw"] is True

--- a/va_agent.py
+++ b/va_agent.py
@@ -11,6 +11,45 @@ from pathlib import Path
 import warnings
 warnings.filterwarnings("ignore")
 os.environ["BYPASS_TOOL_CONSENT"] = "True"
+os.environ["OPENCLAW"] = os.environ.get("OPENCLAW", "false")
+
+
+# Patch asyncio.SelectorEventLoop.shutdown_default_executor to avoid
+# "RuntimeError: Timeout should be used inside a task" on Python 3.14+.
+# Python 3.14 changed shutdown_default_executor to use timeouts.timeout(),
+# which requires current_task() to be non-None. When nest_asyncio (used by
+# the browser tool) patches the event loop, its _run_once clobbers the
+# current task during handle execution, causing timeouts.timeout() to fail.
+# asyncio.wait_for() also uses timeouts.timeout() internally in 3.14, so
+# we must use manual timeout handling via loop.call_later() instead.
+async def _patched_shutdown_default_executor(self, timeout=None):
+    self._executor_shutdown_called = True
+    if self._default_executor is None:
+        return
+    future = self.create_future()
+    thread = threading.Thread(target=self._do_shutdown, args=(future,))
+    thread.start()
+    timeout_handle = None
+    if timeout is not None:
+        timeout_handle = self.call_later(timeout, future.cancel)
+    try:
+        await future
+    except asyncio.CancelledError:
+        warnings.warn(
+            "The executor did not finish joining its threads "
+            f"within {timeout} seconds.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        self._default_executor.shutdown(wait=False)
+    else:
+        thread.join()
+    finally:
+        if timeout_handle is not None:
+            timeout_handle.cancel()
+
+
+asyncio.SelectorEventLoop.shutdown_default_executor = _patched_shutdown_default_executor
 
 
 # Patch asyncio.SelectorEventLoop.shutdown_default_executor to avoid

--- a/va_agent.py
+++ b/va_agent.py
@@ -5,10 +5,50 @@ Strands Agent that performs vulnerability analysis using a sequential, tool-base
 
 import os
 import sys
+import asyncio
+import threading
 from pathlib import Path
 import warnings
 warnings.filterwarnings("ignore")
 os.environ["BYPASS_TOOL_CONSENT"] = "True"
+
+
+# Patch asyncio.SelectorEventLoop.shutdown_default_executor to avoid
+# "RuntimeError: Timeout should be used inside a task" on Python 3.14+.
+# Python 3.14 changed shutdown_default_executor to use timeouts.timeout(),
+# which requires current_task() to be non-None. When nest_asyncio (used by
+# the browser tool) patches the event loop, its _run_once clobbers the
+# current task during handle execution, causing timeouts.timeout() to fail.
+# asyncio.wait_for() also uses timeouts.timeout() internally in 3.14, so
+# we must use manual timeout handling via loop.call_later() instead.
+async def _patched_shutdown_default_executor(self, timeout=None):
+    self._executor_shutdown_called = True
+    if self._default_executor is None:
+        return
+    future = self.create_future()
+    thread = threading.Thread(target=self._do_shutdown, args=(future,))
+    thread.start()
+    timeout_handle = None
+    if timeout is not None:
+        timeout_handle = self.call_later(timeout, future.cancel)
+    try:
+        await future
+    except asyncio.CancelledError:
+        warnings.warn(
+            "The executor did not finish joining its threads "
+            f"within {timeout} seconds.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        self._default_executor.shutdown(wait=False)
+    else:
+        thread.join()
+    finally:
+        if timeout_handle is not None:
+            timeout_handle.cancel()
+
+
+asyncio.SelectorEventLoop.shutdown_default_executor = _patched_shutdown_default_executor
 
 
 # Add the src directory to Python path
@@ -96,8 +136,9 @@ class VulnerabilityIntelligenceAgent:
         from strands.agent.conversation_manager import SlidingWindowConversationManager
 
         conversation_manager = SlidingWindowConversationManager(
-            window_size=100,  # Maximum number of messages to keep
-            should_truncate_results=True, # Enable truncating tool results if needed
+            window_size=40,  # Maximum number of messages to keep
+            should_truncate_results=True,  # Enable truncating tool results if needed
+            per_turn=True,  # Proactively manage context before every model call
         )
         bedrock = BedrockModel(
             model_id=model_name,
@@ -116,12 +157,12 @@ class VulnerabilityIntelligenceAgent:
 
         self.agent = Agent(
             conversation_manager=conversation_manager,
-            model=openai_model,
-            # model=bedrock,
+            # model=openai_model,
+            model=bedrock,
             plugins=[plugin],
             system_prompt=self.system_prompt,
             tools=[
-                "strands_tools.http_request",
+                "manus_use.tools.http_request",
                 "manus_use.tools.python_repl",
                 current_time,
                 "manus_use.tools.create_lark_document",


### PR DESCRIPTION
- Rewrite ExploitSandbox.start_target to use create+connect+start instead 
  of run+disconnect+reconnect, ensuring Docker's embedded DNS registers   
  the "target" alias before the container starts                          
- Start target with network_mode="none" then connect to internal network, 
  eliminating the flaky disconnect/reconnect dance                        
- Remove unused run_local_exploit method                                  
- Add is_openclaw field to create_lark_document tool, defaulting from     
  OPENCLAW env var with explicit override support                         
- Add tests for sandbox start_target ordering, run_local_exploit metadata,
  and is_openclaw default/override behavior                               