### PR TITLE
feat(agents): add strands context management support

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -109,3 +109,12 @@ cve_submit_url = "https://your-webhook.example.com/path/to/webhook"
 document_url = "https://your-lark-api.example.com/path/to/endpoint"
 api_token = "your-lark-api-token"
 # DO NOT commit real tokens to version control!
+[agent]
+# Context manager mode for general agents (ManusAgent, DataAnalysisAgent, MCPAgent).
+# "auto"    — SDK composes SummarizingConversationManager + ContextOffloader with
+#             tuned defaults.  Good for most multi-turn use cases.
+# "agentic" — model monitors its own token usage and calls summarize_context /
+#             truncate_context / pin_context to manage working memory.  Better for
+#             long pipelines where the model can judge message relevance.
+# VulnerabilityIntelligenceAgent always uses "agentic" regardless of this setting.
+context_manager = "auto"

--- a/src/manus_use/agents/base.py
+++ b/src/manus_use/agents/base.py
@@ -1,6 +1,6 @@
 """Base agent implementation for ManusUse."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 
 from strands import Agent
 from strands.types.tools import AgentTool
@@ -10,39 +10,51 @@ from manus_use.config import Config
 
 class BaseManusAgent(Agent):
     """Base agent with ManusUse enhancements."""
-    
+
     def __init__(
         self,
-        tools: Optional[List[AgentTool]] = None,
-        model: Optional[Any] = None,
-        config: Optional[Config] = None,
-        system_prompt: Optional[str] = None,
+        tools: list[AgentTool] | None = None,
+        model: Any | None = None,
+        config: Config | None = None,
+        system_prompt: str | None = None,
+        context_manager: str | Any = "auto",
         **kwargs
     ):
         """Initialize base agent.
-        
+
         Args:
             tools: List of tools to use
             model: Model instance or None to use config
             config: Configuration object
             system_prompt: System prompt for the agent
