### PR TITLE
feat(cli): add --format json output and manus-use history subcommand

### DIFF
--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1,6 +1,8 @@
 """Command-line interface for ManusUse."""
 
 import argparse
+import datetime
+import json
 import os
 import re
 import shutil
@@ -192,6 +194,50 @@ def _run_analyze(
     return 0
 
 
+# ---------------------------------------------------------------------------
+# History helpers
+# ---------------------------------------------------------------------------
+
+_HISTORY_PATH = Path.home() / ".manus-use" / "history.jsonl"
+
+
+def _append_history(
+    task: str,
+    result: str,
+    *,
+    agent_type: str,
+    mode: str,
+    success: bool,
+    format: str = "text",
+) -> None:
+    """Append a single-shot run record to the history log.
+
+    The log lives at ``~/.manus-use/history.jsonl`` (one JSON object per line)
+    so it can be streamed/grepped without loading the whole file.
+
+    Each record has:
+    - ``timestamp``: ISO-8601 UTC timestamp
+    - ``task``: the user's task string
+    - ``agent``: agent type used
+    - ``mode``: execution mode (auto/single/multi)
+    - ``format``: output format requested
+    - ``success``: boolean
+    - ``result``: the result text (or error message)
+    """
+    _HISTORY_PATH.parent.mkdir(parents=True, exist_ok=True)
+    record = {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "task": task,
+        "agent": agent_type,
+        "mode": mode,
+        "format": format,
+        "success": success,
+        "result": result,
+    }
+    with _HISTORY_PATH.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
 def _run_single_shot(
     task: str,
     *,
@@ -199,6 +245,8 @@ def _run_single_shot(
     agent_type: str,
     show_plan: bool,
     output: Path | None,
+    fmt: str,
+    no_history: bool,
     config: Config,
 ) -> int:
     """Execute a single task non-interactively and exit.
@@ -225,28 +273,63 @@ def _run_single_shot(
             transient=True,
         ) as progress:
             _ptask = progress.add_task("Running workflow…", total=None)
-            result = orchestrator.run(task)
+            workflow_result = orchestrator.run(task)
             progress.update(_ptask, completed=True)
 
-        if not result.success:
+        if not workflow_result.success:
+            error_msg = f"Task failed: {workflow_result.error}"
             console.print(Panel(
-                f"Task failed: {result.error}",
+                error_msg,
                 title="[bold red]Error[/bold red]",
                 border_style="red",
             ))
+            if not no_history:
+                _append_history(
+                    task, error_msg,
+                    agent_type=agent_type, mode=mode, success=False, format=fmt,
+                )
             return 1
-        result_text = result.output
+        result_text = workflow_result.output
     else:
         with console.status("Running…", spinner="dots"):
             response = agent(task)
         result_text = str(response)
 
-    console.print(Panel(result_text, title="[bold green]Result[/bold green]", border_style="green"))
+    # ------------------------------------------------------------------
+    # Output formatting
+    # ------------------------------------------------------------------
+    if fmt == "json":
+        payload = json.dumps(
+            {
+                "task": task,
+                "agent": agent_type,
+                "mode": "multi" if use_multi_agent else "single",
+                "result": result_text,
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        # Print raw JSON to stdout so it can be piped to other tools.
+        # Rich's print_json adds colours that break pipe consumers; use sys.stdout.
+        sys.stdout.write(payload + "\n")
+    else:
+        console.print(
+            Panel(result_text, title="[bold green]Result[/bold green]", border_style="green")
+        )
 
     if output is not None:
         output.parent.mkdir(parents=True, exist_ok=True)
-        output.write_text(result_text, encoding="utf-8")
+        if fmt == "json":
+            output.write_text(payload, encoding="utf-8")
+        else:
+            output.write_text(result_text, encoding="utf-8")
         console.print(f"[dim]Output saved to {output}[/dim]")
+
+    if not no_history:
+        _append_history(
+            task, result_text,
+            agent_type=agent_type, mode=mode, success=True, format=fmt,
+        )
 
     return 0
 
@@ -631,7 +714,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history"}
 
 
 def _build_run_parser() -> argparse.ArgumentParser:
@@ -645,13 +728,16 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # Single-shot (non-interactive)\n"
             "  manus-use \"Create a factorial function in Python\"\n"
             "  manus-use --agent browser \"Find the top 5 trending GitHub repos today\"\n"
-            "  manus-use --output result.txt \"Summarise the latest AI news\"\n\n"
+            "  manus-use --output result.txt \"Summarise the latest AI news\"\n"
+            "  manus-use --format json \"List prime numbers up to 50\"\n"
+            "  manus-use --format json \"task\" | jq .result\n\n"
             "  # Interactive REPL\n"
             "  manus-use\n"
             "  manus-use --mode multi\n\n"
             "  # Setup helpers\n"
             "  manus-use init           # create ~/.manus-use/config.toml interactively\n"
             "  manus-use doctor         # check packages, config, and API keys\n"
+            "  manus-use history        # show recent runs (use --help for filters)\n"
             "\n"
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
@@ -693,6 +779,19 @@ def _build_run_parser() -> argparse.ArgumentParser:
         type=Path,
         default=None,
         help="Save the result to FILE (single-shot mode only)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        dest="fmt",
+        help="Output format for single-shot mode: text (default) or json",
+    )
+    parser.add_argument(
+        "--no-history",
+        action="store_true",
+        dest="no_history",
+        help=f"Do not record this run in the history log ({_HISTORY_PATH})",
     )
     parser.add_argument(
         "--config",
@@ -741,6 +840,119 @@ def _build_doctor_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _build_history_parser() -> argparse.ArgumentParser:
+    """Build the `history` subcommand parser."""
+    parser = argparse.ArgumentParser(
+        prog="manus-use history",
+        description="Show past single-shot task runs recorded in the history log.",
+    )
+    parser.add_argument(
+        "--limit",
+        metavar="N",
+        type=int,
+        default=20,
+        help="Maximum number of entries to show (default: 20, 0 = all)",
+    )
+    parser.add_argument(
+        "--format",
+        choices=["text", "json"],
+        default="text",
+        dest="fmt",
+        help="Display format: text (default) or json",
+    )
+    parser.add_argument(
+        "--grep",
+        metavar="PATTERN",
+        default=None,
+        help="Filter entries whose task contains PATTERN (case-insensitive substring)",
+    )
+    parser.add_argument(
+        "--clear",
+        action="store_true",
+        help="Delete all history entries (irreversible)",
+    )
+    return parser
+
+
+def _cmd_history(args: argparse.Namespace) -> int:
+    """Display (or clear) the single-shot run history log."""
+    if args.clear:
+        if _HISTORY_PATH.exists():
+            _HISTORY_PATH.unlink()
+        console.print("[dim]History cleared.[/dim]")
+        return 0
+
+    if not _HISTORY_PATH.exists():
+        console.print(
+            "[dim]No history yet – run a task with [cyan]manus-use 'task...'[/cyan] first.[/dim]"
+        )
+        return 0
+
+    records = []
+    with _HISTORY_PATH.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue  # skip malformed lines
+
+    if args.grep:
+        pattern = args.grep.lower()
+        records = [r for r in records if pattern in r.get("task", "").lower()]
+
+    # Most-recent entries first, then apply limit.
+    records = list(reversed(records))
+    if args.limit > 0:
+        records = records[: args.limit]
+
+    if not records:
+        console.print("[dim]No matching history entries.[/dim]")
+        return 0
+
+    if args.fmt == "json":
+        sys.stdout.write(json.dumps(records, ensure_ascii=False, indent=2) + "\n")
+        return 0
+
+    # Text table
+    from rich.table import Table
+
+    table = Table(
+        title=f"Run history ({len(records)} entries)",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("#", style="dim", width=4)
+    table.add_column("Timestamp", style="cyan", width=22)
+    table.add_column("Agent", style="yellow", width=8)
+    table.add_column("Fmt", style="blue", width=5)
+    table.add_column("OK", width=3)
+    table.add_column("Task", style="white")
+
+    for i, rec in enumerate(records, 1):
+        ts = rec.get("timestamp", "-")
+        # Trim timezone indicator for brevity
+        ts = ts[:19].replace("T", " ")
+        ok = "[green]✓[/green]" if rec.get("success") else "[red]✗[/red]"
+        task_text = rec.get("task", "")[:80]
+        if len(rec.get("task", "")) > 80:
+            task_text += "…"
+        table.add_row(
+            str(i),
+            ts,
+            rec.get("agent", "-"),
+            rec.get("format", "text"),
+            ok,
+            task_text,
+        )
+
+    console.print(table)
+    console.print(f"[dim]History file: {_HISTORY_PATH}[/dim]")
+    return 0
+
+
 def main() -> None:
     """Main CLI entry point."""
     argv = sys.argv[1:]
@@ -769,6 +981,11 @@ def main() -> None:
             config=config,
         ))
 
+    if first_positional == "history":
+        idx = argv.index("history")
+        history_args = _build_history_parser().parse_args(argv[idx + 1 :])
+        sys.exit(_cmd_history(history_args))
+
     # Default: run / interactive
     run_parser = _build_run_parser()
     args = run_parser.parse_args(argv)
@@ -783,12 +1000,16 @@ def main() -> None:
             agent_type=args.agent_type,
             show_plan=args.show_plan,
             output=args.output,
+            fmt=args.fmt,
+            no_history=args.no_history,
             config=config,
         )
         sys.exit(exit_code)
     else:
         if args.output is not None:
             run_parser.error("--output requires a task argument")
+        if args.fmt != "text":
+            run_parser.error("--format requires a task argument")
         _run_interactive(
             mode=args.mode,
             agent_type=args.agent_type,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,7 @@
-"""Tests for CLI single-shot mode, --version, --agent, and --output flags."""
+"""Tests for CLI single-shot mode, --version, --agent, --output, --format, and history flags."""
 
+import json
 import sys
-from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -21,12 +21,14 @@ def _invoke_main(argv, *, patch_single_shot=True, single_shot_rc=0):
 
     captured = {}
 
-    def fake_single_shot(task, *, mode, agent_type, show_plan, output, config):
+    def fake_single_shot(task, *, mode, agent_type, show_plan, output, fmt, no_history, config):
         captured["task"] = task
         captured["mode"] = mode
         captured["agent_type"] = agent_type
         captured["show_plan"] = show_plan
         captured["output"] = output
+        captured["fmt"] = fmt
+        captured["no_history"] = no_history
         return single_shot_rc
 
     with mock.patch.object(sys, "argv", ["manus-use"] + argv):
@@ -50,7 +52,6 @@ def _invoke_main(argv, *, patch_single_shot=True, single_shot_rc=0):
 
 def test_version_flag():
     """--version prints version string and exits 0."""
-    from manus_use import __version__
     from manus_use import cli
 
     with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
@@ -153,7 +154,7 @@ def test_output_without_task_is_error():
 def test_run_single_shot_writes_output_file(tmp_path):
     """_run_single_shot saves result text to the specified output path."""
     from manus_use import cli
-    from manus_use.config import Config, LLMConfig
+    from manus_use.config import Config
 
     out_file = tmp_path / "out.txt"
     fake_config = mock.MagicMock(spec=Config)
@@ -162,14 +163,17 @@ def test_run_single_shot_writes_output_file(tmp_path):
     fake_agent.return_value = "hello world"
 
     with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
-        rc = cli._run_single_shot(
-            "say hello",
-            mode="single",
-            agent_type="manus",
-            show_plan=False,
-            output=out_file,
-            config=fake_config,
-        )
+        with mock.patch.object(cli, "_append_history"):
+            rc = cli._run_single_shot(
+                "say hello",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=out_file,
+                fmt="text",
+                no_history=False,
+                config=fake_config,
+            )
 
     assert rc == 0
     assert out_file.read_text(encoding="utf-8") == "hello world"
@@ -185,15 +189,417 @@ def test_run_single_shot_no_output_file(tmp_path):
     fake_agent.return_value = "result"
 
     with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
-        rc = cli._run_single_shot(
-            "task",
-            mode="single",
-            agent_type="manus",
-            show_plan=False,
-            output=None,
-            config=fake_config,
-        )
+        with mock.patch.object(cli, "_append_history"):
+            rc = cli._run_single_shot(
+                "task",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=None,
+                fmt="text",
+                no_history=False,
+                config=fake_config,
+            )
 
     assert rc == 0
     # No files should have been written in tmp_path
     assert list(tmp_path.iterdir()) == []
+
+
+# ---------------------------------------------------------------------------
+# --format flag (CLI parsing)
+# ---------------------------------------------------------------------------
+
+def test_format_default_is_text():
+    """fmt defaults to 'text' when --format is not passed."""
+    captured = _invoke_main(["some task"])
+    assert captured["fmt"] == "text"
+
+
+def test_format_json_flag():
+    """--format json is forwarded to _run_single_shot."""
+    captured = _invoke_main(["some task", "--format", "json"])
+    assert captured["fmt"] == "json"
+
+
+def test_format_flag_rejected_without_task():
+    """--format json without a task argument exits non-zero."""
+    captured = _invoke_main(["--format", "json"])
+    assert captured.get("exit_code", 0) != 0
+
+
+def test_no_history_default_false():
+    """--no-history defaults to False."""
+    captured = _invoke_main(["some task"])
+    assert captured["no_history"] is False
+
+
+def test_no_history_flag():
+    """--no-history is forwarded to _run_single_shot."""
+    captured = _invoke_main(["some task", "--no-history"])
+    assert captured["no_history"] is True
+
+
+# ---------------------------------------------------------------------------
+# --format json in _run_single_shot (output to stdout/file)
+# ---------------------------------------------------------------------------
+
+def test_run_single_shot_json_format_stdout(tmp_path, capsys):
+    """--format json writes a valid JSON object to stdout."""
+    from manus_use import cli
+    from manus_use.config import Config
+
+    fake_config = mock.MagicMock(spec=Config)
+    fake_agent = mock.MagicMock()
+    fake_agent.return_value = "42 is the answer"
+
+    with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
+        with mock.patch.object(cli, "_append_history"):
+            rc = cli._run_single_shot(
+                "what is 6 × 7",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=None,
+                fmt="json",
+                no_history=False,
+                config=fake_config,
+            )
+
+    assert rc == 0
+    captured_stdout = capsys.readouterr().out
+    data = json.loads(captured_stdout)
+    assert data["task"] == "what is 6 × 7"
+    assert data["result"] == "42 is the answer"
+    assert data["agent"] == "manus"
+    assert "mode" in data
+
+
+def test_run_single_shot_json_format_writes_json_to_file(tmp_path):
+    """--format json + --output FILE writes valid JSON to the file."""
+    from manus_use import cli
+    from manus_use.config import Config
+
+    out_file = tmp_path / "result.json"
+    fake_config = mock.MagicMock(spec=Config)
+    fake_agent = mock.MagicMock()
+    fake_agent.return_value = "some answer"
+
+    with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
+        with mock.patch.object(cli, "_append_history"):
+            rc = cli._run_single_shot(
+                "do something",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=out_file,
+                fmt="json",
+                no_history=False,
+                config=fake_config,
+            )
+
+    assert rc == 0
+    data = json.loads(out_file.read_text(encoding="utf-8"))
+    assert data["result"] == "some answer"
+
+
+# ---------------------------------------------------------------------------
+# _append_history
+# ---------------------------------------------------------------------------
+
+def test_append_history_creates_file(tmp_path):
+    """_append_history creates the history file and writes a valid JSON record."""
+    from manus_use import cli
+
+    hist_path = tmp_path / ".manus-use" / "history.jsonl"
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        cli._append_history(
+            "my task",
+            "my result",
+            agent_type="manus",
+            mode="single",
+            success=True,
+            format="text",
+        )
+
+    assert hist_path.exists()
+    record = json.loads(hist_path.read_text(encoding="utf-8").strip())
+    assert record["task"] == "my task"
+    assert record["result"] == "my result"
+    assert record["agent"] == "manus"
+    assert record["mode"] == "single"
+    assert record["success"] is True
+    assert record["format"] == "text"
+    assert "timestamp" in record
+
+
+def test_append_history_appends_multiple(tmp_path):
+    """Multiple calls to _append_history write one record per line."""
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        for i in range(3):
+            cli._append_history(
+                f"task {i}",
+                f"result {i}",
+                agent_type="manus",
+                mode="single",
+                success=True,
+                format="text",
+            )
+
+    lines = [line for line in hist_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(lines) == 3
+    records = [json.loads(line) for line in lines]
+    assert records[0]["task"] == "task 0"
+    assert records[2]["task"] == "task 2"
+
+
+def test_no_history_flag_skips_append(tmp_path):
+    """--no-history True prevents _append_history from being called."""
+    from manus_use import cli
+    from manus_use.config import Config
+
+    fake_config = mock.MagicMock(spec=Config)
+    fake_agent = mock.MagicMock()
+    fake_agent.return_value = "result"
+
+    with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
+        with mock.patch.object(cli, "_append_history") as m_hist:
+            cli._run_single_shot(
+                "task",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=None,
+                fmt="text",
+                no_history=True,
+                config=fake_config,
+            )
+
+    m_hist.assert_not_called()
+
+
+def test_history_flag_calls_append(tmp_path):
+    """When no_history=False, _append_history is called after success."""
+    from manus_use import cli
+    from manus_use.config import Config
+
+    fake_config = mock.MagicMock(spec=Config)
+    fake_agent = mock.MagicMock()
+    fake_agent.return_value = "result"
+
+    with mock.patch.object(cli, "_make_agent", return_value=fake_agent):
+        with mock.patch.object(cli, "_append_history") as m_hist:
+            cli._run_single_shot(
+                "task",
+                mode="single",
+                agent_type="manus",
+                show_plan=False,
+                output=None,
+                fmt="text",
+                no_history=False,
+                config=fake_config,
+            )
+
+    m_hist.assert_called_once()
+    call_kwargs = m_hist.call_args
+    assert call_kwargs.kwargs["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# manus-use history subcommand
+# ---------------------------------------------------------------------------
+
+def _invoke_history(argv):
+    """Call cli.main() with history subcommand argv."""
+    from manus_use import cli
+
+    captured = {}
+    with mock.patch.object(sys, "argv", ["manus-use", "history"] + argv):
+        with mock.patch.object(cli, "_cmd_history") as m_hist:
+            m_hist.return_value = 0
+            try:
+                cli.main()
+            except SystemExit as exc:
+                captured["exit_code"] = exc.code
+    captured["_cmd_history"] = m_hist
+    return captured
+
+
+def test_history_subcommand_dispatches():
+    """manus-use history dispatches to _cmd_history."""
+    captured = _invoke_history([])
+    assert captured["_cmd_history"].called
+
+
+def test_cmd_history_no_file(tmp_path):
+    """_cmd_history prints a friendly message when no history file exists."""
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    args = mock.MagicMock()
+    args.clear = False
+    args.limit = 20
+    args.fmt = "text"
+    args.grep = None
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+
+
+def test_cmd_history_shows_records(tmp_path):
+    """_cmd_history reads and displays records from the history file."""
+    import datetime
+
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    for i in range(3):
+        record = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "task": f"task {i}",
+            "agent": "manus",
+            "mode": "single",
+            "format": "text",
+            "success": True,
+            "result": f"result {i}",
+        }
+        with hist_path.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    args = mock.MagicMock()
+    args.clear = False
+    args.limit = 20
+    args.fmt = "text"
+    args.grep = None
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+
+
+def test_cmd_history_json_format(tmp_path, capsys):
+    """_cmd_history --format json writes JSON array to stdout."""
+    import datetime
+
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    record = {
+        "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+        "task": "test task",
+        "agent": "manus",
+        "mode": "single",
+        "format": "text",
+        "success": True,
+        "result": "test result",
+    }
+    with hist_path.open("w") as fh:
+        fh.write(json.dumps(record) + "\n")
+
+    args = mock.MagicMock()
+    args.clear = False
+    args.limit = 20
+    args.fmt = "json"
+    args.grep = None
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert isinstance(data, list)
+    assert data[0]["task"] == "test task"
+
+
+def test_cmd_history_grep_filter(tmp_path):
+    """_cmd_history --grep filters entries by task substring."""
+    import datetime
+
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    tasks = ["find CVE-2024", "list files", "analyze data"]
+    for task in tasks:
+        record = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "task": task,
+            "agent": "manus",
+            "mode": "single",
+            "format": "text",
+            "success": True,
+            "result": "ok",
+        }
+        with hist_path.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    args = mock.MagicMock()
+    args.clear = False
+    args.limit = 20
+    args.fmt = "json"
+    args.grep = "CVE"
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+
+
+def test_cmd_history_clear(tmp_path):
+    """_cmd_history --clear deletes the history file."""
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    hist_path.write_text('{"task":"x"}\n', encoding="utf-8")
+
+    args = mock.MagicMock()
+    args.clear = True
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+    assert not hist_path.exists()
+
+
+def test_cmd_history_limit(tmp_path, capsys):
+    """_cmd_history --limit N returns at most N entries."""
+    import datetime
+
+    from manus_use import cli
+
+    hist_path = tmp_path / "history.jsonl"
+    for i in range(10):
+        record = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "task": f"task {i}",
+            "agent": "manus",
+            "mode": "single",
+            "format": "text",
+            "success": True,
+            "result": f"r{i}",
+        }
+        with hist_path.open("a") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    args = mock.MagicMock()
+    args.clear = False
+    args.limit = 3
+    args.fmt = "json"
+    args.grep = None
+
+    with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
+        rc = cli._cmd_history(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert len(data) == 3

--- a/tests/test_init_doctor.py
+++ b/tests/test_init_doctor.py
@@ -315,7 +315,7 @@ class TestBackwardCompat:
 
         captured = {}
 
-        def fake_ss(task, *, mode, agent_type, show_plan, output, config):
+        def fake_ss(task, *, mode, agent_type, show_plan, output, fmt, no_history, config):
             captured["task"] = task
             return 0
 


### PR DESCRIPTION
## What & Why

Single-shot `manus-use "task..."` runs produce human-readable Rich terminal output — helpful for interactive use but unusable in scripts, CI pipelines, and tool compositions. Two complementary features address this:

**1. `--format json` flag**

```bash
manus-use --format json "List prime numbers up to 50"
# stdout: {"task":"...","agent":"manus","mode":"single","result":"..."}

manus-use --format json --output result.json "task"
# writes the same JSON object to result.json

# pipe into jq
manus-use --format json "Get latest CVEs" | jq .result
```

**2. Session history log + `manus-use history`**

Every single-shot run appends one JSONL record to `~/.manus-use/history.jsonl`:
```json
{"timestamp":"2026-06-25T00:01:00+00:00","task":"...","agent":"manus","mode":"single","format":"text","success":true,"result":"..."}
```

`manus-use history` shows past runs in a Rich table. Flags: `--limit N`, `--format json`, `--grep PATTERN`, `--clear`.

```bash
manus-use history                   # rich table, 20 most recent
manus-use history --grep CVE        # filter by substring
manus-use history --format json     # JSON array, pipeable
manus-use history --limit 5         # last 5 only
manus-use history --clear           # wipe the log
manus-use --no-history "task"       # skip logging for this run
```

## Changes

- `src/manus_use/cli.py`
  - `_append_history()` — writes one JSONL record to `~/.manus-use/history.jsonl`
  - `_run_single_shot()` — new `fmt` and `no_history` kwargs; JSON branch writes via `sys.stdout.write` (no Rich colours, safe for pipe consumers); text+file branches updated
  - `_build_history_parser()` + `_cmd_history()` — full `manus-use history` subcommand with limit/format/grep/clear
  - `_build_run_parser()` — `--format {text,json}` and `--no-history` flags
  - `main()` — `history` subcommand dispatch; validates `--format` requires a task; updated epilog with examples
  - `_HISTORY_PATH` constant (`~/.manus-use/history.jsonl`); `_SUBCOMMANDS` updated

- `tests/test_cli.py`
  - 18 new tests covering `--format` flag parsing, JSON stdout/file output, `_append_history` file creation and multi-append, `--no-history` skipping, `history` subcommand dispatch, `_cmd_history` text/json/grep/clear/limit paths
  - Updated `_invoke_main` helper and 2 existing tests for new `_run_single_shot` signature

- `tests/test_init_doctor.py`
  - Updated `TestBackwardCompat.test_single_shot_still_works` mock signature

## Tests

- `tests/test_cli.py` — 32 pass (14 existing + 18 new)
- Full suite: **164 pass**, 3 pre-existing failures in `test_tools.py` (covered by open PR #28)
- `ruff check src/manus_use/cli.py tests/test_cli.py tests/test_init_doctor.py` — clean