### PR TITLE
feat(agents): add GoalLoop report-completeness check to VulnerabilityIntelligenceAgent

### DIFF
--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -98,6 +98,46 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 """
 
 
+# ---------------------------------------------------------------------------
+# GoalLoop validator
+# ---------------------------------------------------------------------------
+
+# Sections the final VA report must contain.  Using a programmatic validator
+# avoids spawning an LLM judge on every successful run (zero extra cost).
+_REQUIRED_REPORT_SECTIONS: tuple[str, ...] = (
+    "CVSS",
+    "Remediation",
+    "Exploitability",
+    "Detection",
+)
+
+
+def _report_complete_validator(
+    response: dict,  # last assistant message from the agent
+    agent: Any,  # host agent instance (unused but required by the interface)
+) -> bool | dict:
+    """Return True when the response contains all required VA report sections.
+
+    On failure returns a dict with ``passed=False`` and ``feedback`` listing
+    the missing sections so the agent can complete them in the next attempt.
+    """
+    text = " ".join(
+        block.get("text", "")
+        for block in response.get("content", [])
+        if isinstance(block, dict)
+    )
+    missing = [s for s in _REQUIRED_REPORT_SECTIONS if s.lower() not in text.lower()]
+    if not missing:
+        return True
+    return {
+        "passed": False,
+        "feedback": (
+            f"Report is incomplete. Missing required sections: {missing}. "
+            "Please complete those sections and regenerate the full report."
+        ),
+    }
+
+
 class VulnerabilityIntelligenceAgent:
     """Agent that performs vulnerability analysis via a sequential, tool-based workflow.
 
@@ -163,6 +203,17 @@ class VulnerabilityIntelligenceAgent:
         # safety-net fallback inside agentic mode.
         context_manager: str = "agentic"
 
