### PR TITLE
feat(tools): add get_poc_week for trending CVE signal from PoC Week digest

### DIFF
--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -55,8 +55,9 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
 
 **Step 3: Gather Public Exploits and Advisories**
-- First, call `get_trickest_pocs` with the CVE ID. This is a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily) — it returns known PoC links in milliseconds with no rate limits.
-- Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by trickest.
+- First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week — note this in your analysis.
+- Then call `get_trickest_pocs` with the CVE ID for a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily).
+- Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by either source.
 - Merge all results, deduplicating URLs.
 
 **Step 4: Mandatory URL Verification and PoC Identification**
@@ -143,6 +144,7 @@ class VulnerabilityIntelligenceAgent:
 
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
+            from manus_use.tools.get_poc_week import get_poc_week
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -167,6 +169,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.create_lark_document",
             "manus_use.tools.get_nvd_data",
             get_trickest_pocs,
+            get_poc_week,
             "manus_use.tools.search_for_exploits",
             "manus_use.tools.get_cwe_details",
             "manus_use.tools.search_exploit_db",

--- a/src/manus_use/tools/get_poc_week.py
+++ b/src/manus_use/tools/get_poc_week.py
@@ -1,0 +1,231 @@
+"""Tool for fetching the PoC Week digest from tonyharris.io.
+
+PoC Week is a weekly digest of the most-mentioned CVEs across security
+newsletters, pre-filtered to only include CVEs with public Proof-of-Concepts
+and ordered by community mention count.  It acts as a "trending" signal on
+top of raw NVD/EPSS data.
+
+URL pattern: https://tonyharris.io/poc-week/poc-week-YYYYMMDD/
+Index page:  https://tonyharris.io/poc-week/
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+__all__ = ["get_poc_week"]
+
+_BASE_URL = "https://tonyharris.io"
+_INDEX_URL = f"{_BASE_URL}/poc-week/"
+_USER_AGENT = "manus-use/poc-week-tool (github.com/manus-use/manus-use)"
+
+# Matches "CVE-YYYY-NNNNN" (standard NVD format)
+_CVE_RE = re.compile(r"CVE-\d{4}-\d{4,7}", re.IGNORECASE)
+# Matches section headings — markdown (## CVE-…) OR HTML (<h2>CVE-…</h2>)
+_HEADING_RE = re.compile(
+    r"^(?:#{1,3}\s+|<h[1-3]>)(CVE-\d{4}-\d{4,7})\b(.*?)(?:</h[1-3]>)?$",
+    re.IGNORECASE | re.MULTILINE,
+)
+# PoC URL lines: lines that start with a bare URL or a markdown link
+_POC_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+
+
+def _fetch_url(url: str, timeout: int = 15) -> str:
+    """Fetch *url* and return the response body as a UTF-8 string."""
+    req = Request(url, headers={"User-Agent": _USER_AGENT})
+    with urlopen(req, timeout=timeout) as resp:  # noqa: S310
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def _last_sunday(ref: date | None = None) -> date:
+    """Return the most recent Sunday on or before *ref* (defaults to today)."""
+    ref = ref or date.today()
+    # weekday(): Mon=0 … Sun=6
+    days_since_sunday = (ref.weekday() + 1) % 7
+    return ref - timedelta(days=days_since_sunday)
+
+
+def _url_for_date(d: date) -> str:
+    return f"{_BASE_URL}/poc-week/poc-week-{d.strftime('%Y%m%d')}/"
+
+
+def _parse_poc_week(html: str) -> list[dict[str, Any]]:
+    """Parse a PoC Week HTML page and return a list of CVE entries.
+
+    Each entry is a dict::
+
+        {
+            "cve_id":        str,           # e.g. "CVE-2026-32201"
+            "severity":      str | None,    # e.g. "9.8 CRITICAL"
+            "products":      str | None,    # impacted products
+            "description":   str | None,    # short description
+            "poc_urls":      list[str],     # PoC links found
+            "is_new":        bool,          # True if "NEW" tag present
+            "mention_rank":  int,           # 1-based order on the page
+        }
+    """
+    results: list[dict[str, Any]] = []
+
+    # Split into per-CVE sections by h2/h3 headings — supports both
+    # markdown (## CVE-…) and HTML (<h2>CVE-…</h2>) heading styles.
+    sections = re.split(
+        r"\n(?=(?:#{1,3}\s+|<h[1-3]>)CVE-)", html, flags=re.IGNORECASE
+    )
+
+    rank = 0
+    for section in sections:
+        heading_match = _HEADING_RE.match(section.lstrip())
+        if not heading_match:
+            continue
+
+        rank += 1
+        cve_id = heading_match.group(1).upper()
+        is_new = "NEW" in heading_match.group(2).upper()
+
+        # Severity line: "- Severity: 9.8 CRITICAL"
+        severity_match = re.search(
+            r"-\s*Severity:\s*(.+?)(?:\n|$)", section, re.IGNORECASE
+        )
+        severity = severity_match.group(1).strip() if severity_match else None
+
+        # Impacted products
+        products_match = re.search(
+            r"-\s*Impacted Products?:\s*(.+?)(?:\n|$)", section, re.IGNORECASE
+        )
+        products = products_match.group(1).strip() if products_match else None
+
+        # Description (first paragraph after "Description:")
+        desc_match = re.search(
+            r"-\s*Description:\s*([\s\S]+?)(?:\n-\s|\Z)", section, re.IGNORECASE
+        )
+        description: str | None = None
+        if desc_match:
+            description = " ".join(desc_match.group(1).split())
+
+        # PoC URLs — lines after a "PoC:" marker
+        poc_section_match = re.search(
+            r"-\s*PoC:\s*([\s\S]+?)(?:\n-\s[A-Z]|\Z)", section, re.IGNORECASE
+        )
+        poc_urls: list[str] = []
+        if poc_section_match:
+            raw = poc_section_match.group(1)
+            poc_urls = _POC_URL_RE.findall(raw)
+            # Strip trailing markdown punctuation
+            poc_urls = [u.rstrip(").,]") for u in poc_urls]
+
+        results.append(
+            {
+                "cve_id": cve_id,
+                "severity": severity,
+                "products": products,
+                "description": description,
+                "poc_urls": poc_urls,
+                "is_new": is_new,
+                "mention_rank": rank,
+            }
+        )
+
+    return results
+
+
+def get_poc_week(
+    date_str: str | None = None,
+    *,
+    timeout: int = 15,
+    max_retries: int = 3,
+) -> dict[str, Any]:
+    """Fetch a PoC Week digest from tonyharris.io.
+
+    Retrieves the weekly digest of trending CVEs with public Proof-of-Concept
+    exploits, curated from security newsletters and ranked by mention count.
+
+    Args:
+        date_str: ISO date string (YYYY-MM-DD) for the desired week.  The
+            tool will round back to the nearest Sunday automatically.  If
+            *None*, defaults to the most recent available Sunday.  When the
+            exact date returns 404, the tool walks back up to *max_retries*
+            prior weeks looking for published content.
+        timeout: HTTP request timeout in seconds.
+        max_retries: Number of prior weeks to try on 404 before giving up.
+
+    Returns:
+        A dict with keys:
+
+        - ``"week_date"`` – ISO date string of the retrieved issue (YYYY-MM-DD)
+        - ``"url"`` – canonical URL of the fetched page
+        - ``"cves"`` – list of CVE entry dicts, each containing:
+            - ``"cve_id"``       – e.g. ``"CVE-2026-32201"``
+            - ``"mention_rank"`` – 1-based position (lower = more buzz)
+            - ``"severity"``     – severity string or *None*
+            - ``"products"``     – impacted products string or *None*
+            - ``"description"``  – short description or *None*
+            - ``"poc_urls"``     – list of PoC/exploit URLs
+            - ``"is_new"``       – *True* if marked NEW in the digest
+        - ``"total"``  – number of CVEs found
+        - ``"error"``  – error message string, only present on failure
+
+    Examples::
+
+        # Latest available issue
+        result = get_poc_week()
+
+        # Specific week (rounds to nearest Sunday)
+        result = get_poc_week("2026-04-27")
+
+        # Access results
+        for entry in result["cves"]:
+            print(entry["cve_id"], entry["mention_rank"], entry["poc_urls"])
+    """
+    # Resolve target date
+    if date_str:
+        try:
+            ref = date.fromisoformat(date_str)
+        except ValueError:
+            return {"error": f"Invalid date format: {date_str!r}. Use YYYY-MM-DD."}
+    else:
+        ref = date.today()
+
+    target = _last_sunday(ref)
+
+    # Try target date, then walk back on 404
+    html: str | None = None
+    fetched_date: date | None = None
+    last_error: str = ""
+
+    for attempt in range(max_retries + 1):
+        candidate = target - timedelta(weeks=attempt)
+        url = _url_for_date(candidate)
+        try:
+            html = _fetch_url(url, timeout=timeout)
+            fetched_date = candidate
+            break
+        except HTTPError as exc:
+            if exc.code == 404:
+                last_error = f"404 for {url}"
+                continue
+            return {"error": f"HTTP {exc.code} fetching {url}: {exc.reason}"}
+        except URLError as exc:
+            return {"error": f"Network error fetching {url}: {exc.reason}"}
+        except Exception as exc:  # noqa: BLE001
+            return {"error": f"Unexpected error fetching {url}: {exc}"}
+
+    if html is None or fetched_date is None:
+        return {
+            "error": (
+                f"No PoC Week issue found within {max_retries} weeks of "
+                f"{target.isoformat()}. Last error: {last_error}"
+            )
+        }
+
+    cves = _parse_poc_week(html)
+
+    return {
+        "week_date": fetched_date.isoformat(),
+        "url": _url_for_date(fetched_date),
+        "cves": cves,
+        "total": len(cves),
+    }

--- a/tests/test_poc_week.py
+++ b/tests/test_poc_week.py
@@ -1,0 +1,270 @@
+"""Tests for the get_poc_week tool."""
+
+from __future__ import annotations
+
+from datetime import date
+from unittest.mock import MagicMock, patch
+from urllib.error import HTTPError, URLError
+
+import pytest
+
+from manus_use.tools.get_poc_week import (
+    _last_sunday,
+    _parse_poc_week,
+    _url_for_date,
+    get_poc_week,
+)
+
+# ---------------------------------------------------------------------------
+# Sample HTML fixture — mirrors real PoC Week structure
+# ---------------------------------------------------------------------------
+
+SAMPLE_HTML = """
+## CVE-2026-33824
+
+- Severity: 9.8 CRITICAL
+- Impacted Products: Microsoft Windows, IKEv2
+- Description: A double free vulnerability in IKE Service Extensions allows RCE.
+- PoC:
+
+https://github.com/z3r0h3ro/CVE-2026-33824
+
+## CVE-2026-32201 NEW
+
+- Severity: 6.5 MEDIUM
+- Impacted Products: Microsoft SharePoint
+- Description: Improper input validation allows spoofing.
+- PoC:
+
+https://github.com/B1tBit/CVE-2026-32201-exploit
+
+## CVE-2026-40175
+
+- Severity: 10.0 CRITICAL
+- Impacted Products: Axios
+- PoC:
+
+https://github.com/pjt3591oo/CVE-2026-40175-poc
+https://github.com/kengzzzz/CVE-2026-40175
+"""
+
+# ---------------------------------------------------------------------------
+# _last_sunday
+# ---------------------------------------------------------------------------
+
+
+def test_last_sunday_on_sunday():
+    # 2026-06-21 is a Sunday
+    d = date(2026, 6, 21)
+    assert _last_sunday(d) == d
+
+
+def test_last_sunday_on_monday():
+    d = date(2026, 6, 22)  # Monday
+    assert _last_sunday(d) == date(2026, 6, 21)
+
+
+def test_last_sunday_on_saturday():
+    d = date(2026, 6, 27)  # Saturday
+    assert _last_sunday(d) == date(2026, 6, 21)
+
+
+# ---------------------------------------------------------------------------
+# _url_for_date
+# ---------------------------------------------------------------------------
+
+
+def test_url_for_date():
+    d = date(2026, 4, 27)
+    assert _url_for_date(d) == "https://tonyharris.io/poc-week/poc-week-20260427/"
+
+
+# ---------------------------------------------------------------------------
+# _parse_poc_week
+# ---------------------------------------------------------------------------
+
+
+def test_parse_returns_list():
+    results = _parse_poc_week(SAMPLE_HTML)
+    assert isinstance(results, list)
+
+
+def test_parse_cve_count():
+    results = _parse_poc_week(SAMPLE_HTML)
+    assert len(results) == 3
+
+
+def test_parse_cve_ids():
+    results = _parse_poc_week(SAMPLE_HTML)
+    ids = [r["cve_id"] for r in results]
+    assert "CVE-2026-33824" in ids
+    assert "CVE-2026-32201" in ids
+    assert "CVE-2026-40175" in ids
+
+
+def test_parse_mention_rank_ordering():
+    results = _parse_poc_week(SAMPLE_HTML)
+    ranks = [r["mention_rank"] for r in results]
+    assert ranks == sorted(ranks)
+    assert ranks[0] == 1
+
+
+def test_parse_is_new_flag():
+    results = _parse_poc_week(SAMPLE_HTML)
+    by_id = {r["cve_id"]: r for r in results}
+    assert by_id["CVE-2026-32201"]["is_new"] is True
+    assert by_id["CVE-2026-33824"]["is_new"] is False
+
+
+def test_parse_severity():
+    results = _parse_poc_week(SAMPLE_HTML)
+    by_id = {r["cve_id"]: r for r in results}
+    assert by_id["CVE-2026-33824"]["severity"] == "9.8 CRITICAL"
+    assert by_id["CVE-2026-32201"]["severity"] == "6.5 MEDIUM"
+    assert by_id["CVE-2026-40175"]["severity"] == "10.0 CRITICAL"
+
+
+def test_parse_poc_urls_present():
+    results = _parse_poc_week(SAMPLE_HTML)
+    by_id = {r["cve_id"]: r for r in results}
+    assert len(by_id["CVE-2026-33824"]["poc_urls"]) >= 1
+    assert any("CVE-2026-33824" in u for u in by_id["CVE-2026-33824"]["poc_urls"])
+
+
+def test_parse_multiple_poc_urls():
+    results = _parse_poc_week(SAMPLE_HTML)
+    by_id = {r["cve_id"]: r for r in results}
+    assert len(by_id["CVE-2026-40175"]["poc_urls"]) >= 2
+
+
+def test_parse_empty_html():
+    assert _parse_poc_week("") == []
+    assert _parse_poc_week("<html><body>No CVEs here</body></html>") == []
+
+
+# ---------------------------------------------------------------------------
+# get_poc_week — happy path (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_response(html: str):
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = html.encode("utf-8")
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_returns_dict(mock_urlopen):
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week("2026-04-27")
+    assert isinstance(result, dict)
+    assert "error" not in result
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_week_date(mock_urlopen):
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week("2026-04-26")  # 2026-04-26 is a Sunday
+    assert result["week_date"] == "2026-04-26"
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_url_field(mock_urlopen):
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week("2026-04-26")  # Sunday
+    assert "20260426" in result["url"]
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_total(mock_urlopen):
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week("2026-04-26")  # Sunday
+    assert result["total"] == len(result["cves"])
+    assert result["total"] == 3
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_rounds_to_sunday(mock_urlopen):
+    """Mid-week date should round back to the preceding Sunday."""
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week("2026-04-29")  # Wednesday
+    assert result["week_date"] == "2026-04-26"  # prior Sunday
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_no_date_uses_today(mock_urlopen):
+    mock_urlopen.return_value = _make_mock_response(SAMPLE_HTML)
+    result = get_poc_week()
+    assert "week_date" in result
+    assert "error" not in result
+
+
+# ---------------------------------------------------------------------------
+# get_poc_week — error handling
+# ---------------------------------------------------------------------------
+
+
+def test_get_poc_week_invalid_date():
+    result = get_poc_week("not-a-date")
+    assert "error" in result
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_404_retries_and_fails(mock_urlopen):
+    mock_urlopen.side_effect = HTTPError(
+        url="https://example.com", code=404, msg="Not Found", hdrs=None, fp=None
+    )
+    result = get_poc_week("2026-04-27", max_retries=2)
+    assert "error" in result
+    assert "No PoC Week issue found" in result["error"]
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_404_then_success(mock_urlopen):
+    """First call returns 404; second call (prior week) succeeds."""
+    http_err = HTTPError(
+        url="https://example.com", code=404, msg="Not Found", hdrs=None, fp=None
+    )
+    mock_urlopen.side_effect = [http_err, _make_mock_response(SAMPLE_HTML)]
+    result = get_poc_week("2026-04-26", max_retries=2)  # Sunday
+    assert "error" not in result
+    assert result["total"] == 3
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_network_error(mock_urlopen):
+    mock_urlopen.side_effect = URLError("Connection refused")
+    result = get_poc_week("2026-04-27")
+    assert "error" in result
+    assert "Network error" in result["error"]
+
+
+@patch("manus_use.tools.get_poc_week.urlopen")
+def test_get_poc_week_non_404_http_error(mock_urlopen):
+    mock_urlopen.side_effect = HTTPError(
+        url="https://example.com", code=503, msg="Service Unavailable", hdrs=None, fp=None
+    )
+    result = get_poc_week("2026-04-27")
+    assert "error" in result
+    assert "503" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# Integration smoke test (skipped in CI without network)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("urllib.request", reason="urllib unavailable"),
+    reason="requires network",
+)
+@pytest.mark.integration
+def test_get_poc_week_live():
+    """Smoke-test against the real site. Skip with: pytest -m 'not integration'."""
+    result = get_poc_week()
+    # If we get a result (not a network error), validate shape
+    if "error" not in result:
+        assert "week_date" in result
+        assert isinstance(result["cves"], list)
+        assert result["total"] == len(result["cves"])

--- a/va_agent.py
+++ b/va_agent.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
 """Vulnerability analysis agent entry point (with optional exploit verification).
 
