### PR TITLE
feat(cli): add manus-use analyze <CVE-ID> subcommand

### DIFF
--- a/src/manus_use/agents/__init__.py
+++ b/src/manus_use/agents/__init__.py
@@ -1,12 +1,13 @@
 """Agent implementations for ManusUse."""
 
-from typing import Any, Optional
+from typing import Any
 
 from manus_use.agents.base import BaseManusAgent
 from manus_use.agents.browser_use_agent import BrowserUseAgent
 from manus_use.agents.data_analysis import DataAnalysisAgent
 from manus_use.agents.manus import ManusAgent
 from manus_use.agents.mcp import MCPAgent
+from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
 from manus_use.config import Config
 
 try:
@@ -25,9 +26,9 @@ class BrowserAgent(BaseManusAgent):
     def __init__(
         self,
         *,
-        config: Optional[Config] = None,
-        headless: Optional[bool] = None,
-        model: Optional[Any] = None,
+        config: Config | None = None,
+        headless: bool | None = None,
+        model: Any | None = None,
         **kwargs: Any,
     ):
         resolved_config = config or Config.from_file()
@@ -61,4 +62,5 @@ __all__ = [
     "BrowserUseAgent",
     "DataAnalysisAgent",
     "MCPAgent",
+    "VulnerabilityIntelligenceAgent",
 ]

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -1,0 +1,300 @@
+"""Vulnerability Intelligence agent.
+
+This module provides :class:`VulnerabilityIntelligenceAgent`, a Strands-based
+agent that produces a comprehensive, actionable vulnerability report for a given
+CVE identifier using free, public data sources (NVD, CISA KEV, OTX, GitHub
+advisories, Exploit-DB, PacketStorm, …) and optional Docker-based exploit
+verification.
+
+The module is written so it can be *imported* without the optional heavy
+dependencies (``strands``, ``strands_tools``, ``browser_use``) being installed:
+all such imports are deferred into :meth:`VulnerabilityIntelligenceAgent.__init__`
+and guarded with ``try/except ImportError``. Only constructing the agent
+requires those dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from manus_use.config import Config
+
+__all__ = ["VulnerabilityIntelligenceAgent", "DEFAULT_MODEL_ID"]
+
+# Sensible default used only when no model can be resolved from ``Config``.
+# Kept as a single named constant rather than scattered literals.
+DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+# Repository root (…/manus-use) — used to locate bundled skills.
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+SYSTEM_PROMPT = """
+You are an expert cybersecurity analyst specializing in vulnerability intelligence and risk assessment. Your primary function is to provide comprehensive, actionable assessments of security vulnerabilities identified by CVE IDs, using a highly efficient, free-source-first workflow.
+
+**Primary Goal:** Produce a detailed, accurate, and actionable vulnerability report using only free, public data sources.
+
+**Core Workflow: NVD and Threat Intelligence First**
+Your process is optimized to build a comprehensive picture from authoritative, free sources.
+
+---
+**General Instructions & Error Handling:**
+- **Tool Failure Fallback:** If you encounter persistent errors with a specific tool (e.g., `get_nvd_data`, `check_cisa_kev`), do not give up. Instead, use the `python_repl` tool to accomplish the same goal. For example, you can use the `requests` library within the `python_repl` to query the underlying API or fetch the raw data from the source website directly. This provides a robust fallback mechanism.
+
+---
+**Your Step-by-Step Analysis and Validation Process:**
+
+**Step 1: Foundational Data Gathering from NVD**
+- Identify the CVE from the user's request.
+- Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
+- Call `get_github_advisory` to get advisory information from GitHub.
+
+**Step 2: Check for Known Exploitation**
+- Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
+- Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
+
+**Step 3: Gather Public Exploits and Advisories**
+- First, call `get_trickest_pocs` with the CVE ID. This is a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily) — it returns known PoC links in milliseconds with no rate limits.
+- Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by trickest.
+- Merge all results, deduplicating URLs.
+
+**Step 4: Mandatory URL Verification and PoC Identification**
+- Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
+- **You must process every single URL in this list.** For each URL:
+    - **Initial Fetch:** First, attempt to fetch the content using `http_request` or `python_repl` (with the `requests` library). This is efficient for static pages and raw files.
+    - **Content Analysis:** Analyze the fetched content. If it appears to be incomplete, is a JavaScript-heavy application (e.g., you see 'Loading...' or framework-specific placeholders), or if the initial fetch fails, you must escalate to the browser agent.
+    - **Browser-Based Fetch (if needed):** For client-side rendered pages, use the `use_browser`. Give it a clear task, such as: "Navigate to this URL and extract the full, rendered text content."
+    - **Validation:** Based on the complete content, determine if the page contains any code snippets, scripts, or technical descriptions that constitute a Proof-of-Concept (PoC). If any such code is present, you must count the URL as a PoC link. The goal is to be inclusive at this stage; the deep analysis of the PoC's functionality will happen in the next step.
+    - Create a new, validated list of URLs that point to these PoCs. You will use this list in the next step. If a link is dead or irrelevant, you must note this and discard it.
+
+**Step 5: Deep PoC Analysis (for Validated Links Only)**
+- For each URL that you validated as a genuine PoC in the previous step, perform a deep analysis. Your goal is to determine if the PoC is functional and what its impact is (e.g., RCE vs. DoS).
+- **1. Contextual Analysis:**
+    - Analyze the PoC's description, README, or accompanying text for keywords that indicate its quality and purpose.
+    - **Look for indicators of a functional exploit:** "weaponized," "RCE," "remote code execution," "privilege escalation," "fully functional."
+    - **Look for indicators of a limited or non-weaponized PoC:** "DoS," "denial of service," "crash," "proof of concept only," "unstable," "for research."
+- **2. Static Code Analysis (using `python_repl`):**
+    - Fetch the raw code of the PoC.
+    - **Search for Network Indicators (for remote exploits):** Look for imports and usage of `socket`, `requests`, `urllib`, `http.client`.
+    - **Search for Command/Code Execution Indicators:** Look for `os.system`, `subprocess.run`, `exec`, `eval`, `pty.spawn`. These are strong signals of RCE.
+    - **Search for File System Indicators:** Look for `open`, `read`, `write` in the context of suspicious file paths, which could indicate path traversal or data exfiltration.
+    - **Search for Memory Corruption Indicators:** Look for `ctypes`, `struct.pack`, or variable names like `shellcode`, `buffer`, `overflow`.
+- **3. Synthesize and Classify:**
+    - Based on your analysis, classify the PoC. Is it a confirmed RCE? A DoS? A simple vulnerability checker?
+    - In your final report, create a dedicated section for this analysis, clearly stating your confidence in the PoC's functionality and impact.
+
+**Step 6: Analyze Weakness**
+- From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
+
+**Step 7: Final Threat Intelligence Check**
+- Use `query_threat_intelligence_feeds` to see if the CVE is being discussed by threat actors, which provides context beyond whether it is just "exploited".
+
+**Step 8: Final Quality Assurance and Report Generation**
+- **Data Completeness Check**: Verify all critical fields are populated.
+- **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
+- **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. Keep `technical_details` concise and focused on vulnerability mechanics, affected components, exploitation prerequisites or scenarios, impact, and detection guidance. Structure `technical_details` with these exact Markdown subsection headers where the corresponding content is present: `### Detection guidance`, `### Exploitability Analysis`, `### Expected impact`, and `### Affected conditions`. Prefix those subsection headers with `### ` exactly, and do not render those labels as plain text or bold-only labels. Avoid one large paragraph; use short paragraphs separated by blank lines, and use bullet points when listing components, prerequisites, impacts, or detection indicators. Use Markdown syntax only when needed, especially the required `### ` subsection headers and inline code for files, functions, variables, commands, CVE/CWE identifiers, or other technical names; avoid decorative formatting such as bold-only section labels. The report must include a dedicated section on Exploitability Analysis and a Sources section listing all URLs. Recommendations section must consist of concise, actionable, and purely proactive technical steps for remediation or mitigation. Each step should be a bullet point starting with an asterisk "*" and ending with a new line character "\\n", without using full sentences or terminal punctuation. Recommendations section should exclude all non-technical actions, such as policy reviews, procedural updates, or post-implementation verification and validation steps. Do not include any passive recommendations.
+"""
+
+
+class VulnerabilityIntelligenceAgent:
+    """Agent that performs vulnerability analysis via a sequential, tool-based workflow.
+
+    The agent wires together the free-source vulnerability-intelligence tools
+    bundled with ManusUse (NVD, CISA KEV, OTX, CWE, Exploit-DB, PacketStorm,
+    GitHub advisories) plus optional Docker-based exploit verification, and
+    drives them with a detailed system prompt.
+    """
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        *,
+        model: Any | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        """Build the underlying Strands agent.
+
+        Args:
+            config: ManusUse configuration. Loaded from disk when omitted.
+            model: A pre-built Strands model instance. Takes precedence over
+                ``model_name`` and over the model resolved from ``config``.
+            model_name: Explicit model id to use instead of resolving one from
+                ``config``. Falls back to :data:`DEFAULT_MODEL_ID`.
+
+        Raises:
+            ImportError: if the optional ``strands`` / ``strands_tools``
+                dependencies required to run the agent are not installed.
+        """
+        self.config = config or Config.from_file()
+        self.system_prompt = SYSTEM_PROMPT
+        self._local_chromium_browser = None
+
+        try:
+            # Heavy / optional dependencies are imported lazily so the module
+            # can be imported (and unit-tested) without them present.
+            os.environ.setdefault("BYPASS_TOOL_CONSENT", "True")
+
+            from strands import Agent
+            from strands.agent.conversation_manager import (
+                SlidingWindowConversationManager,
+            )
+            from strands_tools import current_time
+
+            from manus_use.tools.get_github_advisory import get_github_advisory
+            from manus_use.tools.get_trickest_pocs import get_trickest_pocs
+        except ImportError as exc:  # pragma: no cover - depends on env
+            raise ImportError(
+                "VulnerabilityIntelligenceAgent requires the optional 'strands' "
+                "and 'strands_tools' dependencies. Install them to run analyses."
+            ) from exc
+
+        # Best-effort browser patch + tool; never fatal if unavailable.
+        use_browser = self._resolve_use_browser()
+
+        model_obj = model if model is not None else self._resolve_model(model_name)
+
+        conversation_manager = SlidingWindowConversationManager(
+            window_size=40,
+            should_truncate_results=True,
+            per_turn=True,
+        )
+
+        tools: list[Any] = [
+            "manus_use.tools.http_request",
+            "manus_use.tools.python_repl",
+            current_time,
+            "manus_use.tools.create_lark_document",
+            "manus_use.tools.get_nvd_data",
+            get_trickest_pocs,
+            "manus_use.tools.search_for_exploits",
+            "manus_use.tools.get_cwe_details",
+            "manus_use.tools.search_exploit_db",
+            "manus_use.tools.search_packetstorm",
+            "manus_use.tools.check_cisa_kev",
+            "manus_use.tools.get_otx_cve_details",
+            "manus_use.tools.query_threat_intelligence_feeds",
+            get_github_advisory,
+            "manus_use.tools.verify_exploit",
+        ]
+        if use_browser is not None:
+            tools.append(use_browser)
+
+        agent_kwargs: dict[str, Any] = dict(
+            conversation_manager=conversation_manager,
+            model=model_obj,
+            system_prompt=self.system_prompt,
+            tools=tools,
+        )
+
+        # Attach the bundled verify-exploit skill when AgentSkills is available.
+        plugin = self._resolve_skills_plugin()
+        if plugin is not None:
+            agent_kwargs["plugins"] = [plugin]
+
+        self.agent = Agent(**agent_kwargs)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    def _resolve_use_browser(self):
+        """Return a ``use_browser`` tool, or ``None`` if unavailable."""
+        try:
+            from manus_use.tools.patches.use_browser_patch import (
+                apply_comprehensive_patch,
+            )
+
+            apply_comprehensive_patch()
+        except Exception:  # pragma: no cover - patch is best-effort
+            pass
+
+        try:
+            from strands_tools import use_browser
+
+            return use_browser
+        except Exception:
+            pass
+
+        try:  # pragma: no cover - fallback path
+            from strands_tools.browser import LocalChromiumBrowser
+
+            self._local_chromium_browser = LocalChromiumBrowser()
+            return self._local_chromium_browser.browser
+        except Exception:
+            return None
+
+    def _resolve_model(self, model_name: str | None) -> Any:
+        """Resolve a model instance from an explicit name or from config.
+
+        Avoids hardcoded model ids in the hot path: prefers ``config.get_model``
+        and only falls back to a named id when configuration cannot produce one.
+        """
+        if model_name:
+            return model_name
+
+        try:
+            return self.config.get_model()
+        except Exception:
+            # Fall back to a bare model id string; Strands accepts these.
+            return DEFAULT_MODEL_ID
+
+    def _resolve_skills_plugin(self):
+        """Return an AgentSkills plugin for the verify-exploit skill, if present."""
+        skills_dir = _REPO_ROOT / "skills" / "verify-exploit"
+        if not skills_dir.exists():
+            return None
+        try:
+            from strands import AgentSkills
+
+            return AgentSkills(skills=[str(skills_dir)])
+        except Exception:
+            return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    @staticmethod
+    def build_request(cve_id: str, *, verify: bool = False) -> str:
+        """Build the natural-language analysis request for a CVE.
+
+        Args:
+            cve_id: The CVE identifier (e.g. ``"CVE-2025-6554"``).
+            verify: When ``True``, also instruct the agent to develop and verify
+                exploit code in Docker via the ``verify-exploit`` skill.
+        """
+        if verify:
+            return (
+                f"Please perform a comprehensive vulnerability intelligence analysis "
+                f"for {cve_id}.\n"
+                "Follow your sequential process and create a Lark document with the "
+                "final report.\n"
+                "Additionally, activate the `verify-exploit` skill to develop and "
+                "verify exploit code in Docker."
+            )
+        return (
+            f"Please perform a comprehensive vulnerability intelligence analysis "
+            f"for {cve_id}.\n"
+            "Follow your sequential process and create a Lark document with the "
+            "final report.\n"
+            "Do NOT perform exploit verification."
+        )
+
+    def handle_request(self, request: str) -> str:
+        """Run the agent on a request string and return its response.
+
+        Ensures any local Chromium browser spawned for page rendering is
+        cleaned up afterwards.
+        """
+        try:
+            return self.agent(request, timeout=600)
+        finally:
+            cleanup = getattr(self._local_chromium_browser, "_cleanup", None)
+            if callable(cleanup):
+                try:
+                    cleanup()
+                except Exception as exc:  # pragma: no cover - best effort
+                    print(f"WARNING: Browser cleanup failed: {exc}")
+
+    def analyze(self, cve_id: str, *, verify: bool = False) -> str:
+        """Convenience wrapper: build the request for ``cve_id`` and run it."""
+        return self.handle_request(self.build_request(cve_id, verify=verify))

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -103,6 +103,95 @@ def _make_agent(agent_type: str, config: Config):
 # Single-shot and interactive runners
 # ---------------------------------------------------------------------------
 
+def _build_analyze_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the `analyze` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="manus-use analyze",
+        description="Run a vulnerability intelligence analysis for a CVE.",
+    )
+    parser.add_argument(
+        "cve_id",
+        metavar="CVE-ID",
+        help="CVE identifier to analyze (e.g. CVE-2025-6554)",
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="Enable Docker-based exploit verification (default: off)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json", "lark"],
+        default="text",
+        help="Report output format (default: text)",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="FILE",
+        type=Path,
+        default=None,
+        help="Path to a config.toml file (overrides default search paths)",
+    )
+    return parser
+
+
+def _run_analyze(
+    *,
+    cve_id: str,
+    verify: bool,
+    output: str,
+    config: Config,
+) -> int:
+    """Run the vulnerability intelligence analysis for a CVE and report it.
+
+    Returns an exit code (0 = success, 1 = failure).
+    """
+    try:
+        from .agents import VulnerabilityIntelligenceAgent
+    except ImportError as exc:
+        console.print(f"[red]\u2717 Vulnerability intelligence agent unavailable: {exc}[/red]")
+        return 1
+
+    console.print(f"[bold blue]Analyzing {cve_id}[/bold blue]")
+    if verify:
+        console.print("[dim]Exploit verification: ENABLED[/dim]")
+
+    try:
+        agent = VulnerabilityIntelligenceAgent(config=config)
+    except Exception as exc:
+        console.print(f"[red]\u2717 Failed to initialise agent: {exc}[/red]")
+        return 1
+
+    request = agent.build_request(cve_id, verify=verify)
+
+    try:
+        with console.status(f"Running analysis for {cve_id}\u2026", spinner="dots"):
+            result = agent.handle_request(request)
+    except Exception as exc:
+        console.print(f"[red]\u2717 Analysis failed: {exc}[/red]")
+        return 1
+
+    result_text = str(result)
+
+    if output == "json":
+        import json
+
+        console.print_json(json.dumps({"cve": cve_id, "report": result_text}))
+    elif output == "lark":
+        console.print(
+            "[dim]Report delivered to Lark (see create_lark_document output above).[/dim]"
+        )
+        console.print(
+            Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green")
+        )
+    else:
+        console.print(
+            Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green")
+        )
+
+    return 0
+
+
 def _run_single_shot(
     task: str,
     *,
@@ -542,7 +631,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor"}
+_SUBCOMMANDS = {"init", "doctor", "analyze"}
 
 
 def _build_run_parser() -> argparse.ArgumentParser:
@@ -563,6 +652,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # Setup helpers\n"
             "  manus-use init           # create ~/.manus-use/config.toml interactively\n"
             "  manus-use doctor         # check packages, config, and API keys\n"
+            "\n"
+            "  # Vulnerability intelligence analysis\n"
+            "  manus-use analyze CVE-2025-6554\n"
+            "  manus-use analyze CVE-2024-3094 --verify --output json\n"
         ),
     )
     parser.add_argument(
@@ -664,6 +757,17 @@ def main() -> None:
         idx = argv.index("doctor")
         args = _build_doctor_parser().parse_args(argv[idx + 1 :])
         sys.exit(_cmd_doctor(args))
+
+    if first_positional == "analyze":
+        idx = argv.index("analyze")
+        analyze_args = _build_analyze_parser().parse_args(argv[idx + 1 :])
+        config = Config.from_file(analyze_args.config)
+        sys.exit(_run_analyze(
+            cve_id=analyze_args.cve_id,
+            verify=analyze_args.verify,
+            output=analyze_args.output,
+            config=config,
+        ))
 
     # Default: run / interactive
     run_parser = _build_run_parser()

--- a/tests/test_vi_agent.py
+++ b/tests/test_vi_agent.py
@@ -1,0 +1,111 @@
+"""Tests for the Vulnerability Intelligence agent and the `analyze` CLI subcommand."""
+
+import sys
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import / agent class
+# ---------------------------------------------------------------------------
+
+def test_vi_agent_module_imports_without_crashing():
+    """The module must be importable even without optional deps installed."""
+    import manus_use.agents.vi_agent as vi
+
+    assert hasattr(vi, "VulnerabilityIntelligenceAgent")
+
+
+def test_vi_agent_exported_from_agents_package():
+    """VulnerabilityIntelligenceAgent is re-exported from the agents package."""
+    from manus_use.agents import VulnerabilityIntelligenceAgent  # noqa: F401
+
+
+def test_build_request_includes_cve_and_no_verify_by_default():
+    """build_request embeds the CVE id and disables verification by default."""
+    from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
+
+    request = VulnerabilityIntelligenceAgent.build_request("CVE-2025-6554")
+
+    assert "CVE-2025-6554" in request
+    assert "NOT" in request  # "Do NOT perform exploit verification."
+
+
+def test_build_request_enables_verification():
+    """build_request mentions the verify-exploit skill when verify=True."""
+    from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
+
+    request = VulnerabilityIntelligenceAgent.build_request("CVE-2024-3094", verify=True)
+
+    assert "CVE-2024-3094" in request
+    assert "verify-exploit" in request
+
+
+# ---------------------------------------------------------------------------
+# CLI `analyze` subcommand
+# ---------------------------------------------------------------------------
+
+def test_analyze_help_exits_zero():
+    """`manus-use analyze --help` prints help and exits 0."""
+    from manus_use import cli
+
+    parser = cli._build_analyze_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_analyze_missing_cve_is_error():
+    """`manus-use analyze` with no CVE produces an argparse error (exit 2)."""
+    from manus_use import cli
+
+    parser = cli._build_analyze_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+
+
+def test_analyze_registered_in_main():
+    """`manus-use analyze CVE-...` routes to _run_analyze, not the task runner."""
+    from manus_use import cli
+
+    captured = {}
+
+    def fake_run_analyze(*, cve_id, verify, output, config):
+        captured.update(cve_id=cve_id, verify=verify, output=output)
+        return 0
+
+    argv = ["manus-use", "analyze", "CVE-2025-6554", "--verify", "--output", "json"]
+    with mock.patch.object(sys, "argv", argv):
+        with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
+            with mock.patch("manus_use.cli.Config") as m_cfg:
+                m_cfg.from_file.return_value = mock.MagicMock()
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+    assert exc_info.value.code == 0
+    assert captured["cve_id"] == "CVE-2025-6554"
+    assert captured["verify"] is True
+    assert captured["output"] == "json"
+
+
+def test_run_analyze_calls_handle_request_with_cve():
+    """_run_analyze invokes handle_request with a request string containing the CVE."""
+    from manus_use import cli
+    from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
+
+    with mock.patch.object(VulnerabilityIntelligenceAgent, "__init__", return_value=None):
+        with mock.patch.object(
+            VulnerabilityIntelligenceAgent, "handle_request", return_value="REPORT"
+        ) as m_handle:
+            rc = cli._run_analyze(
+                cve_id="CVE-2025-6554",
+                verify=False,
+                output="text",
+                config=mock.MagicMock(),
+            )
+
+    assert rc == 0
+    assert m_handle.call_count == 1
+    sent = m_handle.call_args.args[0]
+    assert "CVE-2025-6554" in sent

--- a/va_agent.py
+++ b/va_agent.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
-"""
-Strands Agent that performs vulnerability analysis using a sequential, tool-based approach.
+"""Vulnerability analysis agent entry point (with optional exploit verification).
+
+The :class:`VulnerabilityIntelligenceAgent` implementation now lives in the
+importable module ``manus_use.agents.vi_agent``. This script remains a thin
+command-line entry point so existing ``python va_agent.py CVE-... [--verify]``
+workflows keep working.
 """
 
 import os