+        # GoalLoop: ensure the final response contains all required report
+        # sections before returning.  Uses a fast programmatic validator (no
+        # judge-agent invocation) so there is no extra LLM cost on success.
+        from strands.vended_plugins.goal import GoalLoop
+
+        goal_loop = GoalLoop(
+            goal=_report_complete_validator,
+            max_attempts=2,
+            timeout=900.0,
+        )
+
         tools: list[Any] = [
             "manus_use.tools.http_request",
             "manus_use.tools.python_repl",
@@ -193,8 +244,10 @@ class VulnerabilityIntelligenceAgent:
 
         # Attach the bundled verify-exploit skill when AgentSkills is available.
         plugin = self._resolve_skills_plugin()
+        plugins: list[Any] = [goal_loop]
         if plugin is not None:
-            agent_kwargs["plugins"] = [plugin]
+            plugins.append(plugin)
+        agent_kwargs["plugins"] = plugins
 
         self.agent = Agent(**agent_kwargs)
 

--- a/tests/test_goal_loop.py
+++ b/tests/test_goal_loop.py
@@ -1,0 +1,124 @@
+"""Tests for GoalLoop integration in VulnerabilityIntelligenceAgent."""
+
+
+
+# ---------------------------------------------------------------------------
+# Validator unit tests (no strands import needed)
+# ---------------------------------------------------------------------------
+
+def _import_validator():
+    """Import the module-level validator function."""
+    from manus_use.agents.vi_agent import (  # noqa: PLC0415
+        _REQUIRED_REPORT_SECTIONS,
+        _report_complete_validator,
+    )
+    return _report_complete_validator, _REQUIRED_REPORT_SECTIONS
+
+
+def _make_response(text: str) -> dict:
+    return {"content": [{"text": text}]}
+
+
+def test_validator_passes_complete_report():
+    validate, _ = _import_validator()
+    text = (
+        "CVSS: 9.8 (Critical)\n"
+        "Remediation: Apply patch version 1.2.3.\n"
+        "Exploitability: Active exploitation observed.\n"
+        "Detection: Monitor logs for anomalous requests.\n"
+    )
+    assert validate(_make_response(text), None) is True
+
+
+def test_validator_fails_missing_cvss():
+    validate, _ = _import_validator()
+    text = "Remediation: patch it. Exploitability: easy. Detection: monitor logs."
+    result = validate(_make_response(text), None)
+    assert result["passed"] is False
+    assert "CVSS" in result["feedback"]
+
+
+def test_validator_fails_missing_remediation():
+    validate, _ = _import_validator()
+    text = "CVSS: 7.5. Exploitability: low. Detection: check syslog."
+    result = validate(_make_response(text), None)
+    assert result["passed"] is False
+    assert "Remediation" in result["feedback"]
+
+
+def test_validator_fails_missing_exploitability():
+    validate, _ = _import_validator()
+    text = "CVSS: 8.1. Remediation: upgrade now. Detection: firewall rule."
+    result = validate(_make_response(text), None)
+    assert result["passed"] is False
+    assert "Exploitability" in result["feedback"]
+
+
+def test_validator_fails_missing_detection():
+    validate, _ = _import_validator()
+    text = "CVSS: 5.0. Remediation: patch. Exploitability: requires auth."
+    result = validate(_make_response(text), None)
+    assert result["passed"] is False
+    assert "Detection" in result["feedback"]
+
+
+def test_validator_fails_multiple_missing():
+    validate, sections = _import_validator()
+    text = "Some vulnerability was found."
+    result = validate(_make_response(text), None)
+    assert result["passed"] is False
+    for section in sections:
+        assert section in result["feedback"]
+
+
+def test_validator_case_insensitive():
+    validate, _ = _import_validator()
+    # Lowercase variants — validator must match case-insensitively.
+    text = "cvss: 6.5. remediation: update. exploitability: network. detection: ids."
+    assert validate(_make_response(text), None) is True
+
+
+def test_validator_empty_response():
+    validate, _ = _import_validator()
+    result = validate({"content": []}, None)
+    assert result["passed"] is False
+
+
+def test_validator_non_text_blocks_ignored():
+    validate, _ = _import_validator()
+    response = {
+        "content": [
+            {"type": "tool_use", "id": "t1"},
+            {"text": "CVSS: 9.0. Remediation: patch. Exploitability: rce. Detection: waf."},
+        ]
+    }
+    assert validate(response, None) is True
+
+
+# ---------------------------------------------------------------------------
+# Integration: GoalLoop is importable and wires into VulnerabilityIntelligenceAgent
+# ---------------------------------------------------------------------------
+
+def test_goal_loop_attached_to_agent():
+    """GoalLoop plugin is importable and accepts the VA report validator."""
+    from strands.vended_plugins.goal import GoalLoop  # noqa: PLC0415
+
+    from manus_use.agents.vi_agent import (  # noqa: PLC0415
+        _REQUIRED_REPORT_SECTIONS,
+        _report_complete_validator,
+    )
+
+    # Verify GoalLoop instantiates cleanly with the VA validator
+    plugin = GoalLoop(
+        goal=_report_complete_validator,
+        max_attempts=2,
+        timeout=900.0,
+    )
+    assert plugin is not None
+    assert len(_REQUIRED_REPORT_SECTIONS) >= 4
+
+
+def test_required_sections_tuple_not_empty():
+    from manus_use.agents.vi_agent import _REQUIRED_REPORT_SECTIONS  # noqa: PLC0415
+
+    assert len(_REQUIRED_REPORT_SECTIONS) >= 4


### PR DESCRIPTION
## Summary

Attaches a [strands GoalLoop plugin](https://strandsagents.com/docs/user-guide/concepts/plugins/goal-loop/) to `VulnerabilityIntelligenceAgent` as a safety net: if the agent's response is missing required report sections, it automatically gets a second attempt with targeted feedback.

## Why

The VA agent's 8-step CVE pipeline can occasionally produce incomplete reports — e.g. the Lark document step fires but the model skips a section when context is tight or a tool result was sparse. GoalLoop catches this at the boundary without any manual retry plumbing.

## Design choices

**Programmatic validator, not NL judge** — `_report_complete_validator` is a plain Python function that checks for required section keywords. This means:
- Zero extra LLM cost on a passing run (the common case)
- Deterministic, testable behaviour
- Judge config (e.g. Nova Lite) can be added later if nuanced grading is needed

**Required sections:** `CVSS`, `Remediation`, `Exploitability`, `Detection` — matches the Step 8 system-prompt requirements and the subsection headers mandated in the existing prompt.

**Bounds:** `max_attempts=2`, `timeout=900.0s` — one retry is enough for a section-completion task; 15-minute wall clock keeps the pipeline from running unbounded.

**Plugin ordering:** GoalLoop is prepended before the existing AgentSkills verify-exploit plugin so both coexist cleanly.

## Changes

- `src/manus_use/agents/vi_agent.py` — `_REQUIRED_REPORT_SECTIONS`, `_report_complete_validator`, GoalLoop wired into `agent_kwargs["plugins"]`
- `tests/test_goal_loop.py` — 11 new tests covering the validator and GoalLoop instantiation

## Test results
```
117 passed, 4 warnings
```