### PR TITLE
fix(tests): supply LARK_DOCUMENT_URL/LARK_API_TOKEN in create_lark_document is_openclaw tests

### DIFF
--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,17 +1,18 @@
 """Tests for tools module."""
 
-import pytest
 import asyncio
 import importlib
 import sys
 import types
-from pathlib import Path
-import tempfile
 from unittest.mock import Mock, patch
+
+import pytest
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
+from manus_use.agents.browser_use_agent import BrowserUseAgent
+from manus_use.sandbox.exploit_sandbox import InterpreterNotFoundError
 from manus_use.tools import get_tools_by_names
-from manus_use.tools.python_repl import python_repl
+from manus_use.tools.browser_utils import prepare_evaluate_script
 from manus_use.tools.file_operations import (
     file_delete,
     file_list,
@@ -19,11 +20,9 @@ from manus_use.tools.file_operations import (
     file_read,
     file_write,
 )
-from manus_use.tools.browser_utils import prepare_evaluate_script
-from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
 from manus_use.tools.patches import use_browser_patch as use_browser_patch_module
-from manus_use.agents.browser_use_agent import BrowserUseAgent
-from manus_use.sandbox.exploit_sandbox import InterpreterNotFoundError
+from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
+from manus_use.tools.python_repl import python_repl
 
 
 def test_python_repl_interactive_does_not_reexecute_code_when_saving_state(monkeypatch, tmp_path):
@@ -388,10 +387,10 @@ def test_file_read_write(tmp_path):
     # Write a file
     test_file = tmp_path / "test.txt"
     content = "Hello, ManusUse!"
-    
+
     result = file_write(str(test_file), content)
     assert "Successfully wrote" in result
-    
+
     # Read the file
     read_content = file_read(str(test_file))
     assert read_content == content
@@ -403,14 +402,14 @@ def test_file_list(tmp_path):
     (tmp_path / "file1.txt").write_text("content1")
     (tmp_path / "file2.py").write_text("content2")
     (tmp_path / "subdir").mkdir()
-    
+
     # List all files
     files = file_list(str(tmp_path))
     assert len(files) == 3
     assert "file1.txt" in files
     assert "file2.py" in files
     assert "subdir" in files
-    
+
     # List with pattern
     py_files = file_list(str(tmp_path), "*.py")
     assert len(py_files) == 1
@@ -422,15 +421,15 @@ def test_file_delete(tmp_path):
     # Create and delete a file
     test_file = tmp_path / "delete_me.txt"
     test_file.write_text("delete this")
-    
+
     result = file_delete(str(test_file))
     assert "Deleted file" in result
     assert not test_file.exists()
-    
+
     # Delete empty directory
     test_dir = tmp_path / "empty_dir"
     test_dir.mkdir()
-    
+
     result = file_delete(str(test_dir))
     assert "Deleted empty directory" in result
     assert not test_dir.exists()
@@ -441,9 +440,9 @@ def test_file_move(tmp_path):
     # Create source file
     src = tmp_path / "source.txt"
     src.write_text("move me")
-    
+
     dst = tmp_path / "destination.txt"
-    
+
     result = file_move(str(src), str(dst))
     assert "Moved" in result
     assert not src.exists()
@@ -455,7 +454,7 @@ def test_get_tools_by_names():
     """Test tool retrieval by names."""
     tools = get_tools_by_names(["file_read", "file_write"])
     assert len(tools) == 2
-    
+
     # Check that we got the right tools
     tool_names = [t.__name__ for t in tools]
     assert any(name.endswith("file_read") for name in tool_names)
@@ -467,15 +466,15 @@ def test_file_errors():
     # Read non-existent file
     with pytest.raises(FileNotFoundError):
         file_read("/non/existent/file.txt")
-        
+
     # List non-existent directory
     with pytest.raises(FileNotFoundError):
         file_list("/non/existent/directory")
-        
+
     # Delete non-existent file
     with pytest.raises(FileNotFoundError):
         file_delete("/non/existent/file.txt")
-        
+
     # Move non-existent file
     with pytest.raises(FileNotFoundError):
         file_move("/non/existent/source.txt", "/tmp/dest.txt")
@@ -1146,6 +1145,8 @@ def test_create_lark_document_is_openclaw_defaults_false_when_not_set(monkeypatc
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.delenv("OPENCLAW", raising=False)
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t1",
@@ -1199,6 +1200,8 @@ def test_create_lark_document_is_openclaw_defaults_true_when_openclaw_env(monkey
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.setenv("OPENCLAW", "true")
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t2",
@@ -1230,6 +1233,8 @@ def test_create_lark_document_is_openclaw_explicit_override(monkeypatch):
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.delenv("OPENCLAW", raising=False)  # default would be False
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t3",


### PR DESCRIPTION
## What & Why

Three tests added in a recent PR were consistently failing on main:

- `test_create_lark_document_is_openclaw_defaults_false_when_not_set`
- `test_create_lark_document_is_openclaw_defaults_true_when_openclaw_env`
- `test_create_lark_document_is_openclaw_explicit_override`

Each test was designed to verify that the `is_openclaw` field in the tool input is correctly defaulted from the `OPENCLAW` environment variable. They correctly mock `requests.post`, but the `create_lark_document` function raises a `ValueError` earlier — before reaching the HTTP call — when `LARK_DOCUMENT_URL` or `LARK_API_TOKEN` are missing from the environment.

The fix is minimal: add `monkeypatch.setenv()` for both required env vars in each of the three tests so the function can proceed to the HTTP call and the `is_openclaw` assertion.

## Changes

- Added `monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")` to all 3 failing tests
- Added `monkeypatch.setenv("LARK_API_TOKEN", "test-token")` to all 3 failing tests
- No changes to production code

## Tests

All 149 tests now pass (previously 146 passed, 3 failed):

```
========================== 149 passed, 4 warnings in 5.80s ==========================
```

The 3 previously-failing tests now reach the `requests.post` mock and correctly assert on `tool_use["input"]["is_openclaw"]`.