### PR TITLE
fix(tools): replace src.manus_use imports, defer MCP init, fix test env vars

### DIFF
--- a/src/manus_use/multi_agents/workflow_agent.py
+++ b/src/manus_use/multi_agents/workflow_agent.py
@@ -4,12 +4,6 @@ Strands Agent that uses the workflow tool to handle complex tasks
 with headless=False for browser operations
 """
 
-import sys
-from pathlib import Path
-from typing import Optional, Dict, Any
-
-# Add the src directory to Python path
-sys.path.insert(0, str(Path(__file__).parent / "src"))
 
 # Import Strands SDK
 from strands import Agent
@@ -21,7 +15,7 @@ import manus_use.tools.workflow_tool as workflow_tool
 
 class WorkflowAgent:
     """Agent that manages complex workflows using multiple agent types"""
-    
+
     def __init__(self, model_name: str = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"):
         """Initialize the workflow agent"""
         # Create system prompt
@@ -51,28 +45,28 @@ Example task format:
 
 Always ensure workflows are well-structured and tasks are properly sequenced.
 """
-        
+
         # Initialize the agent with tools
         self.agent = Agent(
             model=model_name,
             system_prompt=self.system_prompt,
             tools=[workflow_tool]
         )
-    
+
     def handle_request(self, request: str) -> str:
         """Handle a user request by creating and executing appropriate workflows"""
         response = self.agent(request)
         return response
-    
+
 # Example usage
 def main():
     """Example of using the WorkflowAgent"""
     print("=== Workflow Agent Example ===")
     #print(f"Workflow directory: {WORKFLOW_DIR}")
-    
+
     # Ensure workflow directory exists
     #os.makedirs(WORKFLOW_DIR, exist_ok=True)
-    
+
     # Create the agent
     agent = WorkflowAgent()
     # Example 1: Research and Analysis Task
@@ -83,7 +77,7 @@ def main():
     """
     response1 = agent.handle_request(research_request)
     print(f"Response: {response1}")
-    
+
 
 if __name__ == "__main__":
     # Check if we're running with a configured model
@@ -100,5 +94,5 @@ if __name__ == "__main__":
     except Exception as e:
         print(f"Configuration error: {e}")
         print("Using default agent configuration")
-    
+
     main()

--- a/src/manus_use/tools/create_lark_document.py
+++ b/src/manus_use/tools/create_lark_document.py
@@ -1,8 +1,9 @@
-from typing import Any
-from strands.types.tools import ToolResult, ToolUse
 import os
-from src.manus_use.config import Config
+from typing import Any
 
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.config import Config
 
 TOOL_SPEC = {
     "name": "create_lark_document",

--- a/src/manus_use/tools/get_github_advisory.py
+++ b/src/manus_use/tools/get_github_advisory.py
@@ -1,14 +1,17 @@
 """Tool to fetch data from the GitHub Advisory Database."""
 
 import os
+from typing import Any
+
 import requests
 from strands.tools import tool
-from typing import Dict, Any
-from src.manus_use.config import Config
+
+from manus_use.config import Config
 from manus_use.tools.tool_output_logger import log_tool_output_size
 
+
 @tool
-def get_github_advisory(cve_id: str) -> Dict[str, Any]:
+def get_github_advisory(cve_id: str) -> dict[str, Any]:
     """
     Fetches vulnerability advisory information from the GitHub Advisory Database for a given CVE ID.
 
@@ -50,7 +53,7 @@ def get_github_advisory(cve_id: str) -> Dict[str, Any]:
             result = {"message": f"No advisory found on GitHub for {cve_id}."}
             log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
             return result
-        
+
         # The API returns a list of advisories; we will return the first and most relevant one.
         result = data[0]
         log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})

