### PR TITLE
feat(cli): add `manus-use init` and `manus-use doctor` subcommands

### DIFF
--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1,24 +1,29 @@
 """Command-line interface for ManusUse."""
 
 import argparse
+import os
 import re
+import shutil
 import sys
 from pathlib import Path
-from typing import Optional
 
+import toml
 from rich.console import Console
-from rich.prompt import Prompt
-from rich.table import Table
 from rich.panel import Panel
 from rich.progress import Progress, SpinnerColumn, TextColumn
+from rich.prompt import Confirm, Prompt
+from rich.table import Table
 
 from . import __version__
 from .config import Config
 from .multi_agents import Orchestrator
 
-
 console = Console()
 
+
+# ---------------------------------------------------------------------------
+# Complexity heuristic
+# ---------------------------------------------------------------------------
 
 def is_complex_task(user_input: str) -> bool:
     """Determine if a task requires multi-agent orchestration."""
@@ -50,6 +55,10 @@ def is_complex_task(user_input: str) -> bool:
     return False
 
 
+# ---------------------------------------------------------------------------
+# Execution plan display
+# ---------------------------------------------------------------------------
+
 def display_task_plan(tasks) -> None:
     """Display the execution plan in a formatted table."""
     table = Table(title="Execution Plan", show_header=True, header_style="bold magenta")
@@ -70,6 +79,10 @@ def display_task_plan(tasks) -> None:
     console.print(table)
 
 
+# ---------------------------------------------------------------------------
+# Agent factory
+# ---------------------------------------------------------------------------
+
 def _make_agent(agent_type: str, config: Config):
     """Instantiate the requested agent type."""
     if agent_type == "browser":
@@ -86,13 +99,17 @@ def _make_agent(agent_type: str, config: Config):
     return ManusAgent(config=config)
 
 
