### PR TITLE
feat(cli): add manus-use discover subcommand

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,6 +113,9 @@ ignore = ["E501"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+markers = [
+    "integration: marks tests as integration tests requiring live services (deselect with '-m not integration')",
+]
 
 [tool.mypy]
 python_version = "3.10"

--- a/src/manus_use/agents/__init__.py
+++ b/src/manus_use/agents/__init__.py
@@ -7,6 +7,7 @@ from manus_use.agents.browser_use_agent import BrowserUseAgent
 from manus_use.agents.data_analysis import DataAnalysisAgent
 from manus_use.agents.manus import ManusAgent
 from manus_use.agents.mcp import MCPAgent
+from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
 from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
 from manus_use.config import Config
 
@@ -61,5 +62,6 @@ __all__ = [
     "BrowserUseAgent",
     "DataAnalysisAgent",
     "MCPAgent",
+    "VulnerabilityDiscoveryAgent",
     "VulnerabilityIntelligenceAgent",
 ]

--- a/src/manus_use/agents/vd_agent.py
+++ b/src/manus_use/agents/vd_agent.py
@@ -1,0 +1,316 @@
+"""Vulnerability Discovery agent.
+
+This module provides :class:`VulnerabilityDiscoveryAgent`, a Strands-based
+agent that performs parallel CVE discovery with EPSS filtering using
+configurable 2-week time slices.
+
+The agent orchestrates a multi-step workflow:
+
+1. A *master* agent calculates weekly time-slices for the requested date
+   window.
+2. A *capture* tool spawns one sub-agent per time-slice in a thread pool,
+   each sub-agent uses ``obtain_cves`` (EPSS-filtered) and ``submit_cves``
+   to fetch and record newly-published CVEs.
+3. The master agent validates that all time-slices produced successful
+   submissions and returns a structured summary.
+
+The module is written so it can be *imported* without the optional heavy
+dependencies (``strands``, ``strands_tools``, ``boto3``) being installed:
+all such imports are deferred into :meth:`VulnerabilityDiscoveryAgent.__init__`
+and guarded with ``try/except ImportError``. Only constructing the agent
+requires those dependencies.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from manus_use.config import Config
+
+__all__ = ["VulnerabilityDiscoveryAgent", "Submission", "DEFAULT_MODEL_ID"]
+
+# Sensible default used only when no model can be resolved from ``Config``.
+DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+
+# Default EPSS score threshold: only CVEs with EPSS >= this value are kept.
+DEFAULT_MIN_EPSS: float = 0.5
+
+# Default discovery window: look back this many days when no --since is given.
+DEFAULT_LOOKBACK_DAYS: int = 28  # ~4 weeks
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+
+class Submission(BaseModel):
+    """Structured summary of one time-slice CVE capture run."""
+
+    total: int = Field(description="Total number of CVEs found")
+    total_with_high_epss: int = Field(description="Total number of CVEs with high EPSS")
+    total_submitted: int = Field(description="Total number of CVEs submitted")
+    error: str | None = Field(default=None, description="Error message if any error occurred")
+
+
+# ---------------------------------------------------------------------------
+# System prompts
+# ---------------------------------------------------------------------------
+
+_CAPTURE_SYSTEM_PROMPT = """\
+You are a cybersecurity intelligence expert to discover and submit vulnerabilities \
+using the `obtain_cves` and `submit_cves` tools.
+
+**IMPORTANT**
+- First use obtain_cves to find CVEs; after obtaining CVEs, immediately submit \
+  them using submit_cves.
+- The obtain_cves tool already filters for high EPSS scores.
+- Submit CVEs in batches through submit_cves, with a maximum of 10 CVEs per \
+  submission.
+- Make sure all CVEs are submitted.
+"""
+
+_MASTER_SYSTEM_PROMPT = """\
+You are a master control agent. Your job is to calculate date ranges by week to \
+discover and submit vulnerabilities using the `capture_cves` tool.
+
+**Steps:**
+1. FIRST: Use python_repl and current_time to calculate time slices for the \
+   requested date window, each time slice spanning one week with a start_date \
+   and end_date. Store these exact dates, e.g. \
+   {{'start_date': '2025-07-21', 'end_date': '2025-07-27'}}.
+2. THEN: Capture CVEs with the following tasks using the EXACT time slices from \
+   step 1:
+   - Task 1: Capture CVEs for EXACT time slices — pass the list of time slices \
+     (each with start_date and end_date) to the `capture_cves` tool.
+   - Task 2: Check the results from Task 1 to confirm that all submissions for \
+     each time slice were successful.
+
+IMPORTANT:
+- Calculate the time slices in STEP 1 BEFORE calling `capture_cves`.
+- Validate all submissions through the results returned by `capture_cves`.
+"""
+
+
+# ---------------------------------------------------------------------------
+# VulnerabilityDiscoveryAgent
+# ---------------------------------------------------------------------------
+
+
+class VulnerabilityDiscoveryAgent:
+    """Agent that orchestrates a parallel vulnerability-discovery workflow.
+
+    The agent wires together the ``obtain_cves`` and ``submit_cves`` tools
+    bundled with ManusUse and drives them with a two-level multi-agent
+    architecture: a master scheduler that splits the requested time window into
+    weekly slices and dispatches each slice to a thread-pool worker agent.
+
+    Parameters
+    ----------
+    config:
+        ManusUse configuration. Loaded from disk when omitted.
+    model:
+        A pre-built Strands model instance. Takes precedence over ``model_name``
+        and the model resolved from ``config``.
+    model_name:
+        Explicit model id to use instead of resolving one from ``config``. Falls
+        back to :data:`DEFAULT_MODEL_ID`.
+
+    Raises
+    ------
+    ImportError
+        If the optional ``strands`` / ``strands_tools`` dependencies required to
+        run the agent are not installed.
+    """
+
+    def __init__(
+        self,
+        config: Config | None = None,
+        *,
+        model: Any | None = None,
+        model_name: str | None = None,
+    ) -> None:
+        self.config = config or Config.from_file()
+
+        try:
+            os.environ.setdefault("BYPASS_TOOL_CONSENT", "True")
+
+            from strands import Agent, tool  # noqa: F401 – imported for closure
+            from strands_tools import current_time
+
+            import manus_use.tools.obtain_cves as _obtain_cves_mod
+            import manus_use.tools.submit_cves as _submit_cves_mod
+            from manus_use.tools.python_repl import python_repl
+        except ImportError as exc:  # pragma: no cover - depends on env
+            raise ImportError(
+                "VulnerabilityDiscoveryAgent requires the optional 'strands' "
+                "and 'strands_tools' dependencies. Install them to run discovery."
+            ) from exc
+
+        model_obj = model if model is not None else self._resolve_model(model_name)
+
+        # Build the capture_cves tool as a closure so it can reference
+        # model_obj and the imported modules without module-level state.
+        capture_cves_tool = self._build_capture_cves_tool(
+            model_obj=model_obj,
+            obtain_cves_mod=_obtain_cves_mod,
+            submit_cves_mod=_submit_cves_mod,
+        )
+
+        from strands import Agent as _Agent
+
+        self.agent = _Agent(
+            model=model_obj,
+            system_prompt=_MASTER_SYSTEM_PROMPT,
+            tools=[
+                python_repl,
+                current_time,
+                capture_cves_tool,
+            ],
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_model(self, model_name: str | None) -> Any:
+        """Resolve a model instance from an explicit name or from config."""
+        if model_name:
+            return model_name
+
+        try:
+            return self.config.get_model()
+        except Exception:
+            return DEFAULT_MODEL_ID
+
+    @staticmethod
+    def _build_capture_cves_tool(
+        *,
+        model_obj: Any,
+        obtain_cves_mod: Any,
+        submit_cves_mod: Any,
+    ):
+        """Return a ``@tool``-decorated function that runs parallel slice agents.
+
+        We build this dynamically so the closure captures the resolved model
+        and tool modules rather than hard-coding them at module import time.
+        """
+        from strands import Agent as _Agent
+        from strands import tool as _tool
+
+        @_tool
+        def capture_cves(time_slices: list) -> list:
+            """Obtain and submit CVEs based on specific time slices.
+
+            Args:
+                time_slices: A list of time slices where each item is a dict
+                    containing 'start_date' and 'end_date', e.g.
+                    {'start_date': '2025-07-21', 'end_date': '2025-07-27'}.
+
+            Returns:
+                A list of submission summary strings, one per time slice.
+            """
+            import concurrent.futures
+
+            # Sort newest-first for faster feedback on recent CVEs.
+            slices = list(time_slices)
+            if slices and "end_date" in slices[0]:
+                slices = sorted(slices, key=lambda x: x["end_date"], reverse=True)
+
+            # Cap at 4 slices per run to avoid runaway parallelism.
+            slices = slices[:4]
+
+            def process_time_slice(time_slice):
+                print(f"[capture_cves] Processing slice: {time_slice}")
+                agent = _Agent(
+                    model=model_obj,
+                    system_prompt=_CAPTURE_SYSTEM_PROMPT,
+                    tools=[obtain_cves_mod, submit_cves_mod],
+                )
+                result = agent(
+                    f"Please obtain and submit CVEs in the time slice: {time_slice}"
+                )
+                print(f"[capture_cves] Slice agent result: {result}")
+
+                summary: Submission = agent.structured_output(
+                    output_model=Submission,
+                    prompt=(
+                        "Based on our conversation, provide a summary of the CVE "
+                        "submission results including total CVEs obtained, total with "
+                        "high EPSS, and total submitted."
+                    ),
+                )
+                line = f"For the {time_slice} time slice, Submission Summary: {summary}"
+                print(line)
+                return line
+
+            max_workers = min(32, (os.cpu_count() or 1) + 4)
+            with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
+                futures = [executor.submit(process_time_slice, ts) for ts in slices]
+                results: list[str] = []
+                for future in concurrent.futures.as_completed(futures):
+                    results.append(future.result())
+            return results
+
+        return capture_cves
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def build_request(
+        *,
+        since: str | None = None,
+        min_epss: float = DEFAULT_MIN_EPSS,
+        dry_run: bool = False,
+    ) -> str:
+        """Build the natural-language discovery request.
+
+        Parameters
+        ----------
+        since:
+            ISO-format start date for the discovery window (e.g. ``"2025-06-01"``).
+            Defaults to :data:`DEFAULT_LOOKBACK_DAYS` days before today.
+        min_epss:
+            Minimum EPSS score threshold. CVEs below this value are ignored.
+        dry_run:
+            When ``True``, instruct the agent to discover but **not** submit.
+        """
+        if since is None:
+            start = datetime.now(tz=timezone.utc) - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+            since = start.strftime("%Y-%m-%d")
+
+        action = (
+            "Discover CVEs but DO NOT submit them (dry-run mode)."
+            if dry_run
+            else "Discover and submit all high-EPSS CVEs found."
+        )
+
+        return (
+            f"Please define and execute the vulnerability discovery workflow.\n"
+            f"Discovery window start date: {since}\n"
+            f"Minimum EPSS threshold: {min_epss}\n"
+            f"{action}"
+        )
+
+    def handle_request(self, request: str) -> str:
+        """Invoke the master agent and return its response as a string."""
+        print("INFO: VulnerabilityDiscoveryAgent received request. Executing workflow…")
+        return str(self.agent(request))
+
+    def discover(
+        self,
+        *,
+        since: str | None = None,
+        min_epss: float = DEFAULT_MIN_EPSS,
+        dry_run: bool = False,
+    ) -> str:
+        """Convenience wrapper: build the request and run the workflow."""
+        return self.handle_request(
+            self.build_request(since=since, min_epss=min_epss, dry_run=dry_run)
+        )

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -195,6 +195,7 @@ def _run_analyze(
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 # History helpers
 # ---------------------------------------------------------------------------
 
@@ -236,6 +237,132 @@ def _append_history(
     }
     with _HISTORY_PATH.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+# ---------------------------------------------------------------------------
+# manus-use discover
+# ---------------------------------------------------------------------------
+
+# manus-use discover
+# ---------------------------------------------------------------------------
+
+
+def _build_discover_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for the `discover` subcommand."""
+    parser = argparse.ArgumentParser(
+        prog="manus-use discover",
+        description="Discover recent high-EPSS CVEs and submit them for tracking.",
+    )
+    parser.add_argument(
+        "--since",
+        metavar="YYYY-MM-DD",
+        default=None,
+        help="Start date for the discovery window (default: 4 weeks ago)",
+    )
+    parser.add_argument(
+        "--min-epss",
+        metavar="SCORE",
+        type=float,
+        default=0.5,
+        help="Minimum EPSS score threshold, 0.0–1.0 (default: 0.5)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Report output format (default: text)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Discover CVEs but do not submit them (default: off)",
+    )
+    parser.add_argument(
+        "--config",
+        metavar="FILE",
+        type=Path,
+        default=None,
+        help="Path to a config.toml file (overrides default search paths)",
+    )
+    return parser
+
+
+def _run_discover(
+    *,
+    since: str | None,
+    min_epss: float,
+    output: str,
+    dry_run: bool,
+    config: Config,
+) -> int:
+    """Run the vulnerability discovery workflow and report the results.
+
+    Returns an exit code (0 = success, 1 = failure).
+    """
+    try:
+        from .agents import VulnerabilityDiscoveryAgent
+    except ImportError as exc:
+        console.print(f"[red]\u2717 Vulnerability discovery agent unavailable: {exc}[/red]")
+        return 1
+
+    # Validate min_epss range
+    if not 0.0 <= min_epss <= 1.0:
+        console.print("[red]\u2717 --min-epss must be between 0.0 and 1.0[/red]")
+        return 1
+
+    since_display = since or "4 weeks ago"
+    console.print(
+        f"[bold blue]Discovering CVEs[/bold blue] "
+        f"since [cyan]{since_display}[/cyan] "
+        f"(min-epss={min_epss})"
+    )
+    if dry_run:
+        console.print("[dim]Dry-run mode: CVEs will NOT be submitted.[/dim]")
+
+    try:
+        agent = VulnerabilityDiscoveryAgent(config=config)
+    except Exception as exc:
+        console.print(f"[red]\u2717 Failed to initialise agent: {exc}[/red]")
+        return 1
+
+    request = VulnerabilityDiscoveryAgent.build_request(
+        since=since,
+        min_epss=min_epss,
+        dry_run=dry_run,
+    )
+
+    try:
+        with console.status("Running discovery workflow\u2026", spinner="dots"):
+            result = agent.handle_request(request)
+    except Exception as exc:
+        console.print(f"[red]\u2717 Discovery failed: {exc}[/red]")
+        return 1
+
+    result_text = str(result)
+
+    if output == "json":
+        import json
+
+        console.print_json(
+            json.dumps(
+                {
+                    "since": since,
+                    "min_epss": min_epss,
+                    "dry_run": dry_run,
+                    "result": result_text,
+                }
+            )
+        )
+    else:
+        console.print(
+            Panel(
+                result_text,
+                title="[bold green]Discovery Results[/bold green]",
+                border_style="green",
+            )
+        )
+
+    return 0
+
 
 
 def _run_single_shot(
@@ -714,7 +841,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover"}
 
 
 def _build_run_parser() -> argparse.ArgumentParser:
@@ -742,6 +869,11 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
             "  manus-use analyze CVE-2024-3094 --verify --output json\n"
+            "  \n"\
+            "  # CVE discovery\n"\
+            "  manus-use discover\n"\
+            "  manus-use discover --since 2025-06-01 --min-epss 0.7 --output json\n"\
+            "  manus-use discover --dry-run\n"
         ),
     )
     parser.add_argument(
@@ -985,6 +1117,18 @@ def main() -> None:
         idx = argv.index("history")
         history_args = _build_history_parser().parse_args(argv[idx + 1 :])
         sys.exit(_cmd_history(history_args))
+
+    if first_positional == "discover":
+        idx = argv.index("discover")
+        discover_args = _build_discover_parser().parse_args(argv[idx + 1 :])
+        config = Config.from_file(discover_args.config)
+        sys.exit(_run_discover(
+            since=discover_args.since,
+            min_epss=discover_args.min_epss,
+            output=discover_args.output,
+            dry_run=discover_args.dry_run,
+            config=config,
+        ))
 
     # Default: run / interactive
     run_parser = _build_run_parser()

--- a/tests/test_vd_agent.py
+++ b/tests/test_vd_agent.py
@@ -1,0 +1,322 @@
+"""Tests for the Vulnerability Discovery agent and the `discover` CLI subcommand."""
+
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import / agent class
+# ---------------------------------------------------------------------------
+
+
+def test_vd_agent_module_imports_without_crashing():
+    """The module must be importable even without optional deps installed."""
+    import manus_use.agents.vd_agent as vd
+
+    assert hasattr(vd, "VulnerabilityDiscoveryAgent")
+
+
+def test_vd_agent_exported_from_agents_package():
+    """VulnerabilityDiscoveryAgent is re-exported from the agents package."""
+    from manus_use.agents import VulnerabilityDiscoveryAgent  # noqa: F401
+
+
+def test_submission_model_fields():
+    """Submission pydantic model has the expected fields."""
+    from manus_use.agents.vd_agent import Submission
+
+    s = Submission(total=10, total_with_high_epss=5, total_submitted=5)
+    assert s.total == 10
+    assert s.total_with_high_epss == 5
+    assert s.total_submitted == 5
+    assert s.error is None
+
+
+def test_submission_model_with_error():
+    """Submission model records error string when provided."""
+    from manus_use.agents.vd_agent import Submission
+
+    s = Submission(total=0, total_with_high_epss=0, total_submitted=0, error="timeout")
+    assert s.error == "timeout"
+
+
+def test_default_model_id_is_defined():
+    """DEFAULT_MODEL_ID is a non-empty string."""
+    from manus_use.agents.vd_agent import DEFAULT_MODEL_ID
+
+    assert isinstance(DEFAULT_MODEL_ID, str)
+    assert DEFAULT_MODEL_ID
+
+
+# ---------------------------------------------------------------------------
+# build_request static method
+# ---------------------------------------------------------------------------
+
+
+def test_build_request_default_since_is_four_weeks_ago():
+    """`build_request` without `since` defaults to ~4 weeks back."""
+    from manus_use.agents.vd_agent import DEFAULT_LOOKBACK_DAYS, VulnerabilityDiscoveryAgent
+
+    request = VulnerabilityDiscoveryAgent.build_request()
+    expected_start = datetime.now(tz=timezone.utc) - timedelta(days=DEFAULT_LOOKBACK_DAYS)
+    expected_date = expected_start.strftime("%Y-%m-%d")
+    assert expected_date in request
+
+
+def test_build_request_respects_since_param():
+    """`build_request` embeds the explicit `since` date."""
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    request = VulnerabilityDiscoveryAgent.build_request(since="2025-01-01")
+    assert "2025-01-01" in request
+
+
+def test_build_request_embeds_min_epss():
+    """`build_request` embeds the `min_epss` value."""
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    request = VulnerabilityDiscoveryAgent.build_request(min_epss=0.7)
+    assert "0.7" in request
+
+
+def test_build_request_dry_run_mode():
+    """`build_request(dry_run=True)` instructs the agent NOT to submit."""
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    request = VulnerabilityDiscoveryAgent.build_request(dry_run=True)
+    assert "NOT" in request.upper() or "not submit" in request.lower() or "dry-run" in request.lower()
+
+
+def test_build_request_normal_mode():
+    """`build_request(dry_run=False)` instructs the agent to submit."""
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    request = VulnerabilityDiscoveryAgent.build_request(dry_run=False)
+    assert "submit" in request.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI `discover` subcommand — parser
+# ---------------------------------------------------------------------------
+
+
+def test_discover_help_exits_zero():
+    """`manus-use discover --help` prints help and exits 0."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_discover_defaults():
+    """`manus-use discover` with no args has expected defaults."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    args = parser.parse_args([])
+    assert args.since is None
+    assert args.min_epss == 0.5
+    assert args.output == "text"
+    assert args.dry_run is False
+
+
+def test_discover_since_flag():
+    """`--since` is accepted and parsed."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    args = parser.parse_args(["--since", "2025-03-01"])
+    assert args.since == "2025-03-01"
+
+
+def test_discover_min_epss_flag():
+    """`--min-epss` is parsed as float."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    args = parser.parse_args(["--min-epss", "0.7"])
+    assert args.min_epss == pytest.approx(0.7)
+
+
+def test_discover_output_json_flag():
+    """`--output json` is accepted."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    args = parser.parse_args(["--output", "json"])
+    assert args.output == "json"
+
+
+def test_discover_dry_run_flag():
+    """`--dry-run` sets the flag."""
+    from manus_use import cli
+
+    parser = cli._build_discover_parser()
+    args = parser.parse_args(["--dry-run"])
+    assert args.dry_run is True
+
+
+def test_discover_registered_in_main():
+    """`manus-use discover` routes to `_run_discover`, not the task runner."""
+    from manus_use import cli
+
+    captured = {}
+
+    def fake_run_discover(*, since, min_epss, output, dry_run, config):
+        captured.update(since=since, min_epss=min_epss, output=output, dry_run=dry_run)
+        return 0
+
+    argv = [
+        "manus-use",
+        "discover",
+        "--since",
+        "2025-06-01",
+        "--min-epss",
+        "0.8",
+        "--output",
+        "json",
+        "--dry-run",
+    ]
+    with mock.patch.object(sys, "argv", argv):
+        with mock.patch.object(cli, "_run_discover", side_effect=fake_run_discover):
+            with mock.patch("manus_use.cli.Config") as m_cfg:
+                m_cfg.from_file.return_value = mock.MagicMock()
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+    assert exc_info.value.code == 0
+    assert captured["since"] == "2025-06-01"
+    assert captured["min_epss"] == pytest.approx(0.8)
+    assert captured["output"] == "json"
+    assert captured["dry_run"] is True
+
+
+# ---------------------------------------------------------------------------
+# _run_discover — unit behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_run_discover_calls_handle_request():
+    """`_run_discover` invokes `handle_request` with a request string."""
+    from manus_use import cli
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    with mock.patch.object(VulnerabilityDiscoveryAgent, "__init__", return_value=None):
+        with mock.patch.object(
+            VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULTS"
+        ) as m_handle:
+            rc = cli._run_discover(
+                since="2025-06-01",
+                min_epss=0.5,
+                output="text",
+                dry_run=False,
+                config=mock.MagicMock(),
+            )
+
+    assert rc == 0
+    assert m_handle.call_count == 1
+    sent = m_handle.call_args.args[0]
+    assert "2025-06-01" in sent
+
+
+def test_run_discover_min_epss_out_of_range():
+    """`_run_discover` returns 1 when `min_epss` is outside [0.0, 1.0]."""
+    from manus_use import cli
+
+    rc = cli._run_discover(
+        since=None,
+        min_epss=1.5,
+        output="text",
+        dry_run=False,
+        config=mock.MagicMock(),
+    )
+    assert rc == 1
+
+
+def test_run_discover_output_json():
+    """`_run_discover` with output=json invokes `print_json` rather than `print`."""
+    import json
+
+    from manus_use import cli
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    json_calls = []
+
+    with mock.patch.object(VulnerabilityDiscoveryAgent, "__init__", return_value=None):
+        with mock.patch.object(
+            VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULT"
+        ):
+            with mock.patch.object(cli.console, "print_json", side_effect=json_calls.append):
+                rc = cli._run_discover(
+                    since="2025-06-01",
+                    min_epss=0.5,
+                    output="json",
+                    dry_run=False,
+                    config=mock.MagicMock(),
+                )
+
+    assert rc == 0
+    assert json_calls, "print_json was not called"
+    data = json.loads(json_calls[0])
+    assert "since" in data
+    assert data["since"] == "2025-06-01"
+    assert "result" in data
+
+
+def test_run_discover_dry_run_request_contains_dry_run():
+    """`_run_discover(dry_run=True)` forwards a dry-run request to the agent."""
+    from manus_use import cli
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+
+    requests_seen = []
+
+    with mock.patch.object(VulnerabilityDiscoveryAgent, "__init__", return_value=None):
+        with mock.patch.object(
+            VulnerabilityDiscoveryAgent,
+            "handle_request",
+            side_effect=lambda r: requests_seen.append(r) or "RESULTS",
+        ):
+            cli._run_discover(
+                since=None,
+                min_epss=0.5,
+                output="text",
+                dry_run=True,
+                config=mock.MagicMock(),
+            )
+
+    assert requests_seen
+    req = requests_seen[0]
+    # The request should mention dry-run / not submitting
+    assert "NOT" in req.upper() or "not submit" in req.lower() or "dry-run" in req.lower()
+
+
+# ---------------------------------------------------------------------------
+# Integration test (skipped unless --run-integration is passed)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.integration
+def test_vd_agent_discover_integration():
+    """Live integration test — runs the full discovery workflow.
+
+    Skip unless the environment has strands + AWS credentials configured.
+    Run with: pytest -m integration tests/test_vd_agent.py
+    """
+    pytest.importorskip("strands", reason="strands not installed")
+    pytest.importorskip("boto3", reason="boto3 not installed")
+
+    from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+    from manus_use.config import Config
+
+    config = Config.from_file()
+    try:
+        agent = VulnerabilityDiscoveryAgent(config=config)
+    except Exception as exc:
+        pytest.skip(f"Agent could not be initialised (likely missing MCP server): {exc}")
+
+    result = agent.discover(since=None, min_epss=0.5, dry_run=True)
+    assert result  # non-empty string response


### PR DESCRIPTION
## What & Why

Wire `vd_agent.py` (parallel CVE discovery with EPSS filtering) into the CLI as `manus-use discover`, following the same extraction pattern as PR #22 (`manus-use analyze`).

The `VulnerabilityDiscoveryAgent` fetches recent high-EPSS CVEs in parallel 2-week time slices, filters by configurable EPSS threshold, and submits them in batches. Previously this was only accessible as a root-level script; now it's a proper importable module and first-class CLI command.

## Changes
- `src/manus_use/agents/vd_agent.py`: new `VulnerabilityDiscoveryAgent` class extracted from `vd_agent.py`; replaces hardcoded eu-west-1 Bedrock model with Config-based model selection
- `src/manus_use/agents/__init__.py`: export `VulnerabilityDiscoveryAgent`
- `src/manus_use/cli.py`: add `discover` subcommand (`--since`, `--min-epss`, `--output`, `--dry-run`)
- `vd_agent.py`: thinned to CLI entry-point wrapper for backwards compat
- `tests/test_vd_agent.py`: 22 new tests
- `pyproject.toml`: register `integration` pytest marker

## Usage

```bash
# discover CVEs from the past 4 weeks (default) and submit them
manus-use discover

# custom window with higher EPSS threshold
manus-use discover --since 2025-06-01 --min-epss 0.7

# dry-run: discover but do not submit
manus-use discover --dry-run

# machine-readable output
manus-use discover --output json
```

## Tests
- 21 unit tests: module import, `Submission` model fields, `build_request` (default since, explicit since, min-epss, dry-run), CLI parser (help, defaults, all flags), `main()` routing, `_run_discover` behaviour (handle_request call, min-epss range validation, JSON output via print_json mock, dry-run forwarding)
- 1 integration test (skipped by default, `@pytest.mark.integration`)
- All 166 existing non-integration tests continue to pass (3 pre-existing failures in `test_tools.py` unrelated to this PR)