-The :class:`VulnerabilityIntelligenceAgent` implementation now lives in the
-importable module ``manus_use.agents.vi_agent``. This script remains a thin
-command-line entry point so existing ``python va_agent.py CVE-... [--verify]``
-workflows keep working.
+The :class:`VulnerabilityIntelligenceAgent` implementation lives in
+``manus_use.agents.vi_agent``. This script is a thin command-line entry point
+so existing ``python va_agent.py CVE-... [--verify]`` workflows keep working.
+
+The agent runs an 8-step analysis pipeline for each CVE:
+
+1. NVD data + GitHub advisory
+2. CISA KEV check + OTX threat intel
+3. PoC hunt — trickest/cve index, PoC Week community digest,
+   ExploitDB, Packetstorm, GitHub search
+4. URL verification (browser fallback)
+5. Deep PoC static code analysis
+6. CWE analysis
+7. Threat actor feed query
+8. Lark document report
 """
 
 import os

--- a/vi_agent.py
+++ b/vi_agent.py
@@ -1,10 +1,21 @@
 #!/usr/bin/env python3
 """Vulnerability Intelligence agent entry point.
 
-The :class:`VulnerabilityIntelligenceAgent` implementation now lives in the
-importable module ``manus_use.agents.vi_agent``. This script remains a thin
-command-line entry point so existing ``python vi_agent.py CVE-...`` workflows
-keep working.
+The :class:`VulnerabilityIntelligenceAgent` implementation lives in
+``manus_use.agents.vi_agent``. This script is a thin command-line entry point
+so existing ``python vi_agent.py CVE-...`` workflows keep working.
+
+The agent runs an 8-step analysis pipeline for each CVE:
+
+1. NVD data + GitHub advisory
+2. CISA KEV check + OTX threat intel
+3. PoC hunt — trickest/cve index, PoC Week community digest,
+   ExploitDB, Packetstorm, GitHub search
+4. URL verification (browser fallback)
+5. Deep PoC static code analysis
+6. CWE analysis
+7. Threat actor feed query
+8. Lark document report
 """
 
 import os


### PR DESCRIPTION
## What & Why

[tonyharris.io/poc-week](https://tonyharris.io/poc-week/) publishes a weekly digest of CVEs that are trending across security newsletters, pre-filtered to those with public PoCs and ranked by mention count. This is a complementary signal to NVD/EPSS — it catches high-impact vulns that are new and buzzing before their EPSS scores catch up.

## Changes

- **New tool:** `src/manus_use/tools/get_poc_week.py`
  - `get_poc_week(date_str=None)` — fetches the latest (or specific) PoC Week issue
  - Auto-rounds input date to the nearest Sunday; walks back up to `max_retries` prior weeks on 404
  - Returns a list of CVE entries with `mention_rank`, `severity`, `products`, `description`, `poc_urls`, `is_new`
  - No API key or external dependency — uses stdlib `urllib` only
  - Handles both markdown (`## CVE-…`) and HTML (`<h2>CVE-…</h2>`) heading styles

- **vi_agent.py Step 3 updated** — `get_poc_week` runs first as a fast community-signal check before trickest and the live exploit searches. A low `mention_rank` (1 = most buzzed) is surfaced in the analysis.

## Tests

25 tests in `tests/test_poc_week.py` covering:
- Date rounding to nearest Sunday (incl. edge cases)
- URL construction
- HTML/markdown parsing, CVE count, severity, PoC URL extraction, is_new flag
- 404 retry walk-back logic
- Network error and non-404 HTTP error handling
- Invalid date input