### PR TITLE
feat(cli): add manus-use variants subcommand + VariantAnalysisAgent

### DIFF
--- a/src/manus_use/agents/__init__.py
+++ b/src/manus_use/agents/__init__.py
@@ -9,6 +9,7 @@ from manus_use.agents.manus import ManusAgent
 from manus_use.agents.mcp import MCPAgent
 from manus_use.agents.remediation_agent import RemediationAgent
 from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
+from manus_use.agents.variant_agent import VariantAnalysisAgent
 from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
 from manus_use.config import Config
 
@@ -65,5 +66,6 @@ __all__ = [
     "MCPAgent",
     "RemediationAgent",
     "VulnerabilityDiscoveryAgent",
+    "VariantAnalysisAgent",
     "VulnerabilityIntelligenceAgent",
 ]

--- a/src/manus_use/agents/variant_agent.py
+++ b/src/manus_use/agents/variant_agent.py
@@ -1,0 +1,83 @@
+"""VariantAnalysisAgent — CVE variant analysis and vulnerability hunting."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
+
+SYSTEM_PROMPT = """You are an expert vulnerability researcher specializing in variant analysis.
+Given a CVE identifier, you will:
+1. Research the original vulnerability deeply (root cause, affected code patterns, CWE)
+2. Identify similar code patterns and architectural weaknesses in related projects
+3. Search for variants — similar bugs that may exist in related codebases
+4. Assess exploitability and severity of any variants found
+5. Provide actionable remediation guidance for each finding
+
+Structure your report with sections:
+## Original Vulnerability Analysis
+## Variant Search Strategy
+## Variants Found
+## Risk Assessment
+## Remediation Recommendations
+"""
+
+
+class VariantAnalysisAgent:
+    """Agent that performs CVE variant analysis using available tools."""
+
+    def __init__(self, *, config=None, model: Any | None = None):
+        from manus_use.config import Config
+
+        self._config = config or Config.from_file()
+        self._model = model  # allow injection for tests
+        self._agent = None  # lazy init
+
+    def _build_agent(self):
+        try:
+            from strands import Agent  # noqa: F401
+
+            from manus_use.tools.get_github_advisory import get_github_advisory
+            from manus_use.tools.get_nvd_data import get_nvd_data
+            from manus_use.tools.python_repl import python_repl
+            from manus_use.tools.search_for_exploits import search_for_exploits
+        except ImportError as exc:
+            raise ImportError(f"strands and manus_use tools required: {exc}") from exc
+
+        from strands import Agent
+
+        model = self._model
+        if model is None:
+            try:
+                import botocore  # noqa: F401
+                from strands.models import BedrockModel
+
+                model_id = getattr(self._config.agent, "model_id", DEFAULT_MODEL_ID) or DEFAULT_MODEL_ID
+                region = getattr(self._config.agent, "aws_region", "us-east-1") or "us-east-1"
+                model = BedrockModel(model_id=model_id, region_name=region, max_tokens=8192)
+            except Exception:
+                model = None
+
+        return Agent(
+            model=model,
+            system_prompt=SYSTEM_PROMPT,
+            tools=[get_nvd_data, get_github_advisory, search_for_exploits, python_repl],
+        )
+
+    def handle_request(self, prompt: str) -> str:
+        if self._agent is None:
+            self._agent = self._build_agent()
+        result = self._agent(prompt)
+        return str(result)
+
+    def analyze_variants(self, cve_id: str) -> str:
+        return self.handle_request(
+            f"Perform a comprehensive variant analysis for {cve_id}. "
+            "Research the original vulnerability, then systematically search for similar bugs in related projects."
+        )
+
+
+__all__ = ["VariantAnalysisAgent", "DEFAULT_MODEL_ID"]

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -985,11 +985,52 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
         return 1
 
 
+def _build_variants_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use variants",
+        description="CVE variant analysis — find similar bugs in related codebases",
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_variants(argv: list[str]) -> int:
+    parser = _build_variants_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_use.agents.variant_agent import VariantAnalysisAgent
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    agent = VariantAnalysisAgent()
+    result = agent.analyze_variants(cve_id)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps({"cve_id": cve_id, "report": result}))
+    else:
+        print(result)
+    return 0
+
+
 # ---------------------------------------------------------------------------
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants"}
 
 
 def _build_run_parser() -> argparse.ArgumentParser:
@@ -1275,6 +1316,10 @@ def main() -> None:
         idx = argv.index("history")
         history_args = _build_history_parser().parse_args(argv[idx + 1 :])
         sys.exit(_cmd_history(history_args))
+
+    if first_positional == "variants":
+        idx = argv.index("variants")
+        sys.exit(_run_variants(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/tests/test_variant_agent.py
+++ b/tests/test_variant_agent.py
@@ -1,0 +1,404 @@
+"""Tests for VariantAnalysisAgent and the `variants` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module import + __all__ exports
+# ---------------------------------------------------------------------------
+
+
+def test_variant_agent_module_imports_without_crashing():
+    """The module must be importable even without optional deps installed."""
+    import manus_use.agents.variant_agent as va
+
+    assert hasattr(va, "VariantAnalysisAgent")
+
+
+def test_variant_agent_all_exports():
+    """__all__ exports VariantAnalysisAgent and DEFAULT_MODEL_ID."""
+    from manus_use.agents.variant_agent import __all__
+
+    assert "VariantAnalysisAgent" in __all__
+    assert "DEFAULT_MODEL_ID" in __all__
+
+
+def test_variant_agent_exported_from_agents_package():
+    """VariantAnalysisAgent is re-exported from the agents package."""
+    from manus_use.agents import VariantAnalysisAgent  # noqa: F401
+
+
+def test_default_model_id_is_nonempty_string():
+    """DEFAULT_MODEL_ID is a non-empty string."""
+    from manus_use.agents.variant_agent import DEFAULT_MODEL_ID
+
+    assert isinstance(DEFAULT_MODEL_ID, str)
+    assert DEFAULT_MODEL_ID
+
+
+def test_system_prompt_is_string():
+    """SYSTEM_PROMPT is a non-empty string with the expected sections."""
+    from manus_use.agents.variant_agent import SYSTEM_PROMPT
+
+    assert isinstance(SYSTEM_PROMPT, str)
+    assert "variant" in SYSTEM_PROMPT.lower()
+    assert "CVE" in SYSTEM_PROMPT
+
+
+# ---------------------------------------------------------------------------
+# VariantAnalysisAgent instantiation
+# ---------------------------------------------------------------------------
+
+
+def test_variant_agent_instantiates_with_mock_config():
+    """VariantAnalysisAgent() instantiates when Config is mocked."""
+    with mock.patch("manus_use.agents.variant_agent.VariantAnalysisAgent.__init__", return_value=None):
+        from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = mock.MagicMock()
+        agent._model = None
+        agent._agent = None
+        assert agent._agent is None
+
+
+def test_variant_agent_init_without_strands(monkeypatch):
+    """VariantAnalysisAgent.__init__ works even when strands is absent (lazy import)."""
+    fake_config = mock.MagicMock()
+
+    with mock.patch("manus_use.agents.variant_agent.VariantAnalysisAgent.__init__", return_value=None):
+        from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = fake_config
+        agent._model = None
+        agent._agent = None
+
+    # The agent object exists without strands being imported
+    assert agent._config is fake_config
+
+
+# ---------------------------------------------------------------------------
+# handle_request
+# ---------------------------------------------------------------------------
+
+
+def test_handle_request_calls_internal_agent():
+    """handle_request() calls the internal _agent with the prompt."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+    fake_inner = mock.MagicMock(return_value="RESULT")
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = mock.MagicMock()
+        agent._model = None
+        agent._agent = fake_inner
+
+    result = agent.handle_request("some prompt")
+    fake_inner.assert_called_once_with("some prompt")
+    assert result == "RESULT"
+
+
+def test_handle_request_lazy_builds_agent():
+    """handle_request() calls _build_agent when _agent is None."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+    fake_inner = mock.MagicMock(return_value="LAZY_RESULT")
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = mock.MagicMock()
+        agent._model = None
+        agent._agent = None
+
+    with mock.patch.object(agent, "_build_agent", return_value=fake_inner) as m_build:
+        result = agent.handle_request("test prompt")
+
+    m_build.assert_called_once()
+    fake_inner.assert_called_once_with("test prompt")
+    assert result == "LAZY_RESULT"
+
+
+# ---------------------------------------------------------------------------
+# analyze_variants
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_variants_builds_prompt_with_cve_id():
+    """analyze_variants() builds a prompt containing the CVE id."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+    captured_prompts: list[str] = []
+
+    def fake_handle_request(prompt: str) -> str:
+        captured_prompts.append(prompt)
+        return "REPORT"
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = mock.MagicMock()
+        agent._model = None
+        agent._agent = None
+
+    with mock.patch.object(agent, "handle_request", side_effect=fake_handle_request):
+        result = agent.analyze_variants("CVE-2024-3094")
+
+    assert result == "REPORT"
+    assert len(captured_prompts) == 1
+    assert "CVE-2024-3094" in captured_prompts[0]
+
+
+def test_analyze_variants_prompt_mentions_variant():
+    """analyze_variants() prompt includes variant-related context."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+    captured: list[str] = []
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        agent = VariantAnalysisAgent.__new__(VariantAnalysisAgent)
+        agent._config = mock.MagicMock()
+        agent._model = None
+        agent._agent = None
+
+    with mock.patch.object(agent, "handle_request", side_effect=lambda p: captured.append(p) or "ok"):
+        agent.analyze_variants("CVE-2025-9999")
+
+    assert captured
+    assert "variant" in captured[0].lower()
+
+
+# ---------------------------------------------------------------------------
+# _build_variants_parser
+# ---------------------------------------------------------------------------
+
+
+def test_build_variants_parser_cve_id_required():
+    """_build_variants_parser requires a positional CVE-ID argument."""
+    from manus_use.cli import _build_variants_parser
+
+    parser = _build_variants_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code == 2
+
+
+def test_build_variants_parser_parses_cve_id():
+    """_build_variants_parser correctly parses a CVE-ID positional."""
+    from manus_use.cli import _build_variants_parser
+
+    parser = _build_variants_parser()
+    args = parser.parse_args(["CVE-2024-3094"])
+    assert args.cve_id == "CVE-2024-3094"
+
+
+def test_build_variants_parser_output_default_text():
+    """_build_variants_parser defaults --output to text."""
+    from manus_use.cli import _build_variants_parser
+
+    parser = _build_variants_parser()
+    args = parser.parse_args(["CVE-2024-3094"])
+    assert args.output == "text"
+
+
+def test_build_variants_parser_output_json():
+    """_build_variants_parser accepts --output json."""
+    from manus_use.cli import _build_variants_parser
+
+    parser = _build_variants_parser()
+    args = parser.parse_args(["CVE-2024-3094", "--output", "json"])
+    assert args.output == "json"
+
+
+def test_build_variants_parser_output_invalid():
+    """_build_variants_parser rejects invalid --output values."""
+    from manus_use.cli import _build_variants_parser
+
+    parser = _build_variants_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["CVE-2024-3094", "--output", "xml"])
+    assert exc_info.value.code == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_variants
+# ---------------------------------------------------------------------------
+
+
+def test_run_variants_missing_cve_id_exits_error():
+    """_run_variants with no arguments exits with code 2."""
+    from manus_use.cli import _run_variants
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_variants([])
+    assert exc_info.value.code == 2
+
+
+def test_run_variants_text_output_calls_handle_request(capsys):
+    """_run_variants text mode calls analyze_variants and prints result."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+    from manus_use.cli import _run_variants
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        with mock.patch.object(VariantAnalysisAgent, "analyze_variants", return_value="VARIANT_REPORT") as m_av:
+            rc = _run_variants(["CVE-2024-3094"])
+
+    assert rc == 0
+    m_av.assert_called_once_with("CVE-2024-3094")
+    out = capsys.readouterr().out
+    assert "VARIANT_REPORT" in out
+
+
+def test_run_variants_json_output_emits_valid_json(capsys):
+    """_run_variants json mode emits valid JSON with cve_id and report keys."""
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+    from manus_use.cli import _run_variants
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        with mock.patch.object(VariantAnalysisAgent, "analyze_variants", return_value="JSON_REPORT"):
+            rc = _run_variants(["CVE-2025-1234", "--output", "json"])
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    payload = json.loads(out.strip())
+    assert payload["cve_id"] == "CVE-2025-1234"
+    assert payload["report"] == "JSON_REPORT"
+
+
+def test_run_variants_import_error_returns_1(monkeypatch):
+    """_run_variants returns exit code 1 when ImportError is raised."""
+    from manus_use import cli
+
+    with mock.patch.dict(sys.modules, {"manus_use.agents.variant_agent": None}):
+        # Force ImportError by patching the import inside _run_variants
+        real_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "manus_use.agents.variant_agent":
+                raise ImportError("strands not installed")
+            return real_import(name, *args, **kwargs)
+
+        with mock.patch("builtins.__import__", side_effect=fake_import):
+            rc = cli._run_variants(["CVE-2024-3094"])
+
+    assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# _SUBCOMMANDS set
+# ---------------------------------------------------------------------------
+
+
+def test_subcommands_contains_variants():
+    """_SUBCOMMANDS set includes 'variants'."""
+    from manus_use.cli import _SUBCOMMANDS
+
+    assert "variants" in _SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# main() routes "variants" to _run_variants
+# ---------------------------------------------------------------------------
+
+
+def test_main_routes_variants_subcommand():
+    """main() routes 'variants' to _run_variants."""
+    from manus_use import cli
+
+    captured: dict = {}
+
+    def fake_run_variants(argv):
+        captured["argv"] = argv
+        return 0
+
+    with mock.patch.object(sys, "argv", ["manus-use", "variants", "CVE-2024-3094"]):
+        with mock.patch.object(cli, "_run_variants", side_effect=fake_run_variants) as m_rv:
+            with pytest.raises(SystemExit) as exc_info:
+                cli.main()
+
+    assert exc_info.value.code == 0
+    m_rv.assert_called_once()
+    assert "CVE-2024-3094" in captured["argv"]
+
+
+def test_main_variants_passes_output_flag():
+    """main() passes --output json flag correctly to _run_variants."""
+    from manus_use import cli
+
+    captured: dict = {}
+
+    def fake_run_variants(argv):
+        captured["argv"] = argv
+        return 0
+
+    with mock.patch.object(sys, "argv", ["manus-use", "variants", "CVE-2024-3094", "--output", "json"]):
+        with mock.patch.object(cli, "_run_variants", side_effect=fake_run_variants):
+            with pytest.raises(SystemExit):
+                cli.main()
+
+    assert "--output" in captured["argv"]
+    assert "json" in captured["argv"]
+
+
+# ---------------------------------------------------------------------------
+# variant_analysis_agent.py thin wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_thin_wrapper_imports_from_variant_agent():
+    """variant_analysis_agent.py thin wrapper imports VariantAnalysisAgent."""
+    import importlib.util
+    import pathlib
+
+    wrapper_path = pathlib.Path(__file__).resolve().parents[1] / "variant_analysis_agent.py"
+    spec = importlib.util.spec_from_file_location("variant_analysis_agent", wrapper_path)
+    mod = importlib.util.module_from_spec(spec)
+
+    # Stub out strands/botocore to avoid heavy dep requirement
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "strands": mock.MagicMock(),
+            "strands.models": mock.MagicMock(),
+            "botocore": mock.MagicMock(),
+        },
+    ):
+        spec.loader.exec_module(mod)
+
+    assert hasattr(mod, "main")
+    assert callable(mod.main)
+
+
+def test_thin_wrapper_main_calls_analyze_variants():
+    """variant_analysis_agent.py main() delegates to VariantAnalysisAgent.analyze_variants."""
+    import importlib.util
+    import pathlib
+
+    wrapper_path = pathlib.Path(__file__).resolve().parents[1] / "variant_analysis_agent.py"
+    spec = importlib.util.spec_from_file_location("_va_wrapper_test", wrapper_path)
+    mod = importlib.util.module_from_spec(spec)
+
+    with mock.patch.dict(
+        sys.modules,
+        {
+            "strands": mock.MagicMock(),
+            "strands.models": mock.MagicMock(),
+            "botocore": mock.MagicMock(),
+        },
+    ):
+        spec.loader.exec_module(mod)
+
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
+    with mock.patch.object(VariantAnalysisAgent, "__init__", return_value=None):
+        with mock.patch.object(VariantAnalysisAgent, "analyze_variants", return_value="WRAPPER_RESULT") as m_av:
+            with mock.patch.object(sys, "argv", ["variant_analysis_agent.py", "CVE-2024-3094"]):
+                with mock.patch("builtins.print"):
+                    mod.main()
+
+    m_av.assert_called_once_with("CVE-2024-3094")

--- a/variant_analysis_agent.py
+++ b/variant_analysis_agent.py
@@ -1,55 +1,25 @@
 #!/usr/bin/env python3
+"""CLI entry-point for the Variant Analysis Agent (backwards compat wrapper).
+
+The actual implementation lives in :mod:`manus_use.agents.variant_agent`.
+
+Usage::
+    python variant_analysis_agent.py CVE-2024-3094
+Or via CLI::
+    manus-use variants CVE-2024-3094
 """
-Variant Analysis Agent — demonstrates AgentSkills plugin with real skills.
-
-Skills loaded from skills/ directory:
-  - variant-analysis: CVE variant analysis and vulnerability hunting
-  - oss-contributor: OSS patch writing, PR, and GHSA submission
-  - test-skill: simple CVE summaries (demo)
-
-Usage:
-  python variant_analysis_agent.py [CVE-ID]
-"""
-
 import sys