@@ -9,172 +13,17 @@ import warnings
 from pathlib import Path
 
 warnings.filterwarnings("ignore")
-os.environ["BYPASS_TOOL_CONSENT"] = "True"
+os.environ.setdefault("BYPASS_TOOL_CONSENT", "True")
 os.environ["OPENCLAW"] = os.environ.get("OPENCLAW", "false")
 
-
-# Add the src directory to Python path
+# Add the src directory to Python path for in-tree execution.
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
-
-apply_comprehensive_patch()
-
-# Import Strands SDK and required tools
-from strands import Agent, AgentSkills
-from strands_tools import current_time
-
-from manus_use.tools.get_github_advisory import get_github_advisory
-from manus_use.tools.get_trickest_pocs import get_trickest_pocs
-
-_local_chromium_browser = None
-try:
-    from strands_tools import use_browser
-except Exception:
-    from strands_tools.browser import LocalChromiumBrowser
-
-    _local_chromium_browser = LocalChromiumBrowser()
-    use_browser = _local_chromium_browser.browser
+from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent  # noqa: E402
 
 
-class VulnerabilityIntelligenceAgent:
-    """Agent that performs vulnerability analysis using a sequential, tool-based approach."""
-
-    def __init__(self, model_name: str, config: dict):
-        """Initialize the agent."""
-        self.system_prompt = """
-        You are an expert cybersecurity analyst specializing in vulnerability intelligence and risk assessment. Your primary function is to provide comprehensive, actionable assessments of security vulnerabilities identified by CVE IDs, using a highly efficient, free-source-first workflow.
-
-        **Primary Goal:** Produce a detailed, accurate, and actionable vulnerability report using only free, public data sources.
-
-        **Core Workflow: NVD and Threat Intelligence First**
-        Your process is optimized to build a comprehensive picture from authoritative, free sources.
-
-        ---
-        **General Instructions & Error Handling:**
-        - **Tool Failure Fallback:** If you encounter persistent errors with a specific tool (e.g., `get_nvd_data`, `check_cisa_kev`), do not give up. Instead, use the `python_repl` tool to accomplish the same goal. For example, you can use the `requests` library within the `python_repl` to query the underlying API or fetch the raw data from the source website directly. This provides a robust fallback mechanism.
-
-        ---
-        **Your Step-by-Step Analysis and Validation Process:**
-
-        **Step 1: Foundational Data Gathering from NVD**
-        - Identify the CVE from the user's request.
-        - Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
-        - Call `get_github_advisory` to get advisory information from GitHub.
-
-        **Step 2: Check for Known Exploitation**
-        - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
-        - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
-
-        **Step 3: Gather Public Exploits and Advisories**
-        - First, call `get_trickest_pocs` with the CVE ID. This is a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily) — it returns known PoC links in milliseconds with no rate limits.
-        - Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by trickest.
-        - Merge all results, deduplicating URLs.
-
-        **Step 4: Mandatory URL Verification and PoC Identification**
-        - Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
-        - **You must process every single URL in this list.** For each URL:
-            - **Initial Fetch:** First, attempt to fetch the content using `http_request` or `python_repl` (with the `requests` library). This is efficient for static pages and raw files.
-            - **Content Analysis:** Analyze the fetched content. If it appears to be incomplete, is a JavaScript-heavy application (e.g., you see 'Loading...' or framework-specific placeholders), or if the initial fetch fails, you must escalate to the browser agent.
-            - **Browser-Based Fetch (if needed):** For client-side rendered pages, use the `use_browser`. Give it a clear task, such as: "Navigate to this URL and extract the full, rendered text content."
-            - **Validation:** Based on the complete content, determine if the page contains any code snippets, scripts, or technical descriptions that constitute a Proof-of-Concept (PoC). If any such code is present, you must count the URL as a PoC link. The goal is to be inclusive at this stage; the deep analysis of the PoC's functionality will happen in the next step.
-            - Create a new, validated list of URLs that point to these PoCs. You will use this list in the next step. If a link is dead or irrelevant, you must note this and discard it.
-
-        **Step 5: Deep PoC Analysis (for Validated Links Only)**
-        - For each URL that you validated as a genuine PoC in the previous step, perform a deep analysis. Your goal is to determine if the PoC is functional and what its impact is (e.g., RCE vs. DoS).
-        - **1. Contextual Analysis:**
-            - Analyze the PoC's description, README, or accompanying text for keywords that indicate its quality and purpose.
-            - **Look for indicators of a functional exploit:** "weaponized," "RCE," "remote code execution," "privilege escalation," "fully functional."
-            - **Look for indicators of a limited or non-weaponized PoC:** "DoS," "denial of service," "crash," "proof of concept only," "unstable," "for research."
-        - **2. Static Code Analysis (using `python_repl`):**
-            - Fetch the raw code of the PoC.
-            - **Search for Network Indicators (for remote exploits):** Look for imports and usage of `socket`, `requests`, `urllib`, `http.client`.
-            - **Search for Command/Code Execution Indicators:** Look for `os.system`, `subprocess.run`, `exec`, `eval`, `pty.spawn`. These are strong signals of RCE.
-            - **Search for File System Indicators:** Look for `open`, `read`, `write` in the context of suspicious file paths, which could indicate path traversal or data exfiltration.
-            - **Search for Memory Corruption Indicators:** Look for `ctypes`, `struct.pack`, or variable names like `shellcode`, `buffer`, `overflow`.
-        - **3. Synthesize and Classify:**
-            - Based on your analysis, classify the PoC. Is it a confirmed RCE? A DoS? A simple vulnerability checker?
-            - In your final report, create a dedicated section for this analysis, clearly stating your confidence in the PoC's functionality and impact.
-
-        **Step 6: Analyze Weakness**
-        - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
-
-        **Step 7: Final Threat Intelligence Check**
-        - Use `query_threat_intelligence_feeds` to see if the CVE is being discussed by threat actors, which provides context beyond whether it is just "exploited".
-
-        **Step 8: Final Quality Assurance and Report Generation**
-        - **Data Completeness Check**: Verify all critical fields are populated.
-        - **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
-        - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. Keep `technical_details` concise and focused on vulnerability mechanics, affected components, exploitation prerequisites or scenarios, impact, and detection guidance. Structure `technical_details` with these exact Markdown subsection headers where the corresponding content is present: `### Detection guidance`, `### Exploitability Analysis`, `### Expected impact`, and `### Affected conditions`. Prefix those subsection headers with `### ` exactly, and do not render those labels as plain text or bold-only labels. Avoid one large paragraph; use short paragraphs separated by blank lines, and use bullet points when listing components, prerequisites, impacts, or detection indicators. Use Markdown syntax only when needed, especially the required `### ` subsection headers and inline code for files, functions, variables, commands, CVE/CWE identifiers, or other technical names; avoid decorative formatting such as bold-only section labels. The report must include a dedicated section on Exploitability Analysis and a Sources section listing all URLs. Recommendations section must consist of concise, actionable, and purely proactive technical steps for remediation or mitigation. Each step should be a bullet point starting with an asterisk "*" and ending with a new line character "\n", without using full sentences or terminal punctuation. Recommendations section should exclude all non-technical actions, such as policy reviews, procedural updates, or post-implementation verification and validation steps. Do not include any passive recommendations.
-        """
-        from strands.agent.conversation_manager import SlidingWindowConversationManager
-        from strands.models import BedrockModel
-        from strands.models.openai import OpenAIModel
-
-        conversation_manager = SlidingWindowConversationManager(
-            window_size=40,  # Maximum number of messages to keep
-            should_truncate_results=True,  # Enable truncating tool results if needed
-            per_turn=True,  # Proactively manage context before every model call
-        )
-        bedrock = BedrockModel(
-            model_id=model_name,
-            region_name="us-west-2",
-            max_tokens=65536,  # keep safely under model limit
-        )
-        openai_model = OpenAIModel(
-            client_args={
-                "api_key": config['llm']['api_key'],
-                "base_url": config['llm']['base_url'],
-            },
-            model_id=config['llm']['model'], max_tokens=config['llm']['max_tokens'],  # use whatever model name your endpoint expects
-        )
-        skills_dir = str(Path(__file__).parent / "skills" / "verify-exploit")
-        plugin = AgentSkills(skills=[skills_dir])
-
-        self.agent = Agent(
-            conversation_manager=conversation_manager,
-            model=openai_model,
-            #model=bedrock,
-            plugins=[plugin],
-            system_prompt=self.system_prompt,
-            tools=[
-                "manus_use.tools.http_request",
-                "manus_use.tools.python_repl",
-                current_time,
-                "manus_use.tools.create_lark_document",
-                "manus_use.tools.get_nvd_data",
-                get_trickest_pocs,
-                "manus_use.tools.search_for_exploits",
-                "manus_use.tools.get_cwe_details",
-                "manus_use.tools.search_exploit_db",
-                "manus_use.tools.search_packetstorm",
-                "manus_use.tools.check_cisa_kev",
-                "manus_use.tools.get_otx_cve_details",
-                "manus_use.tools.query_threat_intelligence_feeds",
-                get_github_advisory,
-                "manus_use.tools.verify_exploit",
-                use_browser,
-            ],
-        )
-
-    def handle_request(self, request: str) -> str:
-        """Handles a user request by invoking the agent."""
-        print("INFO: Agent received request. It will now execute the analysis sequentially...")
-        try:
-            response = self.agent(request, timeout=600)
-            return response
-        finally:
-            if _local_chromium_browser is not None:
-                cleanup = getattr(_local_chromium_browser, "_cleanup", None)
-                if callable(cleanup):
-                    try:
-                        cleanup()
-                    except Exception as exc:
-                        print(f"WARNING: Browser cleanup failed: {exc}")
-
-# --- Main Execution Block ---
-def main():
-    """Example of using the simplified VulnerabilityIntelligenceAgent.
+def main() -> None:
+    """Run a vulnerability intelligence analysis from the command line.
 
     Usage:
       python va_agent.py CVE-2024-3094            # analysis only