+            context_manager: Strands context manager mode.  ``"auto"`` (default)
+                composes a SummarizingConversationManager + ContextOffloader
+                with tuned defaults.  ``"agentic"`` lets the model manage its
+                own context via summarize_context / truncate_context /
+                pin_context tools.  Pass an explicit conversation manager
+                instance for full control.
             **kwargs: Additional arguments for Agent
         """
         self.config = config or Config.from_file()
         # Keep an explicit, stable reference for unit tests and callers.
         # The upstream `strands.Agent` does not guarantee a public `tools` attribute.
-        self.tools: List[AgentTool] = list(tools or [])
-        self._tools: List[AgentTool] = self.tools
-        
+        self.tools: list[AgentTool] = list(tools or [])
+        self._tools: list[AgentTool] = self.tools
+
         # Use provided model or create from config
         if model is None:
             model = self.config.get_model()
-            
+
+        # Respect config-level context_manager override; caller kwarg wins.
+        if context_manager == "auto" and hasattr(self.config, "agent"):
+            context_manager = self.config.agent.context_manager
+
         # Initialize base agent
         super().__init__(
             model=model,
             tools=self.tools,
             system_prompt=system_prompt or self._get_default_system_prompt(),
+            context_manager=context_manager,
             **kwargs,
         )
     def __del__(self):

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -137,14 +137,11 @@ class VulnerabilityIntelligenceAgent:
             os.environ.setdefault("BYPASS_TOOL_CONSENT", "True")
 
             from strands import Agent
-            from strands.agent.conversation_manager import (
-                SlidingWindowConversationManager,
-            )
             from strands_tools import current_time
 
             from manus_use.tools.get_github_advisory import get_github_advisory
-            from manus_use.tools.get_trickest_pocs import get_trickest_pocs
             from manus_use.tools.get_poc_week import get_poc_week
+            from manus_use.tools.get_trickest_pocs import get_trickest_pocs
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -156,11 +153,15 @@ class VulnerabilityIntelligenceAgent:
 
         model_obj = model if model is not None else self._resolve_model(model_name)
 
-        conversation_manager = SlidingWindowConversationManager(
-            window_size=40,
-            should_truncate_results=True,
-            per_turn=True,
-        )
+        # Use agentic context management: the model monitors its own token
+        # usage and decides when/what to compress via summarize_context,
+        # truncate_context, and pin_context tools.  This is better than a
+        # fixed SlidingWindow for the VI pipeline because the model can
+        # distinguish "NVD dump I already parsed" from "PoC code I still need".
+        # A ContextOffloader (inline threshold 8 000 tokens) is added
+        # automatically; SlidingWindowConversationManager is kept as a
+        # safety-net fallback inside agentic mode.
+        context_manager: str = "agentic"
 
         tools: list[Any] = [
             "manus_use.tools.http_request",
@@ -184,7 +185,7 @@ class VulnerabilityIntelligenceAgent:
             tools.append(use_browser)
 
         agent_kwargs: dict[str, Any] = dict(
-            conversation_manager=conversation_manager,
+            context_manager=context_manager,
             model=model_obj,
             system_prompt=self.system_prompt,
             tools=tools,

--- a/src/manus_use/config.py
+++ b/src/manus_use/config.py
@@ -135,6 +135,20 @@ class LarkConfig(BaseModel):
     api_token: Optional[str] = None
 
 
+class AgentConfig(BaseModel):
+    """Agent behaviour configuration."""
+
+    context_manager: str = Field(
+        default="auto",
+        description=(
+            "Strands context manager mode for general agents. "
+            "'auto' composes SummarizingConversationManager + ContextOffloader. "
+            "'agentic' lets the model manage context via tool calls. "
+            "VulnerabilityIntelligenceAgent always uses 'agentic'."
+        ),
+    )
+
+
 class Config(BaseModel):
     """Main configuration."""
     
@@ -147,6 +161,7 @@ class Config(BaseModel):
     mcp: MCPConfig = Field(default_factory=MCPConfig)
     webhooks: WebhooksConfig = Field(default_factory=WebhooksConfig)
     lark: LarkConfig = Field(default_factory=LarkConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
     
     @classmethod
     def from_file(cls, path: Optional[Path] = None) -> "Config":

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,10 +1,10 @@
 """Tests for agent implementations."""
 
-import unittest
-import pytest
-from unittest.mock import AsyncMock, MagicMock, Mock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
-from manus_use.agents import ManusAgent, BrowserAgent, DataAnalysisAgent
+import pytest
+
+from manus_use.agents import BrowserAgent, DataAnalysisAgent, ManusAgent
 from manus_use.config import Config
 
 
@@ -12,13 +12,13 @@ def test_manus_agent_initialization():
     """Test ManusAgent initialization."""
     # Mock the model to avoid actual API calls
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         agent = ManusAgent()
-        
+
         # Check that agent has tools
         assert hasattr(agent, "_tools") or hasattr(agent, "tools")
-        
+
         # Check system prompt
         prompt = agent._get_default_system_prompt()
         assert "Manus" in prompt
@@ -28,13 +28,13 @@ def test_manus_agent_initialization():
 def test_browser_agent_initialization():
     """Test BrowserAgent initialization."""
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         agent = BrowserAgent()
-        
+
         # Check browser-specific attributes
         assert hasattr(agent, "headless")
-        
+
         # Check system prompt
         prompt = agent._get_default_system_prompt()
         assert "browsing" in prompt.lower()
@@ -43,10 +43,10 @@ def test_browser_agent_initialization():
 def test_data_analysis_agent_initialization():
     """Test DataAnalysisAgent initialization."""
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         agent = DataAnalysisAgent()
-        
+
         # Check system prompt
         prompt = agent._get_default_system_prompt()
         assert "data analysis" in prompt.lower()
@@ -57,12 +57,12 @@ def test_agent_with_custom_config():
     """Test agent with custom configuration."""
     config = Config()
     config.llm.temperature = 0.5
-    
+
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         agent = ManusAgent(config=config)
-        
+
         # Verify config was used
         assert agent.config.llm.temperature == 0.5
 
@@ -70,15 +70,15 @@ def test_agent_with_custom_config():
 def test_agent_add_tools():
     """Test adding tools to agent."""
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         # Create agent with no tools
         agent = ManusAgent(tools=[])
-        
+
         # Mock tool
         mock_tool = Mock()
         mock_tool.__name__ = "test_tool"
-        
+
         # Verify that add_tools method is removed
         with pytest.raises(AttributeError):
             agent.add_tools([mock_tool])
@@ -87,27 +87,28 @@ def test_agent_add_tools():
 def test_agent_constructor_tools():
     """Test tools passed to agent constructor."""
     with patch("manus_use.config.Config.get_model") as mock_model:
-        mock_model.return_value = Mock()
-        
+        mock_model.return_value = Mock(stateful=False)
+
         mock_tool = Mock()
         mock_tool.__name__ = "constructor_tool"
-        
+
         agent = ManusAgent(tools=[mock_tool])
-        
+
         # Verify tool is present
         # Accessing agent.tools is the public way for Strands
         assert mock_tool in agent.tools
 
 
 # Need to import MCPAgent and MCPClient for the next test
-from manus_use.agents.mcp import MCPAgent
 from strands.tools.mcp import MCPClient
+
+from manus_use.agents.mcp import MCPAgent
 
 
 def test_mcp_agent_tool_initialization():
     """Test tool initialization and add_mcp_server for MCPAgent."""
     with patch("manus_use.config.Config.get_model") as mock_model_create:
-        mock_model_create.return_value = Mock()
+        mock_model_create.return_value = Mock(stateful=False)
 
         # Mock tools
         mock_tool1 = Mock()
@@ -135,19 +136,18 @@ def test_mcp_agent_tool_initialization():
 
         # Assert mock_tool2 is NOT in agent's tools (as add_tools was removed from add_mcp_server)
         assert mock_tool2 not in agent.tools
-        
+
         # Assert mock_server2 IS in agent.mcp_servers
         assert mock_server2 in agent.mcp_servers
-        
+
         # Assert mock_tool1 IS STILL in agent.tools
         assert mock_tool1 in agent.tools
 
 # --- Tests for BrowserUseAgent ---
 import asyncio
-import logging
-from unittest.mock import MagicMock # For async context manager
 
 from manus_use.agents.browser_use_agent import BrowserUseAgent
+
 # Assuming BROWSER_USE_AVAILABLE is True for most tests, will patch it for specific cases
 
 @pytest.fixture
@@ -257,7 +257,7 @@ def test_browser_use_agent_get_llm_bedrock(mock_os_getenv, MockChatBedrock, mock
 
     agent = BrowserUseAgent(config=mock_config_fixture)
     llm = agent._get_browser_llm()
-    
+
     mock_os_getenv.assert_called_once_with('AWS_DEFAULT_REGION', mock_config_fixture.llm.aws_region or 'us-east-1')
     MockChatBedrock.assert_called_once_with(
         model_id=mock_config_fixture.llm.model,
@@ -389,10 +389,10 @@ def test_browser_use_agent_call_sync_context(mock_asyncio, mock_run_task, mock_c
     """Test __call__ in a synchronous context."""
     mock_asyncio.get_running_loop.side_effect = RuntimeError("No running event loop")
     mock_asyncio.run = Mock(return_value="sync_result") # Mock asyncio.run
-    
+
     agent = BrowserUseAgent(config=mock_config_fixture)
     result = agent(task="sync_task_str")
-    
+
     mock_asyncio.get_running_loop.assert_called_once()
     mock_asyncio.run.assert_called_once() # asyncio.run should be used in sync context
     mock_run_task.assert_called_once_with("sync_task_str")
@@ -405,11 +405,11 @@ def test_browser_use_agent_call_async_context(mock_asyncio, mock_run_task, mock_
     """Test __call__ in an asynchronous context."""
     mock_loop = Mock()
     mock_asyncio.get_running_loop.return_value = mock_loop # Simulate existing loop
-    
+
     agent = BrowserUseAgent(config=mock_config_fixture)
     # Call the agent
     coroutine_result = agent(task="async_task_str_direct")
-    
+
     mock_asyncio.get_running_loop.assert_called_once()
     mock_asyncio.run.assert_not_called() # asyncio.run should not be called
     mock_run_task.assert_called_once_with("async_task_str_direct")
@@ -421,7 +421,7 @@ def test_browser_use_agent_call_async_context(mock_asyncio, mock_run_task, mock_
 def test_browser_use_agent_call_list_input(mock_asyncio, mock_run_task, mock_config_fixture):
     """Test __call__ with a list of message dicts as input."""
     mock_asyncio.get_running_loop.side_effect = RuntimeError("No running event loop") # Test sync path
-    
+
     agent = BrowserUseAgent(config=mock_config_fixture)
     task_list = [
         {"role": "user", "content": "ignore this"},


### PR DESCRIPTION
## Summary

Wires in the strands-agents context management system across the project so long-running pipelines handle token pressure gracefully without manual window-size tuning.

### Changes

**`src/manus_use/agents/vi_agent.py`**
- Replace hardcoded `SlidingWindowConversationManager(window_size=40, ...)` with `context_manager="agentic"`
- The model now receives a `<context-status>` telemetry block each turn and can call `summarize_context`, `truncate_context`, or `pin_context` tools to manage its own working memory
- Better fit for the 8-step CVE pipeline where early tool results (NVD, advisory) should stay pinned while mid-pipeline noise (raw PoC HTML) can be compressed

**`src/manus_use/agents/base.py`**
- Add `context_manager: str | Any = "auto"` kwarg to `BaseManusAgent.__init__`
- Passes through to `strands.Agent`; callers can override per-instance
- Reads `config.agent.context_manager` as project-wide default (config wins unless kwarg is set to a non-"auto" value explicitly)

**`src/manus_use/config.py`**
- Add `AgentConfig` model with a `context_manager` field (default `"auto"`)
- Append `agent: AgentConfig` field to `Config`

**`config/config.example.toml`**
- Document the new `[agent]` section with inline explanation of `"auto"` vs `"agentic"` modes

**`tests/test_agents.py`**
- Fix all `Mock()` model objects to `Mock(stateful=False)` — strands raises `ValueError` when `context_manager` is passed with a stateful model, and bare `Mock()` objects have truthy `.stateful`
- Incidentally resolves 34 pre-existing ruff warnings in the test file

### Context manager modes (strands >=1.44)

| Mode | Behaviour |
|------|-----------|
| `"auto"` | SDK composes `SummarizingConversationManager` (summary_ratio=0.3, compression_threshold=0.85) + `ContextOffloader` (max_result_tokens=1500). Background compression, no model involvement. |
| `"agentic"` | Model monitors token-usage telemetry block and calls `summarize_context` / `truncate_context` / `pin_context` tools when needed. Uses `ContextOffloader` with inline threshold of 8000 tokens. |

### Test results
```
106 passed, 3 warnings
```
All 3 warnings are pre-existing (AsyncMock coroutine never awaited in unrelated CLI test).

### Ruff
`src/manus_use/agents/vi_agent.py` and `src/manus_use/agents/base.py` — clean.
`config.py` and `test_agents.py` — net improvement (51 → 17 errors); remaining issues are all pre-existing style debt (N803, E712, E402 mid-file imports) not introduced here.