### PR TITLE
chore(deps): bump strands-agents to 1.44.0, strands-agents-tools to 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
-    "strands-agents>=1.38.0",
-    "strands-agents-tools>=0.5.2",
+    "strands-agents>=1.44.0",
+    "strands-agents-tools>=0.8.1",
     "aiofiles>=24.1.0",
     "docker>=7.1.0",
     "nest_asyncio>=1.5.0",


### PR DESCRIPTION
## What

Bumps the minimum required versions of both Strands SDK packages:

| Package | Before | After |
|---|---|---|
| strands-agents | >=1.38.0 | >=1.44.0 |
| strands-agents-tools | >=0.5.2 | >=0.8.1 |

## Why

Both packages have 6 releases of improvements since our current floor. Highlights in 1.39–1.44:

- **Memory manager** — `BedrockKnowledgeBaseStore`, memory injection/extraction, configurable auto-flush
- **Agentic context management** — model-driven compression to handle long conversations
- **GoalLoop plugin** — structured goal-directed agent loops
- **Sandbox integration** — vended tools/plugins for sandboxed execution
- **Intervention handlers** — HumanInTheLoop and Cedar authorization
- **Internal middleware** for InvokeModelStage
- **Turn-based eviction** for InMemoryStorage
- invocation_state passed to edge condition calls

No breaking changes for existing manus-use usage patterns.

## Tests

106 tests pass against the new versions.