@@ -182,43 +31,28 @@ def main():
     """
     print("=== Vulnerability Intelligence Assessment Agent ===")
 
-    args = sys.argv[1:]
-    verify = "--verify" in args
-    args = [a for a in args if a != "--verify"]
+    args = [a for a in sys.argv[1:] if a != "--verify"]
+    verify = "--verify" in sys.argv[1:]
 
-    # Simplified and robust configuration handling
-    try:
-        from manus_use.config import Config
-        config = Config.from_file()
-        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    except Exception:
-        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-
-    # Create the agent
-    config_dict = config.model_dump()
-    vi_agent = VulnerabilityIntelligenceAgent(model_name=model_name, config=config_dict)
-
-    # Get CVE from command-line arguments or use an example for demonstration
     cve_id = args[0] if args else "CVE-2025-6554"
     if not args:
         print(f"No CVE provided. Using example: {cve_id}")
 
+    try:
+        from manus_use.config import Config
+
+        config = Config.from_file()
+    except Exception as exc:
+        print(f"Could not load config ({exc}); using defaults.")
+        config = None
+
+    agent = VulnerabilityIntelligenceAgent(config=config)
+
     if verify:
         print("Exploit verification: ENABLED")
-        analysis_request = f"""
-    Please perform a comprehensive vulnerability intelligence analysis for {cve_id}.
-    Follow your sequential process and create a Lark document with the final report.
-    Additionally, activate the `verify-exploit` skill to develop and verify exploit code in Docker.
-    """
-    else:
-        analysis_request = f"""
-    Please perform a comprehensive vulnerability intelligence analysis for {cve_id}.
-    Follow your sequential process and create a Lark document with the final report.
-    Do NOT perform exploit verification.
-    """
 
     print(f"\n--- Sending analysis request to agent for: {cve_id} ---")
-    result = vi_agent.handle_request(analysis_request)
+    result = agent.analyze(cve_id, verify=verify)
     print("\n--- Final Response from Agent ---")
     print(result)
 

--- a/vi_agent.py
+++ b/vi_agent.py
@@ -1,171 +1,46 @@
 #!/usr/bin/env python3
-"""
-Strands Agent that performs vulnerability analysis using a sequential, tool-based approach.
+"""Vulnerability Intelligence agent entry point.
+
+The :class:`VulnerabilityIntelligenceAgent` implementation now lives in the
+importable module ``manus_use.agents.vi_agent``. This script remains a thin
+command-line entry point so existing ``python vi_agent.py CVE-...`` workflows
+keep working.
 """
 
 import os
 import sys