+# ---------------------------------------------------------------------------
+# Single-shot and interactive runners
+# ---------------------------------------------------------------------------
+
 def _run_single_shot(
     task: str,
     *,
     mode: str,
     agent_type: str,
     show_plan: bool,
-    output: Optional[Path],
+    output: Path | None,
     config: Config,
 ) -> int:
     """Execute a single task non-interactively and exit.
@@ -225,9 +242,313 @@ def _run_interactive(
             console.print(f"\n[red]Error: {exc}[/red]")
 
 
-def main() -> None:
-    """Main CLI entry point."""
+# ---------------------------------------------------------------------------
+# manus-use init
+# ---------------------------------------------------------------------------
+
+# Provider metadata: (display_name, default_model, env_var_for_api_key, needs_api_key)
+_PROVIDERS = {
+    "openai": ("OpenAI", "gpt-4o", "OPENAI_API_KEY", True),
+    "anthropic": ("Anthropic", "claude-3-5-sonnet-20241022", "ANTHROPIC_API_KEY", True),
+    "bedrock": ("AWS Bedrock", "us.anthropic.claude-3-5-sonnet-20241022-v2:0", None, False),
+    "ollama": ("Ollama (local)", "llama3.2", None, False),
+}
+
+_DEFAULT_CONFIG_PATH = Path.home() / ".manus-use" / "config.toml"
+
+
+def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
+    """Guided interactive config generator."""
+    console.print(Panel(
+        "[bold]Welcome to [cyan]manus-use init[/cyan]![/bold]\n"
+        "This wizard will create a [yellow]config.toml[/yellow] for you.",
+        border_style="blue",
+    ))
+
+    # Destination path
+    dest: Path = args.output or _DEFAULT_CONFIG_PATH
+    if dest.exists() and not args.force:
+        overwrite = Confirm.ask(
+            f"[yellow]{dest}[/yellow] already exists. Overwrite?", default=False
+        )
+        if not overwrite:
+            console.print("[dim]Aborted – existing config left unchanged.[/dim]")
+            return 0
+
+    # Provider selection
+    console.print("\n[bold]Choose a provider:[/bold]")
+    provider_keys = list(_PROVIDERS.keys())
+    for i, key in enumerate(provider_keys, 1):
+        display, default_model, env_var, needs_key = _PROVIDERS[key]
+        env_hint = f" (env: [dim]{env_var}[/dim])" if env_var else ""
+        console.print(f"  [cyan]{i}[/cyan]. {display}{env_hint}")
+
+    while True:
+        choice = Prompt.ask(
+            "Provider",
+            default="1",
+            choices=[str(i) for i in range(1, len(provider_keys) + 1)],
+            show_choices=False,
+        )
+        provider = provider_keys[int(choice) - 1]
+        break
+
+    display_name, default_model, env_var, needs_key = _PROVIDERS[provider]
+
+    # Model
+    model = Prompt.ask(
+        f"\n[bold]Model ID[/bold] for {display_name}",
+        default=default_model,
+    )
+
+    # API key / region
+    api_key: str | None = None
+    aws_region: str | None = None
+    base_url: str | None = None
+
+    if needs_key:
+        env_val = os.environ.get(env_var, "") if env_var else ""
+        if env_val:
+            console.print(
+                f"[green]✓[/green] Found [dim]{env_var}[/dim] in environment "
+                "(will be used at runtime – not stored in config)."
+            )
+            store_key = Confirm.ask("Store API key in config file anyway?", default=False)
+        else:
+            console.print(f"[yellow]![/yellow] [dim]{env_var}[/dim] not set in environment.")
+            store_key = Confirm.ask("Enter API key now and store in config?", default=True)
+
+        if store_key:
+            api_key = Prompt.ask(f"[bold]{env_var}[/bold]", password=True)
+
+    elif provider == "bedrock":
+        aws_region = Prompt.ask(
+            "\n[bold]AWS region[/bold]",
+            default=os.environ.get("AWS_DEFAULT_REGION", "us-east-1"),
+        )
+    elif provider == "ollama":
+        base_url = Prompt.ask(
+            "\n[bold]Ollama base URL[/bold]",
+            default="http://localhost:11434",
+        )
+
+    # Sandbox
+    sandbox_enabled = Confirm.ask("\n[bold]Enable Docker sandbox?[/bold]", default=True)
+
+    # Assemble config dict
+    llm_section: dict = {"provider": provider, "model": model}
+    if api_key:
+        llm_section["api_key"] = api_key
+    if aws_region:
+        llm_section["aws_region"] = aws_region
+    if base_url:
+        llm_section["base_url"] = base_url
+
+    config_data: dict = {
+        "llm": llm_section,
+        "sandbox": {"enabled": sandbox_enabled},
+    }
+
+    # Write
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    with open(dest, "w", encoding="utf-8") as fh:
+        toml.dump(config_data, fh)
+
+    console.print(Panel(
+        f"[green]✓ Config written to[/green] [bold]{dest}[/bold]\n\n"
+        f"Run [cyan]manus-use doctor[/cyan] to verify your setup.",
+        border_style="green",
+        title="[bold green]Done![/bold green]",
+    ))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# manus-use doctor
+# ---------------------------------------------------------------------------
+
+# (package_import, pip_extra, description)
+_PROVIDER_PACKAGES: dict[str, list[tuple[str, str, str]]] = {
+    "openai": [("openai", "openai", "OpenAI SDK")],
+    "anthropic": [("anthropic", "anthropic", "Anthropic SDK")],
+    "bedrock": [("boto3", "boto3", "AWS boto3")],
+    "ollama": [("ollama", "ollama", "Ollama client")],
+}
+
+_ALWAYS_CHECK: list[tuple[str, str, str]] = [
+    ("strands", "strands-agents", "Strands Agents SDK"),
+    ("rich", "rich", "Rich (terminal UI)"),
+    ("toml", "toml", "TOML parser"),
+    ("pydantic", "pydantic", "Pydantic"),
+]
+
+
+def _check_import(package: str) -> bool:
+    """Return True if *package* is importable."""
+    import importlib
+    try:
+        importlib.import_module(package)
+        return True
+    except ImportError:
+        return False
+
+
+def _cmd_doctor(args: argparse.Namespace) -> int:
+    """Check packages, config, and environment variables."""
+    console.print(Panel(
+        "[bold cyan]manus-use doctor[/bold cyan] – environment diagnostics",
+        border_style="blue",
+    ))
+
+    issues: list[str] = []
+
+    # ------------------------------------------------------------------
+    # 1. Core packages
+    # ------------------------------------------------------------------
+    console.print("\n[bold]Core packages[/bold]")
+    for pkg, pip_name, desc in _ALWAYS_CHECK:
+        ok = _check_import(pkg)
+        status = "[green]✓[/green]" if ok else "[red]✗[/red]"
+        note = "" if ok else f"  → [dim]pip install {pip_name}[/dim]"
+        console.print(f"  {status} {desc} ([dim]{pkg}[/dim]){note}")
+        if not ok:
+            issues.append(f"Missing package: {pip_name}")
+
+    # ------------------------------------------------------------------
+    # 2. Config file
+    # ------------------------------------------------------------------
+    console.print("\n[bold]Configuration[/bold]")
+    config_path: Path | None = args.config
+
+    if config_path is None:
+        search_paths = [
+            Path("config.toml"),
+            Path("config/config.toml"),
+            _DEFAULT_CONFIG_PATH,
+        ]
+        for p in search_paths:
+            if p.exists():
+                config_path = p
+                break
+
+    if config_path and config_path.exists():
+        console.print(f"  [green]✓[/green] Config found: [bold]{config_path}[/bold]")
+        try:
+            config = Config.from_file(config_path)
+        except Exception as exc:
+            console.print(f"  [red]✗[/red] Failed to parse config: {exc}")
+            issues.append(f"Config parse error: {exc}")
+            config = Config()
+    else:
+        console.print(
+            "  [yellow]![/yellow] No config file found "
+            "(run [cyan]manus-use init[/cyan] to create one)"
+        )
+        config = Config()
+
+    # ------------------------------------------------------------------
+    # 3. Provider packages + env vars
+    # ------------------------------------------------------------------
+    provider = (config.llm.provider or "openai").lower()
+    console.print(f"\n[bold]Provider[/bold]: [cyan]{provider}[/cyan]  model: [cyan]{config.llm.model}[/cyan]")
+
+    pkg_checks = _PROVIDER_PACKAGES.get(provider, [])
+    for pkg, pip_name, desc in pkg_checks:
+        ok = _check_import(pkg)
+        status = "[green]✓[/green]" if ok else "[red]✗[/red]"
+        note = "" if ok else f"  → [dim]pip install {pip_name}[/dim]"
+        console.print(f"  {status} {desc} ([dim]{pkg}[/dim]){note}")
+        if not ok:
+            issues.append(f"Missing provider package: {pip_name}")
+
+    # Env var checks
+    provider_envs: dict[str, list[tuple[str, bool]]] = {
+        "openai": [("OPENAI_API_KEY", True)],
+        "anthropic": [("ANTHROPIC_API_KEY", True)],
+        "bedrock": [
+            ("AWS_ACCESS_KEY_ID", False),
+            ("AWS_SECRET_ACCESS_KEY", False),
+            ("AWS_DEFAULT_REGION", False),
+        ],
+        "ollama": [],
+    }
+    for env_var, required in provider_envs.get(provider, []):
+        val = os.environ.get(env_var)
+        in_config = False
+        if provider == "openai" and env_var == "OPENAI_API_KEY":
+            in_config = bool(config.llm.api_key)
+        elif provider == "anthropic" and env_var == "ANTHROPIC_API_KEY":
+            in_config = bool(config.llm.api_key)
+
+        if val or in_config:
+            src = "config" if (not val and in_config) else "env"
+            console.print(f"  [green]✓[/green] {env_var} ([dim]{src}[/dim])")
+        elif required:
+            console.print(
+                f"  [red]✗[/red] {env_var} not set "
+                "(required – set it or store in config.toml)"
+            )
+            issues.append(f"Missing env var: {env_var}")
+        else:
+            console.print(f"  [yellow]![/yellow] {env_var} not set (optional for Bedrock)")
+
+    # ------------------------------------------------------------------
+    # 4. Optional tools
+    # ------------------------------------------------------------------
+    console.print("\n[bold]Optional tools[/bold]")
+    _optional: list[tuple[str, str, str]] = [
+        ("docker", "docker", "Docker (sandbox execution)"),
+        ("playwright", "playwright", "Playwright (browser agent)"),
+        ("pandas", "pandas", "Pandas (data analysis agent)"),
+    ]
+    for pkg, pip_name, desc in _optional:
+        ok = _check_import(pkg)
+        status = "[green]✓[/green]" if ok else "[dim]-[/dim]"
+        note = "" if ok else f"  [dim](optional – pip install {pip_name})[/dim]"
+        console.print(f"  {status} {desc}{note}")
+
+    # Docker daemon reachable?
+    if shutil.which("docker"):
+        import subprocess
+        result = subprocess.run(
+            ["docker", "info"], capture_output=True, timeout=5
+        )
+        if result.returncode == 0:
+            console.print("  [green]✓[/green] Docker daemon reachable")
+        else:
+            console.print("  [yellow]![/yellow] Docker installed but daemon not running")
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+    console.print()
+    if not issues:
+        console.print(Panel(
+            "[bold green]All checks passed![/bold green] "
+            "Your environment looks ready.",
+            border_style="green",
+        ))
+        return 0
+    else:
+        issue_list = "\n".join(f"  • {i}" for i in issues)
+        console.print(Panel(
+            f"[bold red]{len(issues)} issue(s) found:[/bold red]\n{issue_list}",
+            border_style="red",
+        ))
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# main() entry point
+# ---------------------------------------------------------------------------
+
+_SUBCOMMANDS = {"init", "doctor"}
+
+
+def _build_run_parser() -> argparse.ArgumentParser:
+    """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
+        prog="manus-use",
         description="ManusUse – Advanced AI Agent Framework",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
