### PR TITLE
docs(readme): overhaul with CLI reference, badges, corrected API examples + 39 living-doc tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,38 @@
 # ManusUse
 
+[![PyPI version](https://img.shields.io/pypi/v/manus-use.svg)](https://pypi.org/project/manus-use/)
+[![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Tests](https://github.com/manus-use/manus-use/actions/workflows/test.yml/badge.svg)](https://github.com/manus-use/manus-use/actions)
+
 A powerful, extensible framework for building AI agents with comprehensive tool support, multi-agent orchestration, and advanced web automation capabilities.
 
 ## Overview
 
 ManusUse empowers developers to create sophisticated AI agents that can:
+
 - Execute code in secure Docker sandboxes
 - Automate web browsing and data extraction
 - Analyze data and generate visualizations
 - Coordinate multiple specialized agents for complex tasks
 - Integrate with various LLM providers seamlessly
+- Perform deep vulnerability intelligence analysis
 
 Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integrated with [browser-use](https://github.com/browser-use/browser-use), ManusUse provides a production-ready foundation for AI agent development.
 
-## Key Features
+## Table of Contents
 
-### 🤖 Multiple Agent Types
-- **ManusAgent**: General-purpose agent for file operations and code execution
-- **BrowserUseAgent**: Advanced web automation using natural language
-- **DataAnalysisAgent**: Specialized for data processing and visualization
-- **VulnerabilityIntelligenceAgent**: Deep CVE analysis with multi-source intelligence (`va_agent.py`)
-- **VulnerabilityDiscoveryAgent**: Automated vulnerability discovery and submission (`vd_agent.py`)
-- **MCPAgent**: Model Context Protocol integration for extended capabilities
-- **WorkflowAgent**: Complex task orchestration with dependency management
+- [Installation](#installation)
+- [Quick Start](#quick-start)
+- [CLI Reference](#cli-reference)
+- [Configuration](#configuration)
+- [Python API](#python-api)
+- [Security & Vulnerability Intelligence](#security--vulnerability-intelligence)
+- [Development](#development)
 
-### 🛠️ Rich Tool Ecosystem
-- File operations (read, write, edit, delete)
-- Code execution in Docker sandboxes
-- Web search and content retrieval
-- Browser automation (click, type, extract)
-- Data visualization (charts, plots, reports)
-- Security analysis tools (CVE checking, threat intelligence)
+---
 
-### 🔄 Multi-Agent Orchestration
-- Automatic task decomposition and routing
-- Parallel execution of independent tasks
-- Intelligent agent selection based on task requirements
-- Result aggregation and error handling
-
-### 🔌 Flexible Integration
-- Support for OpenAI, Anthropic, AWS Bedrock, Ollama
-- Model Context Protocol (MCP) compatibility
-- Extensible tool system
-- Configuration-driven architecture
-
-## Quick Start
-
-### Installation
+## Installation
 
 ```bash
 # Basic installation
@@ -56,214 +42,430 @@ pip install manus-use
 pip install manus-use[browser]
 playwright install chromium
 
-# Full installation with all features
+# Full installation with all optional features
 pip install manus-use[browser,search,visualization]
 ```
 
-### Basic Usage
+---
 
-```python
-from manus_use import ManusAgent
+## Quick Start
 
-# Create an agent
-agent = ManusAgent(model="gpt-4o")
+### 1. Initialize your configuration
 
-# Execute a task
-response = agent("Create a Python script that fetches weather data and saves it to a CSV file")
-print(response)
+```bash
+manus-use init
 ```
 
-### Browser Automation
+The interactive wizard creates `~/.manus-use/config.toml` with your LLM provider credentials.
 
-```python
-from manus_use.agents import BrowserUseAgent
+### 2. Check your environment
 
-# Create a browser agent
-browser_agent = BrowserUseAgent()
-
-# Automate web tasks
-result = browser_agent("Go to GitHub and find the top 5 trending Python repositories today")
+```bash
+manus-use doctor
 ```
 
-### Multi-Agent Workflows
+Verifies installed packages, configuration, and API key accessibility.
 
-```python
-from manus_use.multi_agents import WorkflowAgent
+### 3. Run your first task
 
-# Create a workflow agent
-workflow = WorkflowAgent()
+```bash
+# Single-shot (non-interactive)
+manus-use "Write a Python script that fetches the current Bitcoin price"
 
-# Execute a complex task with multiple agents
-result = workflow.handle_request("""
-    1. Search the web for recent AI research papers
-    2. Analyze the trends and create visualizations
-    3. Generate a comprehensive report with insights
-""")
+# Interactive REPL
+manus-use
 ```
+
+---
+
+## CLI Reference
+
+ManusUse ships a single `manus-use` entry point with several subcommands.
+
+### `manus-use [task]` — Run a task
+
+```bash
+# Single-shot task (prints result, then exits)
+manus-use "Create a factorial function in Python"
+
+# Use a specific agent type
+manus-use --agent browser "Find the top 5 trending GitHub repos today"
+
+# Force multi-agent orchestration
+manus-use --mode multi "Research quantum computing and create a presentation"
+
+# Save output to a file
+manus-use --output result.txt "Summarise the latest AI news"
+
+# JSON output for piping into other tools
+manus-use --format json "List the first 10 prime numbers" | jq .result
+
+# Interactive REPL (omit the task argument)
+manus-use
+manus-use --mode multi
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--mode {auto,single,multi}` | `auto` | Execution mode; `auto` detects task complexity |
+| `--agent {manus,browser,data,mcp}` | `manus` | Agent type for single-agent execution |
+| `--show-plan` | off | Print the multi-agent plan before running |
+| `--output FILE` | — | Write result to FILE (single-shot only) |
+| `--format {text,json}` | `text` | Output format; `json` is scriptable |
+| `--no-history` | off | Skip recording this run in the history log |
+| `--config FILE` | — | Override default config file search path |
+| `--version` | — | Print version and exit |
+
+### `manus-use init` — Configure credentials
+
+```bash
+manus-use init                       # write to ~/.manus-use/config.toml
+manus-use init --output ./my.toml   # write to a custom location
+manus-use init --force               # overwrite without prompting
+```
+
+### `manus-use doctor` — Diagnose your environment
+
+```bash
+manus-use doctor
+manus-use doctor --config ./custom.toml
+```
+
+Checks Python packages, config file validity, and whether API keys are accessible.
+
+### `manus-use analyze <CVE-ID>` — Vulnerability intelligence
+
+```bash
+# Deep CVE analysis (NVD · CISA KEV · OTX · PoC search · CWE · threat feeds)
+manus-use analyze CVE-2025-6554
+
+# With Docker-based exploit verification
+manus-use analyze CVE-2024-3094 --verify
+
+# Machine-readable output
+manus-use analyze CVE-2025-6554 --output json
+
+# Generate a Lark document report
+manus-use analyze CVE-2025-6554 --output lark
+```
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--verify` | off | Run exploit in a Docker sandbox to confirm exploitability |
+| `--output {text,json,lark}` | `text` | Report format |
+| `--config FILE` | — | Override config |
+
+### `manus-use history` — Browse past runs
+
+```bash
+manus-use history                        # last 20 runs
+manus-use history --limit 50             # last 50 runs
+manus-use history --grep "bitcoin"       # filter by task text
+manus-use history --format json | jq .   # all history as JSON
+manus-use history --clear                # delete all history
+```
+
+History is stored at `~/.manus-use/history.jsonl`.
+
+---
 
 ## Configuration
 
-Create a `config/config.toml` file:
+Create `~/.manus-use/config.toml` (or run `manus-use init`):
 
 ```toml
 [llm]
-provider = "openai"  # or "anthropic", "bedrock", "ollama"
-model = "gpt-4o"
-api_key = "your-api-key"  # or use environment variable
+provider = "bedrock"          # "openai" | "anthropic" | "bedrock" | "ollama"
+model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
 [sandbox]
 enabled = true
 docker_image = "python:3.12-slim"
 
 [tools]
-enabled = ["file_ops", "code_execute", "web_search", "browser"]
+enabled = ["file_ops", "code_execute", "web_search"]
+
+[agent]
+# "none" | "sliding_window" | "agentic" (model-managed, recommended for long tasks)
+context_manager = "agentic"
 ```
 
-See [config.example.toml](config/config.example.toml) for all available options.
+See [config/config.example.toml](config/config.example.toml) for all available options.
 
-## CLI Usage
+### Provider-specific examples
 
-ManusUse provides multiple CLI interfaces:
+**AWS Bedrock:**
+```toml
+[llm]
+provider = "bedrock"
+model = "us.anthropic.claude-sonnet-4-20250514-v1:0"
+# Uses ~/.aws/credentials or IAM role automatically
+```
+
+**OpenAI:**
+```toml
+[llm]
+provider = "openai"
+model = "gpt-4o"
+api_key = "sk-..."    # or set OPENAI_API_KEY env var
+```
+
+**Anthropic:**
+```toml
+[llm]
+provider = "anthropic"
+model = "claude-3-5-sonnet-20241022"
+api_key = "sk-ant-..."    # or set ANTHROPIC_API_KEY env var
+```
+
+**Ollama (local):**
+```toml
+[llm]
+provider = "ollama"
+model = "llama3.2"
+base_url = "http://localhost:11434"
+```
+
+---
+
+## Python API
+
+### Basic usage
+
+```python
+from manus_use import ManusAgent
+
+agent = ManusAgent()
+
+result = agent("Write a Python script that fetches weather data and saves it to CSV")
+print(result)
+```
+
+### Browser automation
+
+```python
+from manus_use.agents import BrowserUseAgent
+
+agent = BrowserUseAgent()
+result = agent("Go to GitHub and find the top 5 trending Python repositories today")
+print(result)
+```
+
+### Data analysis
+
+```python
+from manus_use.agents import DataAnalysisAgent
+
+agent = DataAnalysisAgent()
+result = agent("Load sales.csv, compute monthly revenue, and plot a bar chart")
+print(result)
+```
+
+### Multi-agent orchestration
+
+```python
+from manus_use.multi_agents import WorkflowAgent
+
+workflow = WorkflowAgent()
+result = workflow.handle_request("""
+    1. Search the web for recent AI research papers
+    2. Analyse the trends and create visualizations
+    3. Generate a comprehensive report with insights
+""")
+print(result)
+```
+
+### Vulnerability intelligence
+
+```python
+from manus_use.agents import VulnerabilityIntelligenceAgent
+from manus_use.config import Config
+
+config = Config.from_file()
+agent = VulnerabilityIntelligenceAgent(config=config)
+
+result = agent.handle_request("Analyse CVE-2025-6554 and create a comprehensive report")
+print(result)
+```
+
+### Custom configuration
+
+```python
+from manus_use import ManusAgent
+from manus_use.config import Config
+
+config = Config.from_file("path/to/config.toml")
+agent = ManusAgent(config=config)
+
+result = agent("Create a factorial function")
+print(result)
+```
+
+---
+
+## Security & Vulnerability Intelligence
+
+ManusUse includes a multi-source vulnerability intelligence pipeline accessible via the CLI or Python API.
+
+### How it works
+
+The `manus-use analyze` command runs an 8-step pipeline:
+
+1. **NVD + GitHub Advisory** — official CVE metadata, CVSS, CWE
+2. **CISA KEV** — known-exploited-vulnerabilities catalogue
+3. **AlienVault OTX** — threat intelligence pulses and IoCs
+4. **PoC discovery** — PoC Week trending digest, Trickest/CVE index, Exploit-DB, PacketStorm, GitHub
+5. **URL verification** — every candidate URL is fetched and validated
+6. **Static analysis** — code-level analysis of confirmed PoCs (network calls, payload patterns)
+7. **CWE correlation** — weakness classification and remediation hints
+8. **Report generation** — structured text, JSON, or Lark document output
+
+### Examples
 
 ```bash
-# Basic CLI
-manus-use "Create a factorial function in Python"
+# Analyse a CVE and print a structured text report
+manus-use analyze CVE-2024-3094
 
-# Enhanced CLI with rich UI
-manus-use-enhanced
+# Get JSON output and extract the CVSS score
+manus-use analyze CVE-2024-3094 --output json | jq .cvss_score
 
-# Automatic multi-agent mode for complex tasks
-manus-use "Research quantum computing applications and create a presentation"
+# Verify exploitability in a Docker sandbox, then write a Lark report
+manus-use analyze CVE-2025-6554 --verify --output lark
 ```
+
+> **Important:** These tools are designed for defensive security purposes only. Use them for legitimate security research, vulnerability management, and defence.
+
+---
+
+## Key Features
+
+### 🤖 Agent types
+
+| Agent | Class | Best for |
+|-------|-------|----------|
+| General | `ManusAgent` | File ops, code execution, reasoning |
+| Browser automation | `BrowserUseAgent` | JS-heavy sites, form filling, scraping |
+| Lightweight browser | `BrowserAgent` | Static pages, simple navigation |
+| Data analysis | `DataAnalysisAgent` | CSV/JSON processing, charts |
+| MCP | `MCPAgent` | Model Context Protocol tool servers |
+| Multi-agent | `WorkflowAgent` | Complex tasks needing multiple specialists |
+| Vulnerability intel | `VulnerabilityIntelligenceAgent` | CVE analysis, threat intelligence |
+
+### 🛠️ Built-in tools
+
+- File operations (read, write, edit, delete)
+- Code execution in Docker sandboxes
+- Web search (DuckDuckGo, configurable)
+- Browser automation (click, type, extract, screenshot)
+- Data visualization (charts, plots, reports)
+- Security tools (NVD, CISA KEV, OTX, Exploit-DB, Trickest, PoC Week)
+- HTTP requests with content extraction
+- Python REPL with persistent state
+
+### 🔌 LLM providers
+
+- **AWS Bedrock** (Claude, Titan, …)
+- **OpenAI** (GPT-4o, GPT-4-turbo, …)
+- **Anthropic** (Claude 3.5 Sonnet, Opus, …)
+- **Ollama** (Llama, Mistral, … running locally)
+
+---
 
 ## Development
 
-### Setup Development Environment
+### Set up a development environment
 
 ```bash
-# Clone the repository
 git clone https://github.com/manus-use/manus-use.git
 cd manus-use
-
-# Install in development mode
 pip install -e ".[dev,browser,search,visualization]"
+```
 
-# Run tests
+### Run tests
+
+```bash
+# All tests
+pytest tests/ -v
+
+# With coverage
+pytest tests/ --cov=manus_use --cov-report=html
+
+# Or via hatch
 hatch run test
+hatch run test-cov
+```
 
-# Check code quality
+### Lint and format
+
+```bash
+ruff check src/ tests/
+ruff format src/ tests/
+
+# Or via hatch
 hatch run lint
 hatch run format
 ```
 
-### Running Tests
+### Project layout
 
-```bash
-# Run all tests
-hatch run test
-
-# Run with coverage
-hatch run test-cov
-
-# Run specific test
-hatch run pytest tests/test_agents.py -v
+```
+manus-use/
+├── src/manus_use/
+│   ├── agents/          # Agent implementations
+│   │   ├── base.py      # BaseManusAgent (all agents inherit from this)
+│   │   ├── manus.py     # ManusAgent (general purpose)
+│   │   ├── browser.py   # BrowserAgent (lightweight)
+│   │   ├── browser_use_agent.py  # BrowserUseAgent (full JS automation)
+│   │   ├── data_analysis.py      # DataAnalysisAgent
+│   │   ├── mcp.py       # MCPAgent
+│   │   └── vi_agent.py  # VulnerabilityIntelligenceAgent
+│   ├── multi_agents/    # Multi-agent orchestration
+│   │   └── workflow_agent.py
+│   ├── tools/           # Individual tool implementations
+│   ├── cli.py           # manus-use CLI entry point
+│   ├── config.py        # Config model (TOML-backed)
+│   └── __init__.py
+├── tests/               # pytest test suite (175+ tests)
+├── config/
+│   └── config.example.toml
+├── examples/            # Runnable usage examples
+└── pyproject.toml
 ```
 
-## Examples
-
-Explore the [examples/](examples/) directory for:
-- [Basic agent usage](examples/basic_usage.py)
-- [Browser automation](examples/browser_use_demo.py)
-- [Multi-agent workflows](examples/multi_agent_flow.py)
-- [Data analysis](examples/test_browser_agent.py)
-
-## Documentation
-
-- [Quick Start Guide](docs/quick-start.md)
-- [Browser Agent Setup](docs/browser-agent-setup.md)
-- [API Reference](docs/api-reference.md)
-
-## Security and Vulnerability Intelligence
-
-ManusUse includes sophisticated vulnerability intelligence capabilities through specialized agents:
-
-### 🔍 Vulnerability Analysis Agent (`va_agent.py`)
-A comprehensive CVE analysis tool that performs deep vulnerability research:
-
-```bash
-# Analyze a specific CVE
-python va_agent.py CVE-2025-6554
-
-# The agent will automatically:
-# - Fetch data from NVD and GitHub advisories
-# - Check CISA KEV and AlienVault OTX
-# - Search for public exploits and PoCs
-# - Perform deep PoC analysis and validation
-# - Generate a comprehensive Lark document report
-```
-
-Features:
-- Multi-source intelligence gathering (NVD, CISA KEV, OTX, GitHub)
-- Automatic PoC discovery and validation
-- Deep code analysis of exploits
-- Threat intelligence correlation
-- Automated report generation
-
-### 🎯 Vulnerability Discovery Agent (`vd_agent.py`)
-An automated vulnerability discovery and submission system:
-
-```bash
-# Run automated vulnerability discovery
-python vd_agent.py
-
-# The agent will:
-# - Calculate time slices for the current two weeks
-# - Discover CVEs with high EPSS scores
-# - Submit vulnerabilities in batches
-# - Provide detailed submission summaries
-```
-
-Features:
-- Automated time-based CVE discovery
-- EPSS score filtering for high-impact vulnerabilities
-- Concurrent processing for efficiency
-- Batch submission capabilities
-- Multi-agent orchestration
-
-### Usage Examples
-
-```python
-# Using the Vulnerability Analysis Agent programmatically
-from va_agent import VulnerabilityIntelligenceAgent
-
-agent = VulnerabilityIntelligenceAgent(model_name="us.anthropic.claude-sonnet-4-20250514-v1:0")
-result = agent.handle_request("Analyze CVE-2025-6554 and create a comprehensive report")
-
-# Using the Vulnerability Discovery Agent
-from vd_agent import VulnerabilityDiscoveryAgent
-
-discovery = VulnerabilityDiscoveryAgent(model_name="us.anthropic.claude-sonnet-4-20250514-v1:0")
-result = discovery.handle_request("Execute vulnerability discovery workflow")
-```
-
-**Important**: These tools are designed for defensive security purposes only and should be used for legitimate security research, vulnerability management, and defense.
-
-## Contributing
+### Contributing
 
 We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
-## License
+---
 
-This project is licensed under the MIT License - see [LICENSE](LICENSE) for details.
+## Examples
 
-## Acknowledgments
+Explore the [examples/](examples/) directory for runnable scripts:
 
-- Built with [Strands SDK](https://github.com/strands-agents/sdk-python) - A powerful Python SDK for building AI agents
-- Browser automation powered by [browser-use](https://github.com/browser-use/browser-use) - Framework for AI-driven web automation
-- Inspired by Anthropic's computer use demonstrations
+- [`basic_usage.py`](examples/basic_usage.py) — simple ManusAgent task
+- [`browser_use_demo.py`](examples/browser_use_demo.py) — browser automation
+- [`multi_agent_flow.py`](examples/multi_agent_flow.py) — multi-agent orchestration
+
+---
 
 ## Support
 
 - 📖 [Documentation](https://github.com/manus-use/manus-use/wiki)
 - 🐛 [Issue Tracker](https://github.com/manus-use/manus-use/issues)
 - 💬 [Discussions](https://github.com/manus-use/manus-use/discussions)
+
+---
+
+## License
+
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for details.
+
+## Acknowledgments
+
+- Built with [Strands SDK](https://github.com/strands-agents/sdk-python) — a powerful Python SDK for building AI agents
+- Browser automation powered by [browser-use](https://github.com/browser-use/browser-use) — framework for AI-driven web automation
+- Inspired by Anthropic's computer use demonstrations

--- a/tests/test_readme_cli.py
+++ b/tests/test_readme_cli.py
@@ -1,0 +1,452 @@
+"""Tests verifying that the CLI's --help output and subcommand routing match the README.
+
+These tests act as living documentation: if any CLI flag, subcommand, or usage
+example in the README drifts from the actual implementation, at least one test
+here will catch it.
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _parser_help(build_fn_name: str) -> str:
+    """Return the --help text for a named _build_*_parser function."""
+    import io  # noqa: PLC0415
+
+    from manus_use import cli  # noqa: PLC0415
+
+    build_fn = getattr(cli, build_fn_name)
+    parser = build_fn()
+    buf = io.StringIO()
+    parser.print_help(buf)
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Top-level help
+# ---------------------------------------------------------------------------
+
+
+class TestTopLevelHelp:
+    def test_help_exits_zero(self):
+        """`manus-use --help` exits with code 0."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+                cli.main()
+        assert exc_info.value.code == 0
+
+    def test_help_mentions_task_positional(self, capsys):
+        """`manus-use --help` describes the [task] positional argument."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit):
+            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+                cli.main()
+
+        out = capsys.readouterr().out
+        assert "task" in out.lower()
+
+    def test_help_mentions_subcommands(self, capsys):
+        """`manus-use --help` lists init, doctor, history, and analyze."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit):
+            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+                cli.main()
+
+        out = capsys.readouterr().out
+        for sub in ("init", "doctor", "history", "analyze"):
+            assert sub in out, f"Subcommand '{sub}' not mentioned in --help output"
+
+    def test_help_shows_format_flag(self, capsys):
+        """`manus-use --help` documents --format."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit):
+            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+                cli.main()
+
+        out = capsys.readouterr().out
+        assert "--format" in out
+
+    def test_help_shows_no_history_flag(self, capsys):
+        """`manus-use --help` documents --no-history."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit):
+            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+                cli.main()
+
+        out = capsys.readouterr().out
+        assert "--no-history" in out
+
+
+# ---------------------------------------------------------------------------
+# init subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestInitSubcommand:
+    def test_init_parser_has_output_flag(self):
+        """`manus-use init` parser exposes --output."""
+        assert "--output" in _parser_help("_build_init_parser")
+
+    def test_init_parser_has_force_flag(self):
+        """`manus-use init` parser exposes --force."""
+        assert "--force" in _parser_help("_build_init_parser")
+
+    def test_init_routing_in_main(self):
+        """`manus-use init` routes to _cmd_init, not the task runner."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch.object(cli, "_cmd_init", return_value=0) as m:
+            with mock.patch.object(sys, "argv", ["manus-use", "init"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 0
+        m.assert_called_once()
+
+    def test_init_does_not_route_to_single_shot(self):
+        """`manus-use init` must NOT invoke _run_single_shot."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch.object(cli, "_cmd_init", return_value=0):
+            with mock.patch.object(cli, "_run_single_shot") as m_shot:
+                with mock.patch.object(sys, "argv", ["manus-use", "init"]):
+                    with pytest.raises(SystemExit):
+                        cli.main()
+
+        m_shot.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# doctor subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorSubcommand:
+    def test_doctor_parser_has_config_flag(self):
+        """`manus-use doctor` parser exposes --config."""
+        assert "--config" in _parser_help("_build_doctor_parser")
+
+    def test_doctor_routing_in_main(self):
+        """`manus-use doctor` routes to _cmd_doctor."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch.object(cli, "_cmd_doctor", return_value=0) as m:
+            with mock.patch.object(sys, "argv", ["manus-use", "doctor"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 0
+        m.assert_called_once()
+
+    def test_doctor_does_not_route_to_single_shot(self):
+        """`manus-use doctor` must NOT invoke _run_single_shot."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch.object(cli, "_cmd_doctor", return_value=0):
+            with mock.patch.object(cli, "_run_single_shot") as m_shot:
+                with mock.patch.object(sys, "argv", ["manus-use", "doctor"]):
+                    with pytest.raises(SystemExit):
+                        cli.main()
+
+        m_shot.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# analyze subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestAnalyzeSubcommand:
+    def test_analyze_parser_has_verify_flag(self):
+        """`manus-use analyze` parser exposes --verify."""
+        assert "--verify" in _parser_help("_build_analyze_parser")
+
+    def test_analyze_parser_has_output_flag(self):
+        """`manus-use analyze` parser exposes --output."""
+        assert "--output" in _parser_help("_build_analyze_parser")
+
+    def test_analyze_parser_has_config_flag(self):
+        """`manus-use analyze` parser exposes --config."""
+        assert "--config" in _parser_help("_build_analyze_parser")
+
+    def test_analyze_output_choices(self):
+        """`manus-use analyze --output` accepts text, json, and lark."""
+        from manus_use import cli  # noqa: PLC0415
+
+        parser = cli._build_analyze_parser()
+        for choice in ("text", "json", "lark"):
+            args = parser.parse_args(["CVE-2025-1234", "--output", choice])
+            assert args.output == choice
+
+    def test_analyze_verify_defaults_false(self):
+        """`manus-use analyze` has --verify default to False."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_analyze_parser().parse_args(["CVE-2025-1234"])
+        assert args.verify is False
+
+    def test_analyze_output_default_is_text(self):
+        """`manus-use analyze` --output defaults to 'text'."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_analyze_parser().parse_args(["CVE-2025-1234"])
+        assert args.output == "text"
+
+    def test_analyze_cve_id_required(self):
+        """`manus-use analyze` without a CVE-ID exits with code 2."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli._build_analyze_parser().parse_args([])
+        assert exc_info.value.code == 2
+
+    def test_analyze_routing_in_main(self):
+        """`manus-use analyze CVE-...` routes to _run_analyze."""
+        from manus_use import cli  # noqa: PLC0415
+
+        captured: dict = {}
+
+        def fake_run_analyze(*, cve_id, verify, output, config):
+            captured.update(cve_id=cve_id, verify=verify, output=output)
+            return 0
+
+        with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
+            with mock.patch("manus_use.cli.Config") as m_cfg:
+                m_cfg.from_file.return_value = mock.MagicMock()
+                with mock.patch.object(
+                    sys, "argv", ["manus-use", "analyze", "CVE-2025-6554"]
+                ):
+                    with pytest.raises(SystemExit) as exc_info:
+                        cli.main()
+
+        assert exc_info.value.code == 0
+        assert captured["cve_id"] == "CVE-2025-6554"
+        assert captured["verify"] is False
+
+    def test_analyze_verify_flag_forwarded(self):
+        """`manus-use analyze CVE-... --verify` passes verify=True to _run_analyze."""
+        from manus_use import cli  # noqa: PLC0415
+
+        captured: dict = {}
+
+        def fake_run_analyze(*, cve_id, verify, output, config):
+            captured["verify"] = verify
+            return 0
+
+        with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
+            with mock.patch("manus_use.cli.Config") as m_cfg:
+                m_cfg.from_file.return_value = mock.MagicMock()
+                with mock.patch.object(
+                    sys, "argv", ["manus-use", "analyze", "CVE-2025-6554", "--verify"]
+                ):
+                    with pytest.raises(SystemExit):
+                        cli.main()
+
+        assert captured["verify"] is True
+
+    def test_analyze_output_json_forwarded(self):
+        """`manus-use analyze CVE-... --output json` passes output='json' to _run_analyze."""
+        from manus_use import cli  # noqa: PLC0415
+
+        captured: dict = {}
+
+        def fake_run_analyze(*, cve_id, verify, output, config):
+            captured["output"] = output
+            return 0
+
+        with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
+            with mock.patch("manus_use.cli.Config") as m_cfg:
+                m_cfg.from_file.return_value = mock.MagicMock()
+                with mock.patch.object(
+                    sys,
+                    "argv",
+                    ["manus-use", "analyze", "CVE-2024-3094", "--output", "json"],
+                ):
+                    with pytest.raises(SystemExit):
+                        cli.main()
+
+        assert captured["output"] == "json"
+
+
+# ---------------------------------------------------------------------------
+# history subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestHistorySubcommand:
+    def test_history_parser_has_limit_flag(self):
+        """`manus-use history` parser exposes --limit."""
+        assert "--limit" in _parser_help("_build_history_parser")
+
+    def test_history_parser_has_grep_flag(self):
+        """`manus-use history` parser exposes --grep."""
+        assert "--grep" in _parser_help("_build_history_parser")
+
+    def test_history_parser_has_format_flag(self):
+        """`manus-use history` parser exposes --format."""
+        assert "--format" in _parser_help("_build_history_parser")
+
+    def test_history_parser_has_clear_flag(self):
+        """`manus-use history` parser exposes --clear."""
+        assert "--clear" in _parser_help("_build_history_parser")
+
+    def test_history_routing_in_main(self):
+        """`manus-use history` routes to _cmd_history."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch.object(cli, "_cmd_history", return_value=0) as m:
+            with mock.patch.object(sys, "argv", ["manus-use", "history"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 0
+        m.assert_called_once()
+
+    def test_history_limit_default(self):
+        """`manus-use history` --limit defaults to 20."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_history_parser().parse_args([])
+        assert args.limit == 20
+
+    def test_history_format_default(self):
+        """`manus-use history` --format defaults to 'text'."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_history_parser().parse_args([])
+        assert args.fmt == "text"
+
+
+# ---------------------------------------------------------------------------
+# --format flag on run command
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFlag:
+    def test_format_json_is_valid(self):
+        """`manus-use task --format json` is accepted by the run parser."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_run_parser().parse_args(["some task", "--format", "json"])
+        assert args.fmt == "json"
+
+    def test_format_text_is_valid(self):
+        """`manus-use task --format text` is accepted by the run parser."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_run_parser().parse_args(["some task", "--format", "text"])
+        assert args.fmt == "text"
+
+    def test_format_default_is_text(self):
+        """`--format` defaults to 'text' when omitted."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_run_parser().parse_args(["some task"])
+        assert args.fmt == "text"
+
+    def test_format_without_task_is_rejected(self):
+        """`--format json` without a task argument exits with code 2."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with mock.patch("manus_use.cli.Config") as m_cfg:
+            m_cfg.from_file.return_value = mock.MagicMock()
+            with mock.patch.object(sys, "argv", ["manus-use", "--format", "json"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+
+        assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------\n# --version flag
+# ---------------------------------------------------------------------------
+
+
+class TestVersionFlag:
+    def test_version_exits_zero(self):
+        """`manus-use --version` exits with code 0."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+                cli.main()
+        assert exc_info.value.code == 0
+
+    def test_version_string_matches_package(self, capsys):
+        """`manus-use --version` output contains the installed package version."""
+        import importlib.metadata  # noqa: PLC0415
+
+        from manus_use import cli  # noqa: PLC0415
+
+        try:
+            expected = importlib.metadata.version("manus-use")
+        except importlib.metadata.PackageNotFoundError:
+            pytest.skip("package not installed in editable mode; skip version check")
+
+        with pytest.raises(SystemExit):
+            with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+                cli.main()
+
+        # argparse sends --version to stdout (Python >=3.11) or stderr (<3.11)
+        captured = capsys.readouterr()
+        combined = captured.out + captured.err
+        assert expected in combined
+
+
+# ---------------------------------------------------------------------------
+# --agent flag
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFlag:
+    def test_agent_choices(self):
+        """--agent accepts manus, browser, data, and mcp."""
+        from manus_use import cli  # noqa: PLC0415
+
+        parser = cli._build_run_parser()
+        for choice in ("manus", "browser", "data", "mcp"):
+            args = parser.parse_args(["task", "--agent", choice])
+            assert args.agent_type == choice
+
+    def test_agent_default_is_manus(self):
+        """--agent defaults to 'manus'."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_run_parser().parse_args(["task"])
+        assert args.agent_type == "manus"
+
+
+# ---------------------------------------------------------------------------
+# --mode flag
+# ---------------------------------------------------------------------------
+
+
+class TestModeFlag:
+    def test_mode_choices(self):
+        """--mode accepts auto, single, and multi."""
+        from manus_use import cli  # noqa: PLC0415
+
+        parser = cli._build_run_parser()
+        for choice in ("auto", "single", "multi"):
+            args = parser.parse_args(["task", "--mode", choice])
+            assert args.mode == choice
+
+    def test_mode_default_is_auto(self):
+        """--mode defaults to 'auto'."""
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_run_parser().parse_args(["task"])
+        assert args.mode == "auto"


### PR DESCRIPTION
## What & Why

The README has been increasingly out of date since PR #20 started expanding the CLI. By PR #32 it still documented `python va_agent.py CVE-2025-6554` and `from va_agent import VulnerabilityIntelligenceAgent` — both superseded by the proper CLI and package imports. New users reading the README got a completely wrong picture of how to use the tool.

This PR rewrites the README to match reality and adds a test file that will keep it accurate going forward.

## Changes

### README.md (complete overhaul)
- **Badges** — PyPI version, Python 3.10+, MIT licence, CI status
- **Table of Contents** — makes a long README navigable
- **Quick Start** — leads with `manus-use init` → `manus-use doctor` → run (the actual onboarding path)
- **CLI Reference** (new section) — documents every subcommand with all flags and defaults:
  - `manus-use [task]` — `--mode`, `--agent`, `--format`, `--no-history`, `--output`, `--config`, `--version`
  - `manus-use init` — `--output`, `--force`
  - `manus-use doctor` — `--config`
  - `manus-use analyze <CVE-ID>` — `--verify`, `--output {text,json,lark}`, `--config`
  - `manus-use history` — `--limit`, `--grep`, `--format`, `--clear`
- **Configuration** — provider-specific TOML examples for Bedrock, OpenAI, Anthropic, Ollama; documents `[agent] context_manager`
- **Python API** — correct imports (`from manus_use.agents import …`) instead of root-script imports
- **Security section** — shows `manus-use analyze` instead of `python va_agent.py`; explains the 8-step pipeline
- **Agent type table** and **project layout tree**

### tests/test_readme_cli.py (new, 39 tests)
Living-documentation tests that verify the CLI actually behaves as the README describes:
- `TestTopLevelHelp` — `--help` exits 0, mentions all subcommands, shows `--format` / `--no-history`
- `TestInitSubcommand` — flags, routing, non-interference with single-shot
- `TestDoctorSubcommand` — flags, routing
- `TestAnalyzeSubcommand` — `--verify`/`--output` flags, choices, defaults, CVE-ID required, routing + flag forwarding
- `TestHistorySubcommand` — all flags, defaults, routing
- `TestFormatFlag` / `TestVersionFlag` / `TestAgentFlag` / `TestModeFlag` — exhaustive parser coverage

## Tests

```
pytest tests/test_readme_cli.py -v   # 39 passed
pytest tests/ -v                     # 214 passed (175 pre-existing + 39 new)
ruff check tests/test_readme_cli.py  # All checks passed
```