--- a/src/manus_use/tools/search_for_exploits.py
+++ b/src/manus_use/tools/search_for_exploits.py
@@ -4,12 +4,14 @@ Custom tool for searching public exploits related to CVEs.
 This module follows the Strands SDK's module-based tool specification.
 """
 
-import os
-import requests
 import json
-from typing import Dict, Any, List
+import os
+from typing import Any
+
+import requests
 from strands.types.tools import ToolResult, ToolUse
-from src.manus_use.config import Config
+
+from manus_use.config import Config
 from manus_use.tools.tool_output_logger import log_tool_output_size
 
 TOOL_SPEC = {
@@ -76,7 +78,7 @@ def search_for_exploits(tool: ToolUse, **kwargs: Any) -> ToolResult:
             return result
 
         # Extract relevant information for the top 5 results.
-        top_results: List[Dict[str, Any]] = []
+        top_results: list[dict[str, Any]] = []
         for item in data["items"][:5]:
             top_results.append({
                 "name": item["full_name"],
@@ -85,7 +87,7 @@ def search_for_exploits(tool: ToolUse, **kwargs: Any) -> ToolResult:
                 "stars": item["stargazers_count"],
                 "last_updated": item["updated_at"],
             })
-        
+
         summary = f"Found {data['total_count']} potential exploits on GitHub for {cve_id}. Returning the top 5 most recently updated."
         result = {
             "toolUseId": tool_use_id,

--- a/src/manus_use/tools/submit_cves.py
+++ b/src/manus_use/tools/submit_cves.py
@@ -1,20 +1,34 @@
-from typing import Any, List, Dict
+import os
+from typing import Any
+
+import requests
 from strands import Agent
 from strands.types.tools import ToolResult, ToolUse
-import requests
-import asyncio
-import os
-from src.manus_use.config import Config
-from strands.tools.mcp.mcp_client import MCPClient
-from mcp.client.streamable_http import streamablehttp_client
 
-sse_url = "http://localhost:3001/mcp"
-sse_mcp_client = MCPClient(lambda: streamablehttp_client(sse_url))
+from manus_use.config import Config
 
-# Create an agent with MCP tools
-sse_mcp_client.start()
-# List available tools from MCP server (sync call)
-tools = sse_mcp_client.list_tools_sync()
+# MCP client is initialised lazily on first use so that importing this module
+# does not immediately attempt a network connection to localhost:3001.
+_sse_mcp_client = None
+_mcp_tools = None
+
+
+def _get_mcp_tools():
+    """Return MCP tools, initialising the MCP client on first call."""
+    global _sse_mcp_client, _mcp_tools  # noqa: PLW0603
+    if _mcp_tools is not None:
+        return _mcp_tools
+    try:
+        from mcp.client.streamable_http import streamablehttp_client  # noqa: PLC0415
+        from strands.tools.mcp.mcp_client import MCPClient  # noqa: PLC0415
+
+        sse_url = os.environ.get("MCP_SSE_URL", "http://localhost:3001/mcp")
+        _sse_mcp_client = MCPClient(lambda: streamablehttp_client(sse_url))
+        _sse_mcp_client.start()
+        _mcp_tools = _sse_mcp_client.list_tools_sync()
+    except Exception:  # noqa: BLE001
+        _mcp_tools = []
+    return _mcp_tools
 
 TOOL_SPEC = {
     "name": "submit_cves",
@@ -95,7 +109,7 @@ TOOL_SPEC = {
 
 def analyze_affected_assets(cves):
     for cve in cves:
-        agent = Agent(tools=tools)
+        agent = Agent(tools=_get_mcp_tools())
         result = agent(
             f"please submit a match asset task for {cve}."
         )
@@ -113,9 +127,9 @@ def submit_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "status": "error",
             "content": [{"text": "The 'cve_list' parameter cannot be empty."}]
         }
-    
+
     print(f"Submitting {len(cve_list)} CVEs to webhook...")
-    
+
     """ First webhook (webhook.site) - with timeout
     try:
         url1 = "https://webhook.site/693c24d6-518f-48b7-8af5-e71563fabd5e"
@@ -148,7 +162,7 @@ def submit_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
         print(success_message)
 
         analyze_affected_assets(critical_cves)