@@ -238,20 +559,22 @@ def main() -> None:
             "  manus-use --output result.txt \"Summarise the latest AI news\"\n\n"
             "  # Interactive REPL\n"
             "  manus-use\n"
-            "  manus-use --mode multi\n"
+            "  manus-use --mode multi\n\n"
+            "  # Setup helpers\n"
+            "  manus-use init           # create ~/.manus-use/config.toml interactively\n"
+            "  manus-use doctor         # check packages, config, and API keys\n"
         ),
-    )
-
-    parser.add_argument(
-        "task",
-        nargs="?",
-        default=None,
-        help="Task to execute (omit for interactive mode)",
     )
     parser.add_argument(
         "--version",
         action="version",
         version=f"manus-use {__version__}",
+    )
+    parser.add_argument(
+        "task",
+        nargs="?",
+        default=None,
+        help="Task to execute (omit for interactive mode)",
     )
     parser.add_argument(
         "--mode",
@@ -285,8 +608,66 @@ def main() -> None:
         default=None,
         help="Path to a config.toml file (overrides default search paths)",
     )
+    return parser
 
-    args = parser.parse_args()
+
+def _build_init_parser() -> argparse.ArgumentParser:
+    """Build the `init` subcommand parser."""
+    parser = argparse.ArgumentParser(
+        prog="manus-use init",
+        description="Guided wizard to create a manus-use configuration file.",
+    )
+    parser.add_argument(
+        "--output",
+        metavar="FILE",
+        type=Path,
+        default=None,
+        help=f"Where to write config (default: {_DEFAULT_CONFIG_PATH})",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing config without prompting",
+    )
+    return parser
+
+
+def _build_doctor_parser() -> argparse.ArgumentParser:
+    """Build the `doctor` subcommand parser."""
+    parser = argparse.ArgumentParser(
+        prog="manus-use doctor",
+        description="Diagnose your manus-use installation: packages, config file, API keys.",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="FILE",
+        type=Path,
+        default=None,
+        help="Path to a config.toml file to validate (overrides default search paths)",
+    )
+    return parser
+
+
+def main() -> None:
+    """Main CLI entry point."""
+    argv = sys.argv[1:]
+
+    # Check whether the first non-flag token is a known subcommand.
+    first_positional = next((a for a in argv if not a.startswith("-")), None)
+
+    if first_positional == "init":
+        idx = argv.index("init")
+        args = _build_init_parser().parse_args(argv[idx + 1 :])
+        sys.exit(_cmd_init(args))
+
+    if first_positional == "doctor":
+        idx = argv.index("doctor")
+        args = _build_doctor_parser().parse_args(argv[idx + 1 :])
+        sys.exit(_cmd_doctor(args))
+
+    # Default: run / interactive
+    run_parser = _build_run_parser()
+    args = run_parser.parse_args(argv)
 
     config = Config.from_file(args.config)
 