-from pathlib import Path
 import warnings
+from pathlib import Path
+
 warnings.filterwarnings("ignore")
-os.environ["BYPASS_TOOL_CONSENT"] = "True"
+os.environ.setdefault("BYPASS_TOOL_CONSENT", "True")
 
-
-# Add the src directory to Python path
+# Add the src directory to Python path for in-tree execution.
 sys.path.insert(0, str(Path(__file__).parent / "src"))
 
-# Patch use_browser for better error handling (must be before importing use_browser)
-from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
+from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent  # noqa: E402
 
-apply_comprehensive_patch()
 
-# Import Strands SDK and required tools
-from strands import Agent
-from strands_tools import current_time, use_browser
-from manus_use.tools.python_repl import python_repl
-from manus_use.tools.http_request import http_request
-# Import specific tool functions directly
-import manus_use.tools.get_nvd_data as get_nvd_data
-import manus_use.tools.search_for_exploits as search_for_exploits
-import manus_use.tools.get_cwe_details as get_cwe_details
-import manus_use.tools.search_exploit_db as search_exploit_db
-import manus_use.tools.search_packetstorm as search_packetstorm
-import manus_use.tools.create_lark_document as create_lark_document
-import manus_use.tools.query_threat_intelligence_feeds as query_threat_intelligence_feeds
-import manus_use.tools.get_github_advisory as get_github_advisory
-import manus_use.tools.check_cisa_kev as check_cisa_kev
-import manus_use.tools.get_otx_cve_details as get_otx_cve_details
-#import manus_use.tools.browser_agent_tool as browser_agent_tool
+def main() -> None:
+    """Run a vulnerability intelligence analysis from the command line."""
+    print("=== Vulnerability Intelligence Agent ===")
 
