### PR TITLE
feat(tools): add get_trickest_pocs for fast PoC pre-flight lookup

### DIFF
--- a/src/manus_use/tools/get_trickest_pocs.py
+++ b/src/manus_use/tools/get_trickest_pocs.py
@@ -1,0 +1,165 @@
+"""
+Tool: get_trickest_pocs
+
+Fetches known PoC links for a CVE from the trickest/cve repository
+(https://github.com/trickest/cve), a continuously auto-updated index of
+250k+ CVEs with PoC links sourced from CVE references, GitHub search, and
+HackerOne reports.
+
+This is a fast pre-flight PoC lookup — returns results in milliseconds with
+no rate limits, complementing the slower ExploitDB/Packetstorm/GitHub-search tools.
+"""
+
+from __future__ import annotations
+
+import re
+
+from strands import tool
+
+__all__ = ["get_trickest_pocs"]
+
+_RAW_URL = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+_CVE_YEAR_RE = re.compile(r"CVE-(\d{4})-\d+", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://\S+")
+
+
+def _parse_pocs(markdown: str) -> dict:
+    """Parse the trickest markdown file into structured PoC data."""
+    result = {
+        "description": "",
+        "reference_pocs": [],
+        "github_pocs": [],
+        "all_pocs": [],
+    }
+
+    lines = markdown.splitlines()
+    section = None
+    subsection = None
+    desc_lines = []
+    in_description = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("### Description"):
+            in_description = True
+            section = "description"
+            continue
+        elif stripped.startswith("### POC"):
+            in_description = False
+            section = "poc"
+            continue
+        elif stripped.startswith("#### Reference") and section == "poc":
+            subsection = "reference"
+            continue
+        elif stripped.startswith("#### Github") and section == "poc":
+            subsection = "github"
+            continue
+        elif stripped.startswith("###"):
+            in_description = False
+            section = None
+            subsection = None
+            continue
+
+        if section == "description" and in_description and stripped:
+            desc_lines.append(stripped)
+
+        if section == "poc":
+            urls = _URL_RE.findall(stripped)
+            for url in urls:
+                url = url.rstrip(")")
+                if subsection == "reference":
+                    result["reference_pocs"].append(url)
+                elif subsection == "github":
+                    result["github_pocs"].append(url)
+                result["all_pocs"].append(url)
+
+    result["description"] = " ".join(desc_lines)
+    # Deduplicate while preserving order
+    seen: set = set()
+    deduped = []
+    for url in result["all_pocs"]:
+        if url not in seen:
+            seen.add(url)
+            deduped.append(url)
+    result["all_pocs"] = deduped
+
+    return result
+
+
+@tool
+def get_trickest_pocs(cve_id: str) -> str:
+    """Fetch known PoC links for a CVE from the trickest/cve repository.
+
+    trickest/cve is a continuously auto-updated index of 250k+ CVEs with PoC
+    links sourced from CVE references, GitHub search, and HackerOne reports.
+    This is a fast, rate-limit-free alternative/complement to ExploitDB and
+    Packetstorm searches.
+
+    Args:
+        cve_id: CVE identifier, e.g. "CVE-2025-6554" or "cve-2024-3094".
+
+    Returns:
+        A formatted string with the CVE description and all known PoC URLs,
+        or a message indicating no entry was found.
+    """
+    import urllib.error
+    import urllib.request
+
+    cve_id = cve_id.strip().upper()
+
+    match = _CVE_YEAR_RE.match(cve_id)
+    if not match:
+        return f"Invalid CVE ID format: {cve_id!r}. Expected format: CVE-YYYY-NNNNN"
+
+    year = match.group(1)
+    url = _RAW_URL.format(year=year, cve_id=cve_id)
+
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={"User-Agent": "manus-use/trickest-cve-tool"},
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            markdown = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return (
+                f"No trickest/cve entry found for {cve_id}. "
+                "The CVE may be too new or not yet indexed."
+            )
+        return f"HTTP error fetching trickest/cve data for {cve_id}: {exc.code} {exc.reason}"
+    except Exception as exc:  # noqa: BLE001
+        return f"Error fetching trickest/cve data for {cve_id}: {exc}"
+
+    data = _parse_pocs(markdown)
+
+    if not data["all_pocs"]:
+        return (
+            f"trickest/cve entry found for {cve_id}, but no PoC links listed.\n\n"
+            f"Description: {data['description'] or 'N/A'}\n\n"
+            f"Source: {url}"
+        )
+
+    lines = [
+        f"## trickest/cve PoC Report: {cve_id}",
+        f"Source: {url}",
+        "",
+    ]
+
+    if data["description"]:
+        lines += [f"**Description:** {data['description']}", ""]
+
+    lines.append(f"**Total PoC links found:** {len(data['all_pocs'])}")
+
+    if data["reference_pocs"]:
+        lines += ["", f"### Reference PoCs ({len(data['reference_pocs'])})"]
+        for poc in data["reference_pocs"]:
+            lines.append(f"- {poc}")
+
+    if data["github_pocs"]:
+        lines += ["", f"### GitHub PoCs ({len(data['github_pocs'])})"]
+        for poc in data["github_pocs"]:
+            lines.append(f"- {poc}")
+
+    return "\n".join(lines)

--- a/tests/test_trickest_pocs.py
+++ b/tests/test_trickest_pocs.py
@@ -1,0 +1,135 @@
+"""Tests for get_trickest_pocs tool."""
+
+from __future__ import annotations
+
+import urllib.error
+from unittest.mock import MagicMock, patch
+
+from manus_use.tools.get_trickest_pocs import _parse_pocs, get_trickest_pocs
+
+# --- Unit tests for _parse_pocs ---
+
+SAMPLE_MARKDOWN = """### [CVE-2025-6554](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2025-6554)
+
+### Description
+
+Type confusion in V8 in Google Chrome prior to 138.0.7204.96.
+
+### POC
+
+#### Reference
+- https://chromereleases.googleblog.com/2025/06/example
+
+#### Github
+- https://github.com/example/CVE-2025-6554
+- https://github.com/another/exploit-poc
+"""
+
+NO_POC_MARKDOWN = """### [CVE-2024-0001](https://cve.mitre.org)
+
+### Description
+
+Some vulnerability with no public PoCs.
+
+### POC
+
+#### Reference
+No PoCs from references.
+
+#### Github
+No PoCs from Github.
+"""
+
+
+def test_parse_pocs_extracts_description():
+    data = _parse_pocs(SAMPLE_MARKDOWN)
+    assert "Type confusion" in data["description"]
+
+
+def test_parse_pocs_extracts_reference_pocs():
+    data = _parse_pocs(SAMPLE_MARKDOWN)
+    assert len(data["reference_pocs"]) == 1
+    assert "chromereleases" in data["reference_pocs"][0]
+
+
+def test_parse_pocs_extracts_github_pocs():
+    data = _parse_pocs(SAMPLE_MARKDOWN)
+    assert len(data["github_pocs"]) == 2
+    assert any("CVE-2025-6554" in u for u in data["github_pocs"])
+
+
+def test_parse_pocs_all_pocs_deduped():
+    data = _parse_pocs(SAMPLE_MARKDOWN)
+    assert len(data["all_pocs"]) == len(set(data["all_pocs"]))
+    assert len(data["all_pocs"]) == 3
+
+
+def test_parse_pocs_no_pocs():
+    data = _parse_pocs(NO_POC_MARKDOWN)
+    assert data["all_pocs"] == []
+    assert data["reference_pocs"] == []
+    assert data["github_pocs"] == []
+
+
+# --- Integration-style tests for get_trickest_pocs (mocked HTTP) ---
+
+def _make_mock_response(content: str):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = content.encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+def test_invalid_cve_format():
+    result = get_trickest_pocs("NOT-A-CVE")
+    assert "Invalid CVE ID format" in result
+
+
+def test_valid_cve_returns_pocs():
+    with patch("urllib.request.urlopen", return_value=_make_mock_response(SAMPLE_MARKDOWN)):
+        result = get_trickest_pocs("CVE-2025-6554")
+    assert "trickest/cve PoC Report" in result
+    assert "CVE-2025-6554" in result
+    assert "github.com/example" in result
+
+
+def test_valid_cve_case_insensitive():
+    with patch("urllib.request.urlopen", return_value=_make_mock_response(SAMPLE_MARKDOWN)):
+        result = get_trickest_pocs("cve-2025-6554")
+    assert "CVE-2025-6554" in result
+
+
+def test_404_returns_not_found_message():
+    http_error = urllib.error.HTTPError(url="", code=404, msg="Not Found", hdrs=None, fp=None)
+    with patch("urllib.request.urlopen", side_effect=http_error):
+        result = get_trickest_pocs("CVE-2099-9999")
+    assert "No trickest/cve entry found" in result
+
+
+def test_http_error_non_404():
+    http_error = urllib.error.HTTPError(url="", code=500, msg="Server Error", hdrs=None, fp=None)
+    with patch("urllib.request.urlopen", side_effect=http_error):
+        result = get_trickest_pocs("CVE-2025-1234")
+    assert "HTTP error" in result
+    assert "500" in result
+
+
+def test_no_pocs_found_message():
+    with patch("urllib.request.urlopen", return_value=_make_mock_response(NO_POC_MARKDOWN)):
+        result = get_trickest_pocs("CVE-2024-0001")
+    assert "no PoC links listed" in result
+
+
+def test_url_constructed_with_correct_year():
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _make_mock_response(SAMPLE_MARKDOWN)
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        get_trickest_pocs("CVE-2023-44487")
+
+    assert "2023" in captured["url"]
+    assert "CVE-2023-44487" in captured["url"]

--- a/va_agent.py
+++ b/va_agent.py
@@ -5,8 +5,9 @@ Strands Agent that performs vulnerability analysis using a sequential, tool-base
 
 import os
 import sys
-from pathlib import Path
 import warnings
+from pathlib import Path
+
 warnings.filterwarnings("ignore")
 os.environ["BYPASS_TOOL_CONSENT"] = "True"
 os.environ["OPENCLAW"] = os.environ.get("OPENCLAW", "false")
@@ -22,7 +23,9 @@ apply_comprehensive_patch()
 # Import Strands SDK and required tools
 from strands import Agent, AgentSkills
 from strands_tools import current_time
+
 from manus_use.tools.get_github_advisory import get_github_advisory
+from manus_use.tools.get_trickest_pocs import get_trickest_pocs
 
 _local_chromium_browser = None
 try:
@@ -64,7 +67,9 @@ class VulnerabilityIntelligenceAgent:
         - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
 
         **Step 3: Gather Public Exploits and Advisories**
-        - Call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find public proof-of-concept (PoC) exploits.
+        - First, call `get_trickest_pocs` with the CVE ID. This is a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily) — it returns known PoC links in milliseconds with no rate limits.
+        - Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by trickest.
+        - Merge all results, deduplicating URLs.
 
         **Step 4: Mandatory URL Verification and PoC Identification**
         - Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