@@ -303,7 +684,7 @@ def main() -> None:
         sys.exit(exit_code)
     else:
         if args.output is not None:
-            parser.error("--output requires a task argument")
+            run_parser.error("--output requires a task argument")
         _run_interactive(
             mode=args.mode,
             agent_type=args.agent_type,

--- a/tests/test_init_doctor.py
+++ b/tests/test_init_doctor.py
@@ -1,0 +1,352 @@
+"""Tests for `manus-use init` and `manus-use doctor` subcommands."""
+
+import contextlib
+import importlib
+import os
+import sys
+from unittest import mock
+
+import pytest
+import toml
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _invoke(argv: list[str], *, inputs: list[str] | None = None):
+    """Call cli.main() with patched sys.argv and optional stdin inputs.
+
+    Returns (exit_code, capsys-style stdout) via capturing sys.exit.
+    """
+    from manus_use import cli  # noqa: PLC0415
+
+    exit_code = 0
+
+    # Patch Prompt.ask / Confirm.ask so tests don't block on stdin.
+    with mock.patch.object(sys, "argv", ["manus-use"] + argv):
+        try:
+            cli.main()
+        except SystemExit as exc:
+            exit_code = exc.code if isinstance(exc.code, int) else 0
+
+    return exit_code
+
+
+# ---------------------------------------------------------------------------
+# init – argument parsing / flag tests
+# ---------------------------------------------------------------------------
+
+class TestInitCommand:
+    def test_init_writes_config(self, tmp_path):
+        """init writes a valid TOML config to the specified path."""
+        from manus_use import cli
+
+        dest = tmp_path / "config.toml"
+
+        # Simulate user choosing: provider=1 (openai), default model,
+        # no env-var found, don't store key, sandbox=yes.
+        prompt_responses = iter([
+            "1",           # provider choice (openai)
+            "gpt-4o",      # model
+            "n",           # don't store api key (Confirm)
+            "y",           # enable sandbox (Confirm)
+        ])
+        confirm_responses = iter([
+            False,  # store key? → no
+            True,   # sandbox? → yes
+        ])
+
+        with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_responses)):
+            with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_responses)):
+                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        assert dest.exists()
+        data = toml.load(dest)
+        assert data["llm"]["provider"] == "openai"
+        assert data["llm"]["model"] == "gpt-4o"
+
+    def test_init_aborts_when_no_overwrite(self, tmp_path):
+        """init exits 0 without writing when user declines overwrite."""
+        from manus_use import cli
+
+        dest = tmp_path / "config.toml"
+        dest.write_text("[llm]\nprovider = 'openai'\n")
+        original_mtime = dest.stat().st_mtime
+
+        with mock.patch("manus_use.cli.Confirm.ask", return_value=False):
+            with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest)]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 0
+        assert dest.stat().st_mtime == original_mtime  # file not touched
+
+    def test_init_force_overwrites_without_prompt(self, tmp_path):
+        """--force skips the overwrite prompt."""
+        from manus_use import cli
+
+        dest = tmp_path / "config.toml"
+        dest.write_text("[llm]\nprovider = 'openai'\n")
+
+        prompt_seq = iter(["1", "gpt-4o"])
+        confirm_seq = iter([False, True])  # no api key, yes sandbox
+
+        with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
+            with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
+                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        data = toml.load(dest)
+        assert data["llm"]["provider"] == "openai"
+
+    def test_init_anthropic_with_api_key(self, tmp_path):
+        """init stores api_key in config when user opts to."""
+        from manus_use import cli
+
+        dest = tmp_path / "config.toml"
+
+        prompt_seq = iter(["2", "claude-3-5-sonnet-20241022", "sk-secret"])
+        confirm_seq = iter([True, True])  # store key? yes; sandbox? yes
+
+        env_patch = {"ANTHROPIC_API_KEY": ""}  # not set in env
+
+        with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
+            with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
+                with mock.patch.dict(os.environ, env_patch, clear=False):
+                    with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                        with pytest.raises(SystemExit) as exc_info:
+                            cli.main()
+
+        assert exc_info.value.code == 0
+        data = toml.load(dest)
+        assert data["llm"]["provider"] == "anthropic"
+        assert data["llm"]["api_key"] == "sk-secret"
+
+    def test_init_bedrock_writes_region(self, tmp_path):
+        """init stores aws_region for the bedrock provider."""
+        from manus_use import cli
+
+        dest = tmp_path / "config.toml"
+        # provider choice 3 = bedrock; then model, region, sandbox
+        prompt_seq = iter([
+            "3",
+            "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
+            "us-west-2",
+        ])
+        confirm_seq = iter([True])  # sandbox
+
+        with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
+            with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
+                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        data = toml.load(dest)
+        assert data["llm"]["provider"] == "bedrock"
+        assert data["llm"]["aws_region"] == "us-west-2"
+
+    def test_init_creates_parent_directory(self, tmp_path):
+        """init creates missing parent directories."""
+        from manus_use import cli
+
+        dest = tmp_path / "nested" / "dir" / "config.toml"
+        assert not dest.parent.exists()
+
+        prompt_seq = iter(["4", "llama3.2", "http://localhost:11434"])
+        confirm_seq = iter([False])  # sandbox
+
+        with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
+            with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
+                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        assert dest.exists()
+
+
+# ---------------------------------------------------------------------------
+# doctor – argument parsing / logic tests
+# ---------------------------------------------------------------------------
+
+class TestDoctorCommand:
+    def _run_doctor(self, extra_argv=None, env_patch=None, import_side_effects=None):
+        """Helper: run `manus-use doctor` and return exit code."""
+        from manus_use import cli
+
+        argv = ["manus-use", "doctor"] + (extra_argv or [])
+
+        def fake_import(name):
+            if import_side_effects and name in import_side_effects:
+                raise ImportError(f"No module named '{name}'")
+            return importlib.import_module(name)
+
+        patches = [mock.patch.object(sys, "argv", argv)]
+        if env_patch is not None:
+            patches.append(mock.patch.dict(os.environ, env_patch))
+        if import_side_effects:
+            patches.append(mock.patch("manus_use.cli._check_import", side_effect=lambda p: p not in import_side_effects))
+
+        with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
+            ctx = contextlib.ExitStack()
+            for p in patches:
+                ctx.enter_context(p)
+            with ctx:
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        return exc_info.value.code if isinstance(exc_info.value.code, int) else 0
+
+    def test_doctor_exits_0_all_ok(self, tmp_path):
+        """doctor returns 0 when all core packages present and API key set."""
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[llm]\nprovider = 'openai'\nmodel = 'gpt-4o'\n")
+
+        rc = self._run_doctor(
+            extra_argv=["--config", str(config_file)],
+            env_patch={"OPENAI_API_KEY": "sk-test"},
+        )
+        assert rc == 0
+
+    def test_doctor_exits_1_missing_env_var(self, tmp_path):
+        """doctor returns 1 when required env var is absent."""
+        from manus_use import cli
+
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[llm]\nprovider = 'openai'\nmodel = 'gpt-4o'\n")
+
+        # Remove OPENAI_API_KEY from env
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(sys, "argv", ["manus-use", "doctor", "--config", str(config_file)]):
+                with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 1
+
+    def test_doctor_exits_1_missing_package(self, tmp_path):
+        """doctor returns 1 when a required package is missing."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[llm]\nprovider = 'openai'\nmodel = 'gpt-4o'\n")
+
+        # Pretend 'strands' is missing
+        rc = self._run_doctor(
+            extra_argv=["--config", str(config_file)],
+            env_patch={"OPENAI_API_KEY": "sk-test"},
+            import_side_effects={"strands"},
+        )
+        assert rc == 1
+
+    def test_doctor_anthropic_provider(self, tmp_path):
+        """doctor checks ANTHROPIC_API_KEY for anthropic provider."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text("[llm]\nprovider = 'anthropic'\nmodel = 'claude-3-5-sonnet-20241022'\n")
+
+        rc = self._run_doctor(
+            extra_argv=["--config", str(config_file)],
+            env_patch={"ANTHROPIC_API_KEY": "sk-ant-test"},
+        )
+        assert rc == 0
+
+    def test_doctor_no_config_file_warns_but_doesnt_crash(self, tmp_path):
+        """doctor with no config file still runs (exits 0 if packages+env ok)."""
+
+        # Point to non-existent path; doctor should handle gracefully
+        rc = self._run_doctor(
+            extra_argv=["--config", str(tmp_path / "nonexistent.toml")],
+            env_patch={"OPENAI_API_KEY": "sk-test"},
+        )
+        # May be 0 or 1 depending on packages, but must not raise
+        assert rc in (0, 1)
+
+    def test_doctor_api_key_in_config_counts(self, tmp_path):
+        """doctor passes even without env var when api_key is stored in config."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[llm]\nprovider = 'openai'\nmodel = 'gpt-4o'\napi_key = 'sk-config-key'\n"
+        )
+
+        env = {k: v for k, v in os.environ.items() if k != "OPENAI_API_KEY"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(sys, "argv", ["manus-use", "doctor", "--config", str(config_file)]):
+                with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
+                    with pytest.raises(SystemExit) as exc_info:
+                        from manus_use import cli as _cli
+                        _cli.main()
+
+        assert exc_info.value.code == 0
+
+    def test_doctor_bedrock_no_required_env(self, tmp_path):
+        """doctor does not require API key for bedrock provider."""
+        config_file = tmp_path / "config.toml"
+        config_file.write_text(
+            "[llm]\nprovider = 'bedrock'\nmodel = 'us.anthropic.claude-3-5-sonnet-20241022-v2:0'\n"
+        )
+
+        # Strip all AWS env vars
+        env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_")}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(sys, "argv", ["manus-use", "doctor", "--config", str(config_file)]):
+                with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
+                    with pytest.raises(SystemExit) as exc_info:
+                        from manus_use import cli as _cli
+                        _cli.main()
+
+        # Missing optional AWS env vars should not cause exit 1
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Backward-compat: existing CLI behaviour still works
+# ---------------------------------------------------------------------------
+
+class TestBackwardCompat:
+    def test_single_shot_still_works(self):
+        """Positional task argument still routes to _run_single_shot."""
+        from manus_use import cli
+
+        captured = {}
+
+        def fake_ss(task, *, mode, agent_type, show_plan, output, config):
+            captured["task"] = task
+            return 0
+
+        with mock.patch.object(sys, "argv", ["manus-use", "hello world"]):
+            with mock.patch.object(cli, "_run_single_shot", side_effect=fake_ss):
+                with mock.patch("manus_use.cli.Config") as m_cfg:
+                    m_cfg.from_file.return_value = mock.MagicMock()
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        assert captured.get("task") == "hello world"
+
+    def test_interactive_still_works(self):
+        """No positional task → routes to _run_interactive."""
+        from manus_use import cli
+
+        with mock.patch.object(sys, "argv", ["manus-use"]):
+            with mock.patch.object(cli, "_run_interactive") as m_int:
+                with mock.patch("manus_use.cli.Config") as m_cfg:
+                    m_cfg.from_file.return_value = mock.MagicMock()
+                    cli.main()
+
+        m_int.assert_called_once()
+
+    def test_version_flag_still_works(self):
+        """--version still exits 0 and doesn't need subcommand."""
+        from manus_use import cli
+
+        with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Adds two setup-helper subcommands to the CLI, completing the onboarding story started by PRs #19 and #20.