-class VulnerabilityIntelligenceAgent:
-    """Agent that performs vulnerability analysis using a sequential, tool-based approach."""
-
-    def __init__(self, model_name: str):
-        """Initialize the agent."""
-        self.system_prompt = """
-        You are an expert cybersecurity analyst specializing in vulnerability intelligence and risk assessment. Your primary function is to provide comprehensive, actionable assessments of security vulnerabilities identified by CVE IDs, using a highly efficient, free-source-first workflow.
-
-        **Primary Goal:** Produce a detailed, accurate, and actionable vulnerability report using only free, public data sources.
-
-        **Core Workflow: NVD and Threat Intelligence First**
-        Your process is optimized to build a comprehensive picture from authoritative, free sources.
-
-        ---
-        **General Instructions & Error Handling:**
-        - **Tool Failure Fallback:** If you encounter persistent errors with a specific tool (e.g., `get_nvd_data`, `check_cisa_kev`), do not give up. Instead, use the `python_repl` tool to accomplish the same goal. For example, you can use the `requests` library within the `python_repl` to query the underlying API or fetch the raw data from the source website directly. This provides a robust fallback mechanism.
-
-        ---
-        **Your Step-by-Step Analysis and Validation Process:**
-
-        **Step 1: Foundational Data Gathering from NVD**
-        - Identify the CVE from the user's request.
-        - Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
-        - Call `get_github_advisory` to get advisory information from GitHub.
-
-        **Step 2: Check for Known Exploitation**
-        - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
-        - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
-
-        **Step 3: Gather Public Exploits and Advisories**
-        - Call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find public proof-of-concept (PoC) exploits.
-
-        **Step 4: Mandatory URL Verification and PoC Identification**
-        - Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
-        - **You must process every single URL in this list.** For each URL:
-            - **Initial Fetch:** First, attempt to fetch the content using `http_request` or `python_repl` (with the `requests` library). This is efficient for static pages and raw files.
-            - **Content Analysis:** Analyze the fetched content. If it appears to be incomplete, is a JavaScript-heavy application (e.g., you see 'Loading...' or framework-specific placeholders), or if the initial fetch fails, you must escalate to the browser agent.
-            - **Browser-Based Fetch (if needed):** For client-side rendered pages, use the `use_browser`. Give it a clear task, such as: "Navigate to this URL and extract the full, rendered text content."
-            - **Validation:** Based on the complete content, determine if the page contains any code snippets, scripts, or technical descriptions that constitute a Proof-of-Concept (PoC). If any such code is present, you must count the URL as a PoC link. The goal is to be inclusive at this stage; the deep analysis of the PoC's functionality will happen in the next step.
-            - Create a new, validated list of URLs that point to these PoCs. You will use this list in the next step. If a link is dead or irrelevant, you must note this and discard it.
-
-        **Step 5: Deep PoC Analysis (for Validated Links Only)**
-        - For each URL that you validated as a genuine PoC in the previous step, perform a deep analysis. Your goal is to determine if the PoC is functional and what its impact is (e.g., RCE vs. DoS).
-        - **1. Contextual Analysis:**
-            - Analyze the PoC's description, README, or accompanying text for keywords that indicate its quality and purpose.
-            - **Look for indicators of a functional exploit:** "weaponized," "RCE," "remote code execution," "privilege escalation," "fully functional."
-            - **Look for indicators of a limited or non-weaponized PoC:** "DoS," "denial of service," "crash," "proof of concept only," "unstable," "for research."
-        - **2. Static Code Analysis (using `python_repl`):**
-            - Fetch the raw code of the PoC.
-            - **Search for Network Indicators (for remote exploits):** Look for imports and usage of `socket`, `requests`, `urllib`, `http.client`.
-            - **Search for Command/Code Execution Indicators:** Look for `os.system`, `subprocess.run`, `exec`, `eval`, `pty.spawn`. These are strong signals of RCE.
-            - **Search for File System Indicators:** Look for `open`, `read`, `write` in the context of suspicious file paths, which could indicate path traversal or data exfiltration.
-            - **Search for Memory Corruption Indicators:** Look for `ctypes`, `struct.pack`, or variable names like `shellcode`, `buffer`, `overflow`.
-        - **3. Synthesize and Classify:**
-            - Based on your analysis, classify the PoC. Is it a confirmed RCE? A DoS? A simple vulnerability checker?
-            - In your final report, create a dedicated section for this analysis, clearly stating your confidence in the PoC's functionality and impact.
-
-        **Step 6: Analyze Weakness**
-        - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
-
-        **Step 7: Final Threat Intelligence Check**
-        - Use `query_threat_intelligence_feeds` to see if the CVE is being discussed by threat actors, which provides context beyond whether it is just "exploited".
-
-        **Step 8: Final Quality Assurance and Report Generation**
-        - **Data Completeness Check**: Verify all critical fields are populated.
-        - **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
-        - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. The report must include a dedicated section on the **Exploitability Analysis** and a **Sources** section listing all URLs.
-        """
-        self.agent = Agent(
-            model=model_name,
-            system_prompt=self.system_prompt,
-            tools=[
-                http_request,
-                python_repl,
-                current_time,
-                create_lark_document,
-                get_nvd_data,
-                search_for_exploits,
-                get_cwe_details,
-                search_exploit_db,
-                search_packetstorm,
-                check_cisa_kev,
-                get_otx_cve_details,
-                query_threat_intelligence_feeds,
-                get_github_advisory,
-                use_browser,
-            ]
-        )
-
-    def handle_request(self, request: str) -> str:
-        """Handles a user request by invoking the agent."""
-        print("INFO: Agent received request. It will now execute the analysis sequentially...")
-        response = self.agent(request)
-        return response
-
-# --- Main Execution Block ---
-def main():
-    """Example of using the simplified VulnerabilityIntelligenceAgent."""
-    print("=== Simplified Vulnerability Intelligence Agent ===")
-
-    # Simplified and robust configuration handling
-    try:
-        from manus_use.config import Config
-        config = Config.from_file()
-        # Use a specific, powerful model suitable for orchestration
-        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-        print(f"Using configured model: {model_name}")
-    except Exception as e:
-        model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"  # A sensible default
-        print(f"Could not load config ({e}), using default model: {model_name}")
-
-    # Create the agent
-    vi_agent = VulnerabilityIntelligenceAgent(model_name=model_name)
-
-    # Get CVE from command-line arguments or use an example for demonstration
-    if len(sys.argv) > 1:
-        cve_id = sys.argv[1]
-    else:
-        cve_id = "CVE-2025-6554"
+    cve_id = sys.argv[1] if len(sys.argv) > 1 else "CVE-2025-6554"
+    if len(sys.argv) <= 1:
         print(f"No CVE provided. Using example: {cve_id}")
 