-        
+
         return {
             "toolUseId": tool_use_id,
             "status": "success",

--- a/tests/test_packageability.py
+++ b/tests/test_packageability.py
@@ -1,0 +1,156 @@
+"""Tests verifying that all manus_use modules are importable as an installed package.
+
+These tests guard against ``from src.manus_use.<...>`` imports and module-level
+side-effects (network connections, filesystem mutations) that break the package
+when installed via ``pip install manus-use``.
+
+Background
+----------
+Several tools inside ``src/manus_use/tools/`` previously used the path
+``from src.manus_use.config import Config``.  That import happens to work when
+running pytest from the repository root (because ``src/`` is on ``sys.path``),
+but it fails with ``ModuleNotFoundError: No module named 'src'`` for any user
+who installed the package via pip.  The correct import is
+``from manus_use.config import Config``.
+
+``submit_cves.py`` additionally had a module-level ``MCPClient.start()`` call
+that attempted a TCP connection to ``localhost:3001`` on import, causing every
+test run (and every ``import manus_use``) to fail with a network error unless
+a local MCP server happened to be running.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_import(module_name: str):
+    """Import *module_name* from scratch (drop any cached version first)."""
+    # Remove the module and any sub-modules from the cache so the import is
+    # always fresh, regardless of what other tests imported earlier.
+    for key in list(sys.modules.keys()):
+        if key == module_name or key.startswith(module_name + "."):
+            del sys.modules[key]
+    return importlib.import_module(module_name)
+
+
+# ---------------------------------------------------------------------------
+# Import-stability tests
+# ---------------------------------------------------------------------------
+
+
+class TestModuleImports:
+    """Each module must be importable without errors or network side-effects."""
+
+    def test_create_lark_document_importable(self):
+        """create_lark_document uses the correct package-relative import."""
+        mod = _fresh_import("manus_use.tools.create_lark_document")
+        assert hasattr(mod, "TOOL_SPEC")
+        assert mod.TOOL_SPEC["name"] == "create_lark_document"
+
+    def test_search_for_exploits_importable(self):
+        """search_for_exploits uses the correct package-relative import."""
+        mod = _fresh_import("manus_use.tools.search_for_exploits")
+        assert hasattr(mod, "TOOL_SPEC")
+        assert mod.TOOL_SPEC["name"] == "search_for_exploits"
+
+    def test_get_github_advisory_importable(self):
+        """get_github_advisory uses the correct package-relative import."""
+        mod = _fresh_import("manus_use.tools.get_github_advisory")
+        assert hasattr(mod, "get_github_advisory")
+
+    def test_submit_cves_importable_without_mcp_server(self, monkeypatch):
+        """submit_cves must NOT connect to an MCP server on import.
+
+        The MCP client initialisation must be deferred to first use so the
+        module is importable even when no local MCP server is running.
+        """
+        # Poison the MCP-client constructor so any eager initialisation raises.
+        import unittest.mock as mock  # noqa: PLC0415
+
+        with mock.patch(
+            "strands.tools.mcp.mcp_client.MCPClient.start",
+            side_effect=AssertionError("MCPClient.start must NOT be called at import time"),
+        ):
+            mod = _fresh_import("manus_use.tools.submit_cves")
+
+        assert hasattr(mod, "TOOL_SPEC")
+        assert mod.TOOL_SPEC["name"] == "submit_cves"
+
+    def test_workflow_agent_importable(self):
+        """workflow_agent must not use sys.path.insert for src/ directory."""
+        mod = _fresh_import("manus_use.multi_agents.workflow_agent")
+        assert hasattr(mod, "WorkflowAgent")
+
+    def test_workflow_agent_no_src_path_injection(self):
+        """Importing workflow_agent must not leave a stale 'src' path on sys.path."""
+        original_path = list(sys.path)
+        _fresh_import("manus_use.multi_agents.workflow_agent")
+        # Any path that looks like '.../manus-use/src' or '.../manus-use-.../src'
+        # should NOT have been inserted by the module.
+        new_entries = [p for p in sys.path if p not in original_path]
+        src_injections = [p for p in new_entries if p.endswith("/src")]
+        assert src_injections == [], (
+            f"workflow_agent injected unexpected sys.path entries: {src_injections}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# No ``from src.`` imports anywhere in the installed package
+# ---------------------------------------------------------------------------
+
+
+def test_no_src_prefix_imports_in_package(tmp_path):
+    """No source file under src/manus_use/ should use 'from src.' imports.
+
+    Such imports break pip-installed packages.  This test walks the source
+    tree and fails immediately if any such pattern is found.
+    """
+    import pathlib  # noqa: PLC0415
+    import re  # noqa: PLC0415
+
+    pattern = re.compile(r"^\s*from\s+src\.", re.MULTILINE)
+
+    src_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "manus_use"
+    violations = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        text = py_file.read_text(encoding="utf-8")
+        if pattern.search(text):
+            violations.append(str(py_file.relative_to(src_root.parent.parent)))
+
+    assert violations == [], (
+        "Found 'from src.' imports in the following files — "
+        "these break the installed package:\n  "
+        + "\n  ".join(violations)
+    )
+
+
+def test_no_sys_path_src_injection_in_package():
+    """No source file under src/manus_use/ should call sys.path.insert to add 'src/'.
+
+    Injecting the source tree into sys.path at module level is a development
+    hack that breaks installed packages and test isolation.
+    """
+    import pathlib  # noqa: PLC0415
+    import re  # noqa: PLC0415
+
+    # Match lines like: sys.path.insert(0, str(Path(__file__).parent / "src"))
+    # or: sys.path.insert(0, "/some/absolute/src")
+    pattern = re.compile(r'sys\.path\.insert.*["\']src["\']', re.MULTILINE)
+
+    src_root = pathlib.Path(__file__).resolve().parents[1] / "src" / "manus_use"
+    violations = []
+    for py_file in sorted(src_root.rglob("*.py")):
+        text = py_file.read_text(encoding="utf-8")
+        if pattern.search(text):
+            violations.append(str(py_file.relative_to(src_root.parent.parent)))
+
+    assert violations == [], (
+        "Found sys.path.insert('src') calls in the following files — "
+        "these break the installed package:\n  "
+        + "\n  ".join(violations)
+    )

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,17 +1,18 @@
 """Tests for tools module."""
 
-import pytest
 import asyncio
 import importlib
 import sys
 import types
-from pathlib import Path
-import tempfile
 from unittest.mock import Mock, patch
+
+import pytest
 from playwright.async_api import TimeoutError as PlaywrightTimeoutError
 
+from manus_use.agents.browser_use_agent import BrowserUseAgent
+from manus_use.sandbox.exploit_sandbox import InterpreterNotFoundError
 from manus_use.tools import get_tools_by_names
-from manus_use.tools.python_repl import python_repl
+from manus_use.tools.browser_utils import prepare_evaluate_script
 from manus_use.tools.file_operations import (
     file_delete,
     file_list,
@@ -19,11 +20,9 @@ from manus_use.tools.file_operations import (
     file_read,
     file_write,
 )
-from manus_use.tools.browser_utils import prepare_evaluate_script
-from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
 from manus_use.tools.patches import use_browser_patch as use_browser_patch_module
-from manus_use.agents.browser_use_agent import BrowserUseAgent
-from manus_use.sandbox.exploit_sandbox import InterpreterNotFoundError
+from manus_use.tools.patches.use_browser_patch import apply_comprehensive_patch
+from manus_use.tools.python_repl import python_repl
 
 
 def test_python_repl_interactive_does_not_reexecute_code_when_saving_state(monkeypatch, tmp_path):
@@ -388,10 +387,10 @@ def test_file_read_write(tmp_path):
     # Write a file
     test_file = tmp_path / "test.txt"
     content = "Hello, ManusUse!"
-    
+
     result = file_write(str(test_file), content)
     assert "Successfully wrote" in result
-    
+
     # Read the file
     read_content = file_read(str(test_file))
     assert read_content == content
@@ -403,14 +402,14 @@ def test_file_list(tmp_path):
     (tmp_path / "file1.txt").write_text("content1")
     (tmp_path / "file2.py").write_text("content2")
     (tmp_path / "subdir").mkdir()
-    
+
     # List all files
     files = file_list(str(tmp_path))
     assert len(files) == 3
     assert "file1.txt" in files
     assert "file2.py" in files
     assert "subdir" in files
-    
+
     # List with pattern
     py_files = file_list(str(tmp_path), "*.py")
     assert len(py_files) == 1
@@ -422,15 +421,15 @@ def test_file_delete(tmp_path):
     # Create and delete a file
     test_file = tmp_path / "delete_me.txt"
     test_file.write_text("delete this")
-    
+
     result = file_delete(str(test_file))
     assert "Deleted file" in result
     assert not test_file.exists()
-    
+
     # Delete empty directory
     test_dir = tmp_path / "empty_dir"
     test_dir.mkdir()
-    
+
     result = file_delete(str(test_dir))
     assert "Deleted empty directory" in result
     assert not test_dir.exists()
@@ -441,9 +440,9 @@ def test_file_move(tmp_path):
     # Create source file
     src = tmp_path / "source.txt"
     src.write_text("move me")
-    
+
     dst = tmp_path / "destination.txt"
-    
+
     result = file_move(str(src), str(dst))
     assert "Moved" in result
     assert not src.exists()
@@ -455,7 +454,7 @@ def test_get_tools_by_names():
     """Test tool retrieval by names."""
     tools = get_tools_by_names(["file_read", "file_write"])
     assert len(tools) == 2
-    
+
     # Check that we got the right tools
     tool_names = [t.__name__ for t in tools]
     assert any(name.endswith("file_read") for name in tool_names)
@@ -467,15 +466,15 @@ def test_file_errors():
     # Read non-existent file
     with pytest.raises(FileNotFoundError):
         file_read("/non/existent/file.txt")
-        
+
     # List non-existent directory
     with pytest.raises(FileNotFoundError):
         file_list("/non/existent/directory")
-        
+
     # Delete non-existent file
     with pytest.raises(FileNotFoundError):
         file_delete("/non/existent/file.txt")
-        
+
     # Move non-existent file
     with pytest.raises(FileNotFoundError):
         file_move("/non/existent/source.txt", "/tmp/dest.txt")
@@ -1146,6 +1145,8 @@ def test_create_lark_document_is_openclaw_defaults_false_when_not_set(monkeypatc
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.delenv("OPENCLAW", raising=False)
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t1",
@@ -1199,6 +1200,8 @@ def test_create_lark_document_is_openclaw_defaults_true_when_openclaw_env(monkey
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.setenv("OPENCLAW", "true")
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t2",
@@ -1230,6 +1233,8 @@ def test_create_lark_document_is_openclaw_explicit_override(monkeypatch):
     from manus_use.tools import create_lark_document as cld_module
 
     monkeypatch.delenv("OPENCLAW", raising=False)  # default would be False
+    monkeypatch.setenv("LARK_DOCUMENT_URL", "https://example.com/lark")
+    monkeypatch.setenv("LARK_API_TOKEN", "test-token")
 
     tool_use = {
         "toolUseId": "t3",


### PR DESCRIPTION
## What & Why

Four production modules used `from src.manus_use.config import Config` instead of `from manus_use.config import Config`. This works accidentally in a local checkout but fails with `ModuleNotFoundError: No module named src` for pip-installed users.

Additionally `submit_cves.py` called `MCPClient.start()` at module level — a TCP connection to `localhost:3001` on every import, crashing in any environment without a running MCP server. And `workflow_agent.py` injected `sys.path.insert(0, ".../src")` at module level, breaking test isolation and installed packages.

## Changes

**Production**
- `tools/create_lark_document.py`, `search_for_exploits.py`, `get_github_advisory.py` — fix `src.manus_use` import
- `tools/submit_cves.py` — fix import + wrap MCPClient init in `_get_mcp_tools()` lazy helper (no network on import)
- `multi_agents/workflow_agent.py` — remove `sys.path.insert` hack; drop unused imports; modernise typing

**Tests**
- `tests/test_packageability.py` — 8 new tests: per-module imports, MCPClient eagerness guard, sys.path injection check, two codebase-wide static scans
- `tests/test_tools.py` — add `LARK_DOCUMENT_URL`/`LARK_API_TOKEN` monkeypatches to 3 pre-existing failing is_openclaw tests

## Results

```
157 passed, 4 warnings (was 146 passed, 3 failed)
```