### `manus-use init`

Guided interactive wizard for first-time users:

- Prompts for **provider** (openai / anthropic / bedrock / ollama) with numbered menu
- Prompts for **model ID** (pre-filled with a sensible default per provider)
- Handles **API keys**: detects env-var presence, offers to store in config
- Handles **AWS region** (Bedrock) and **base URL** (Ollama)
- Prompts for **Docker sandbox** preference
- Writes a minimal `config.toml` — by default to `~/.manus-use/config.toml`
- `--output FILE` to choose a custom path; `--force` to overwrite without prompting
- Suggests `manus-use doctor` next

### `manus-use doctor`

Environment diagnostics:

- **Core packages**: strands-agents, rich, toml, pydantic
- **Config file**: finds and parses it, reports path or missing warning
- **Provider packages**: openai / anthropic / boto3 / ollama (based on configured provider)
- **API key / credentials**: checks env vars; recognises api_key stored in config as equivalent
- **Optional tools**: docker (+ daemon reachability), playwright, pandas
- Exits **0** when all checks pass, **1** if any issue found

## Implementation notes

Both subcommands are dispatched via pre-argv inspection, keeping the existing positional-task single-shot mode and interactive REPL **fully backward-compatible**.

## Tests

16 new tests in `tests/test_init_doctor.py` — all 40 tests pass (16 new + 24 existing).