-    # The request is a high-level instruction to the agent.
-    analysis_request = f"""
-    Please perform a comprehensive vulnerability intelligence analysis for {cve_id}.
-    Follow your sequential process and create a Lark document with the final report.
-    """
+    try:
+        from manus_use.config import Config
+
+        config = Config.from_file()
+    except Exception as exc:
+        print(f"Could not load config ({exc}); using defaults.")
+        config = None
+
+    agent = VulnerabilityIntelligenceAgent(config=config)
 
     print(f"\n--- Sending analysis request to agent for: {cve_id} ---")
-    result = vi_agent.handle_request(analysis_request)
+    result = agent.analyze(cve_id)
     print("\n--- Final Response from Agent ---")
     print(result)
 


### PR DESCRIPTION
## What & Why

The vulnerability intelligence system (`vi_agent.py`, `va_agent.py`) is a sophisticated 8-step CVE analysis pipeline but was completely inaccessible — loose root-level scripts with no CLI integration. This PR makes it a first-class `manus-use` command.

## Changes

- **`src/manus_use/agents/vi_agent.py`** — new importable `VulnerabilityIntelligenceAgent` class refactored from `va_agent.py`; lazy optional-dep imports (strands, browser, tools all guarded with `try/except ImportError`); model resolved via `Config.get_model()` with a `DEFAULT_MODEL_ID` fallback constant; no hardcoded model IDs in hot path
- **`src/manus_use/agents/__init__.py`** — re-exports `VulnerabilityIntelligenceAgent`
- **`src/manus_use/cli.py`** — adds `manus-use analyze <CVE-ID>` subcommand with `--verify` (Docker exploit sandbox), `--output {text,json,lark}`, and `--config`; existing commands unchanged
- **`vi_agent.py` / `va_agent.py`** (root) — slimmed to thin entry points importing from the new module
- **`tests/test_vi_agent.py`** — 8 new tests

## Usage

```bash
manus-use analyze CVE-2025-6554
manus-use analyze CVE-2024-3094 --verify
manus-use analyze CVE-2025-6554 --output json
manus-use analyze CVE-2025-6554 --output lark
```

## Tests

8 new tests in `tests/test_vi_agent.py`:
- Import safety (no crash without optional deps)
- Package-level export check
- `build_request()` with verify on/off
- CLI `analyze --help` exits 0
- Missing CVE argument exits 2 with error
- `main()` routing
- Mock-based `handle_request()` call verification

All 8 pass. Pre-existing `test_tools.py::*openclaw*` failures are unrelated (confirmed on base branch).