-from pathlib import Path
+import warnings
 
-sys.path.insert(0, str(Path(__file__).parent / "src"))
-
-from strands import Agent, AgentSkills
-from strands.models import BedrockModel
+warnings.filterwarnings("ignore")
 
 
-def main():
+def main() -> None:
+    from manus_use.agents.variant_agent import VariantAnalysisAgent
+
     cve_id = sys.argv[1] if len(sys.argv) > 1 else "CVE-2024-3094"
-
-    model = BedrockModel(
-        model_id="us.anthropic.claude-opus-4-6-v1",
-        region_name="us-east-1",
-        max_tokens=4096,
-    )
-
-    skills_dir = Path(__file__).parent / "skills"
-    plugin = AgentSkills(skills=str(skills_dir))
-
-    agent = Agent(
-        model=model,
-        plugins=[plugin],
-        system_prompt=(
-            "You are a vulnerability analyst assistant. "
-            "You have these skills available:\n"
-            "  - variant-analysis: for CVE variant analysis and vulnerability hunting\n"
-            "  - oss-contributor: for writing fix patches and submitting PRs/GHSAs\n"
-            "  - test-skill: for simple CVE summaries\n"
-            "Activate the most relevant skill before answering. "
-            "After activating, follow the skill instructions exactly."
-        ),
-    )
-
-    print("=== Variant Analysis Agent (AgentSkills test) ===")
-    print(f"Query: {cve_id}\n")
-
-    result = agent(f"Analyze {cve_id}")
+    agent = VariantAnalysisAgent()
+    result = agent.analyze_variants(cve_id)
     print(result)
 
 


### PR DESCRIPTION
## Summary
Extract `VariantAnalysisAgent` from the root `variant_analysis_agent.py` script into
`src/manus_use/agents/variant_agent.py` and wire it into the CLI as `manus-use variants <CVE-ID>`.

## What's new
- `src/manus_use/agents/variant_agent.py` — `VariantAnalysisAgent` class with lazy Bedrock init, Config-based model selection, deferred strands imports
- `manus-use variants CVE-XXXX-YYYY` — CLI subcommand with `--output text|json`
- `variant_analysis_agent.py` — thinned to a backwards-compat wrapper (same treatment as `vd_agent.py`)
- `tests/test_variant_agent.py` — 25 tests covering module, CLI routing, output modes, error paths
- `tests/test_cli.py` — accept `stream=False` kwarg in `fake_single_shot` mock (compat fix for pre-existing stream feature in working tree)

## Usage
```bash
manus-use variants CVE-2024-3094
manus-use variants CVE-2024-3094 --output json | jq .report
```

## Quality gates
- `ruff check` — clean ✅
- `pytest tests/test_variant_agent.py tests/test_cli.py` — 57 passed ✅
- Full suite — 260 passed, 1 pre-existing integration failure (OpenAI API key required) ✅