@@ -102,9 +107,9 @@ class VulnerabilityIntelligenceAgent:
         - **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
         - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. Keep `technical_details` concise and focused on vulnerability mechanics, affected components, exploitation prerequisites or scenarios, impact, and detection guidance. Structure `technical_details` with these exact Markdown subsection headers where the corresponding content is present: `### Detection guidance`, `### Exploitability Analysis`, `### Expected impact`, and `### Affected conditions`. Prefix those subsection headers with `### ` exactly, and do not render those labels as plain text or bold-only labels. Avoid one large paragraph; use short paragraphs separated by blank lines, and use bullet points when listing components, prerequisites, impacts, or detection indicators. Use Markdown syntax only when needed, especially the required `### ` subsection headers and inline code for files, functions, variables, commands, CVE/CWE identifiers, or other technical names; avoid decorative formatting such as bold-only section labels. The report must include a dedicated section on Exploitability Analysis and a Sources section listing all URLs. Recommendations section must consist of concise, actionable, and purely proactive technical steps for remediation or mitigation. Each step should be a bullet point starting with an asterisk "*" and ending with a new line character "\n", without using full sentences or terminal punctuation. Recommendations section should exclude all non-technical actions, such as policy reviews, procedural updates, or post-implementation verification and validation steps. Do not include any passive recommendations.
         """
+        from strands.agent.conversation_manager import SlidingWindowConversationManager
         from strands.models import BedrockModel
         from strands.models.openai import OpenAIModel
-        from strands.agent.conversation_manager import SlidingWindowConversationManager
 
         conversation_manager = SlidingWindowConversationManager(
             window_size=40,  # Maximum number of messages to keep
@@ -138,6 +143,7 @@ class VulnerabilityIntelligenceAgent:
                 current_time,
                 "manus_use.tools.create_lark_document",
                 "manus_use.tools.get_nvd_data",
+                get_trickest_pocs,
                 "manus_use.tools.search_for_exploits",
                 "manus_use.tools.get_cwe_details",
                 "manus_use.tools.search_exploit_db",
@@ -185,7 +191,7 @@ def main():
         from manus_use.config import Config
         config = Config.from_file()
         model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
-    except Exception as e:
+    except Exception:
         model_name = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
     # Create the agent


### PR DESCRIPTION
## What

Adds `src/manus_use/tools/get_trickest_pocs.py` — a new `@tool` that queries the [trickest/cve](https://github.com/trickest/cve) repository for known PoC links for a given CVE ID, and wires it into `va_agent.py` as a fast pre-flight step before the slower ExploitDB/Packetstorm/GitHub searches.

## Why

trickest/cve is a continuously auto-updated index of 250k+ CVEs with PoC links sourced from CVE references, GitHub search, and HackerOne reports. Querying it is:
- **Instant** — raw file fetch, no search API overhead
- **Rate-limit free** — no API key needed
- **Comprehensive** — pre-aggregated from multiple sources with false-positive filtering

The VI agent was already doing the work to find these links via live API calls. This gives it a fast authoritative baseline first, then the live searches fill in anything not yet indexed.

## Changes

- **`src/manus_use/tools/get_trickest_pocs.py`** — new tool; fetches `https://raw.githubusercontent.com/trickest/cve/main/{year}/{CVE}.md`, parses Reference and GitHub PoC sections, deduplicates URLs; handles 404/errors gracefully
- **`va_agent.py`** — imports `get_trickest_pocs`, adds it to tool list, updates Step 3 system prompt to call it first as a pre-flight
- **`tests/test_trickest_pocs.py`** — 12 tests: parser unit tests + mocked HTTP integration tests

## Usage (in agent)

```python
# Tool call the agent will make:
get_trickest_pocs("CVE-2025-6554")
# → Returns categorised PoC links in ~50ms, no rate limits
```

## Tests

```
12 passed in 1.12s
```
ruff clean on all new/modified files.