### PR TITLE
feat(cli): add --stream flag for real-time output in single-shot mode

### DIFF
--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -85,20 +85,24 @@ def display_task_plan(tasks) -> None:
 # Agent factory
 # ---------------------------------------------------------------------------
 
-def _make_agent(agent_type: str, config: Config):
-    """Instantiate the requested agent type."""
+def _make_agent(agent_type: str, config: Config, **agent_kwargs):
+    """Instantiate the requested agent type.
+
+    Extra keyword arguments (e.g. *callback_handler*) are forwarded to the
+    agent constructor so callers can inject streaming handlers.
+    """
     if agent_type == "browser":
         from .agents import BrowserUseAgent
-        return BrowserUseAgent(config=config)
+        return BrowserUseAgent(config=config, **agent_kwargs)
     if agent_type == "data":
         from .agents import DataAnalysisAgent
-        return DataAnalysisAgent(config=config)
+        return DataAnalysisAgent(config=config, **agent_kwargs)
     if agent_type == "mcp":
         from .agents import MCPAgent
-        return MCPAgent(config=config)
+        return MCPAgent(config=config, **agent_kwargs)
     # default: manus
     from .agents import ManusAgent
-    return ManusAgent(config=config)
+    return ManusAgent(config=config, **agent_kwargs)
 
 
 # ---------------------------------------------------------------------------
@@ -375,6 +379,7 @@ def _run_single_shot(
     fmt: str,
     no_history: bool,
     config: Config,
+    stream: bool = False,
 ) -> int:
     """Execute a single task non-interactively and exit.
 
@@ -418,13 +423,73 @@ def _run_single_shot(
             return 1
         result_text = workflow_result.output
     else:
-        with console.status("Running…", spinner="dots"):
-            response = agent(task)
-        result_text = str(response)
+        if stream:
+            # --stream + --format json are incompatible: warn and fall back.
+            if fmt == "json":
+                sys.stderr.write(
+                    "[warn] --stream is incompatible with --format json;"
+                    " falling back to buffered JSON output\n"
+                )
+
+            # Try to use PrintingCallbackHandler for real-time output.
+            _streamed = False
+            try:
+                from strands.handlers import PrintingCallbackHandler
+
+                stream_agent = _make_agent(
+                    agent_type,
+                    config,
+                    callback_handler=PrintingCallbackHandler(),
+                )
+                response = stream_agent(task)
+                # PrintingCallbackHandler already flushed tokens to stdout.
+                # str(response) extracts text content from AgentResult.
+                result_text = str(response)
+                _streamed = True
+            except (ImportError, TypeError):
+                pass
+
+            if not _streamed:
+                # Fallback: call normally, check if result is a generator.
+                response = agent(task)
+                import types
+
+                if isinstance(response, types.GeneratorType):
+                    chunks = []
+                    for chunk in response:
+                        chunk_str = str(chunk)
+                        sys.stdout.write(chunk_str)
+                        sys.stdout.flush()
+                        chunks.append(chunk_str)
+                    sys.stdout.write("\n")
+                    result_text = "".join(chunks)
+                else:
+                    sys.stderr.write(
+                        "[warn] streaming not supported by this agent/model,"
+                        " falling back to buffered output\n"
+                    )
+                    result_text = str(response)
+        else:
+            with console.status("Running…", spinner="dots"):
+                response = agent(task)
+            result_text = str(response)
 
     # ------------------------------------------------------------------
     # Output formatting
     # ------------------------------------------------------------------
+    if stream and fmt != "json" and not use_multi_agent:
+        # Streaming path already printed to stdout; only handle file save + history.
+        if output is not None:
+            output.parent.mkdir(parents=True, exist_ok=True)
+            output.write_text(result_text, encoding="utf-8")
+            console.print(f"[dim]Output saved to {output}[/dim]")
+        if not no_history:
+            _append_history(
+                task, result_text,
+                agent_type=agent_type, mode=mode, success=True, format=fmt,
+            )
+        return 0
+
     if fmt == "json":
         payload = json.dumps(
             {
@@ -932,6 +997,12 @@ def _build_run_parser() -> argparse.ArgumentParser:
         default=None,
         help="Path to a config.toml file (overrides default search paths)",
     )
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        default=False,
+        help="Stream output tokens in real time (single-shot mode only)",
+    )
     return parser
 
 
@@ -1147,6 +1218,7 @@ def main() -> None:
             fmt=args.fmt,
             no_history=args.no_history,
             config=config,
+            stream=args.stream,
         )
         sys.exit(exit_code)
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ def _invoke_main(argv, *, patch_single_shot=True, single_shot_rc=0):
 
     captured = {}
 
-    def fake_single_shot(task, *, mode, agent_type, show_plan, output, fmt, no_history, config):
+    def fake_single_shot(task, *, mode, agent_type, show_plan, output, fmt, no_history, config, stream=False):
         captured["task"] = task
         captured["mode"] = mode
         captured["agent_type"] = agent_type

--- a/tests/test_cli_stream.py
+++ b/tests/test_cli_stream.py
@@ -1,0 +1,478 @@
+"""Tests for the --stream flag in single-shot CLI mode."""
+
+import json
+import sys
+from io import StringIO
+from unittest import mock
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_run_parser():
+    from manus_use.cli import _build_run_parser as _brp
+
+    return _brp()
+
+
+def _invoke_main(argv, *, single_shot_rc=0):
+    """Call cli.main() and return captured data."""
+    from manus_use import cli
+
+    captured = {}
+
+    def fake_single_shot(
+        task,
+        *,
+        mode,
+        agent_type,
+        show_plan,
+        output,
+        fmt,
+        no_history,
+        config,
+        stream=False,
+    ):
+        captured["task"] = task
+        captured["mode"] = mode
+        captured["agent_type"] = agent_type
+        captured["show_plan"] = show_plan
+        captured["output"] = output
+        captured["fmt"] = fmt
+        captured["no_history"] = no_history
+        captured["stream"] = stream
+        return single_shot_rc
+
+    with mock.patch.object(sys, "argv", ["manus-use"] + argv):
+        with mock.patch.object(cli, "_run_single_shot", side_effect=fake_single_shot) as m_ss:
+            with mock.patch.object(cli, "_run_interactive"):
+                with mock.patch("manus_use.cli.Config") as m_cfg:
+                    m_cfg.from_file.return_value = mock.MagicMock()
+                    try:
+                        cli.main()
+                    except SystemExit as exc:
+                        captured["exit_code"] = exc.code
+
+    captured["_run_single_shot"] = m_ss
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# 1. --stream flag exists in the parser
+# ---------------------------------------------------------------------------
+
+
+def test_stream_flag_in_parser_help():
+    """--stream appears in the run parser help text."""
+    parser = _build_run_parser()
+    help_text = parser.format_help()
+    assert "--stream" in help_text
+
+
+def test_stream_flag_in_parser_actions():
+    """The run parser has a --stream action registered."""
+    parser = _build_run_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" in action_dests
+
+
+# ---------------------------------------------------------------------------
+# 2. --stream defaults to False
+# ---------------------------------------------------------------------------
+
+
+def test_stream_default_false_no_flag():
+    """Parsing without --stream gives stream=False."""
+    parser = _build_run_parser()
+    args = parser.parse_args(["my task"])
+    assert args.stream is False
+
+
+def test_stream_default_false_explicit():
+    """args.stream is a boolean False (not just falsy) when omitted."""
+    parser = _build_run_parser()
+    args = parser.parse_args(["task"])
+    assert args.stream == False  # noqa: E712
+
+
+def test_stream_true_when_flag_present():
+    """Parsing with --stream gives stream=True."""
+    parser = _build_run_parser()
+    args = parser.parse_args(["--stream", "my task"])
+    assert args.stream is True
+
+
+# ---------------------------------------------------------------------------
+# 3. main() routes --stream to _run_single_shot with stream=True
+# ---------------------------------------------------------------------------
+
+
+def test_main_stream_flag_forwarded():
+    """main() passes stream=True to _run_single_shot when --stream used."""
+    captured = _invoke_main(["--stream", "do something"])
+    assert captured.get("stream") is True
+    assert captured["task"] == "do something"
+
+
+def test_main_no_stream_flag_forwarded_false():
+    """main() passes stream=False to _run_single_shot when --stream not used."""
+    captured = _invoke_main(["do something"])
+    assert captured.get("stream") is False
+
+
+# ---------------------------------------------------------------------------
+# 4. --stream + --format json: warn to stderr, fall back to buffered JSON
+# ---------------------------------------------------------------------------
+
+
+def test_stream_and_json_warns_stderr(tmp_path):
+    """--stream --format json writes a warning to stderr."""
+    from manus_use import cli
+
+    fake_agent = mock.MagicMock()
+    fake_agent.return_value = "some result"
+    fake_config = mock.MagicMock()
+
+    stderr_capture = StringIO()
+
+    with mock.patch("manus_use.cli._make_agent", return_value=fake_agent):
+        with mock.patch("manus_use.cli._append_history"):
+            with mock.patch("sys.stderr", stderr_capture):
+                with mock.patch("sys.stdout", StringIO()):
+                    cli._run_single_shot(
+                        "task",
+                        mode="single",
+                        agent_type="manus",
+                        show_plan=False,
+                        output=None,
+                        fmt="json",
+                        no_history=True,
+                        config=fake_config,
+                        stream=True,
+                    )
+
+    warn_output = stderr_capture.getvalue()
+    assert "[warn]" in warn_output
+    assert "json" in warn_output.lower()
+
+
+def test_stream_and_json_output_is_valid_json(tmp_path):
+    """--stream --format json still produces valid JSON output."""
+    from manus_use import cli
+
+    fake_response = mock.MagicMock()
+    fake_response.__str__ = lambda self: "hello result"
+
+    fake_agent = mock.MagicMock(return_value=fake_response)
+    fake_config = mock.MagicMock()
+
+    stdout_capture = StringIO()
+
+    with mock.patch("manus_use.cli._make_agent", return_value=fake_agent):
+        with mock.patch("manus_use.cli._append_history"):
+            with mock.patch("sys.stderr", StringIO()):
+                with mock.patch("sys.stdout", stdout_capture):
+                    cli._run_single_shot(
+                        "task",
+                        mode="single",
+                        agent_type="manus",
+                        show_plan=False,
+                        output=None,
+                        fmt="json",
+                        no_history=True,
+                        config=fake_config,
+                        stream=True,
+                    )
+
+    payload = json.loads(stdout_capture.getvalue())
+    assert "result" in payload
+    assert payload["task"] == "task"
+
+
+# ---------------------------------------------------------------------------
+# 5. _run_single_shot with stream=True + PrintingCallbackHandler available
+# ---------------------------------------------------------------------------
+
+
+def test_stream_true_uses_printing_callback_handler():
+    """With stream=True and PrintingCallbackHandler available, it is used."""
+    from manus_use import cli
+
+    fake_response = mock.MagicMock()
+    fake_response.__str__ = lambda self: "streamed result"
+
+    mock_handler_instance = mock.MagicMock()
+    mock_handler_class = mock.MagicMock(return_value=mock_handler_instance)
+
+    fake_stream_agent = mock.MagicMock(return_value=fake_response)
+    fake_config = mock.MagicMock()
+
+    make_agent_calls = []
+
+    def capturing_make_agent(agent_type, config, **kwargs):
+        make_agent_calls.append(kwargs)
+        return fake_stream_agent
+
+    with mock.patch("manus_use.cli._make_agent", side_effect=capturing_make_agent):
+        with mock.patch("manus_use.cli._append_history"):
+            with mock.patch("sys.stdout", StringIO()):
+                with mock.patch(
+                    "strands.handlers.PrintingCallbackHandler", mock_handler_class
+                ):
+                    cli._run_single_shot(
+                        "task",
+                        mode="single",
+                        agent_type="manus",
+                        show_plan=False,
+                        output=None,
+                        fmt="text",
+                        no_history=True,
+                        config=fake_config,
+                        stream=True,
+                    )
+
+    # The streaming agent should have been called
+    fake_stream_agent.assert_called_once_with("task")
+    # callback_handler was passed
+    assert any("callback_handler" in call for call in make_agent_calls)
+
+
+# ---------------------------------------------------------------------------
+# 6. _run_single_shot with stream=True when PrintingCallbackHandler unavailable
+# ---------------------------------------------------------------------------
+
+
+def test_stream_true_fallback_when_import_fails():
+    """When PrintingCallbackHandler is unavailable, falls back gracefully."""
+    from manus_use import cli
+
+    fake_response = mock.MagicMock()
+    fake_response.__str__ = lambda self: "buffered result"
+    # Make __iter__ raise TypeError so we hit the non-iterable warn path
+    type(fake_response).__iter__ = mock.Mock(side_effect=TypeError("not iterable"))
+
+    fake_config = mock.MagicMock()
+    stderr_capture = StringIO()
+
+    # Make _make_agent raise TypeError when callback_handler is passed
+    # (simulates an agent that doesn't accept callback_handler)
+    real_make_agent_call_count = [0]
+    buffered_agent = mock.MagicMock(return_value=fake_response)
+
+    def mock_make_agent(agent_type, config, **kwargs):
+        real_make_agent_call_count[0] += 1
+        if "callback_handler" in kwargs:
+            raise TypeError("callback_handler not supported")
+        return buffered_agent
+
+    with mock.patch("manus_use.cli._make_agent", side_effect=mock_make_agent):
+        with mock.patch("manus_use.cli._append_history"):
+            with mock.patch("sys.stderr", stderr_capture):
+                with mock.patch("manus_use.cli.console"):
+                    rc = cli._run_single_shot(
+                        "task",
+                        mode="single",
+                        agent_type="manus",
+                        show_plan=False,
+                        output=None,
+                        fmt="text",
+                        no_history=True,
+                        config=fake_config,
+                        stream=True,
+                    )
+
+    # Should not crash; returns 0
+    assert rc == 0
+    # The buffered (fallback) agent was called
+    buffered_agent.assert_called_once_with("task")
+    # The [warn] about streaming fallback was emitted
+    assert "[warn]" in stderr_capture.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# 7. _run_single_shot with stream=True when result is a generator
+# ---------------------------------------------------------------------------
+
+
+def test_stream_generator_result_iterates_chunks():
+    """When result is a generator, chunks are printed and joined."""
+    from manus_use import cli
+
+    def fake_gen():
+        yield "Hello"
+        yield " "
+        yield "world"
+
+    # Make PrintingCallbackHandler import fail so we hit the fallback path
+    fake_agent = mock.MagicMock(return_value=fake_gen())
+    fake_config = mock.MagicMock()
+
+    stdout_capture = StringIO()
+    stderr_capture = StringIO()
+
+    import builtins
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        fromlist = args[2] if len(args) > 2 else []
+        if name == "strands.handlers" and "PrintingCallbackHandler" in fromlist:
+            raise ImportError("mocked")
+        return real_import(name, *args, **kwargs)
+
+    with mock.patch("builtins.__import__", side_effect=mock_import):
+        with mock.patch("manus_use.cli._make_agent", return_value=fake_agent):
+            with mock.patch("manus_use.cli._append_history"):
+                with mock.patch("sys.stdout", stdout_capture):
+                    with mock.patch("sys.stderr", stderr_capture):
+                        rc = cli._run_single_shot(
+                            "task",
+                            mode="single",
+                            agent_type="manus",
+                            show_plan=False,
+                            output=None,
+                            fmt="text",
+                            no_history=True,
+                            config=fake_config,
+                            stream=True,
+                        )
+
+    assert rc == 0
+    written = stdout_capture.getvalue()
+    assert "Hello" in written
+    assert "world" in written
+
+
+# ---------------------------------------------------------------------------
+# 8. _run_single_shot with stream=False: normal buffered output (regression)
+# ---------------------------------------------------------------------------
+
+
+def test_stream_false_uses_buffered_path():
+    """With stream=False, normal console.status path is used."""
+    from manus_use import cli
+
+    fake_response = mock.MagicMock()
+    fake_response.__str__ = lambda self: "buffered result"
+
+    fake_agent = mock.MagicMock(return_value=fake_response)
+    fake_config = mock.MagicMock()
+
+    with mock.patch("manus_use.cli._make_agent", return_value=fake_agent):
+        with mock.patch("manus_use.cli._append_history"):
+            with mock.patch("manus_use.cli.console"):
+                rc = cli._run_single_shot(
+                    "task",
+                    mode="single",
+                    agent_type="manus",
+                    show_plan=False,
+                    output=None,
+                    fmt="text",
+                    no_history=True,
+                    config=fake_config,
+                    stream=False,
+                )
+
+    assert rc == 0
+    fake_agent.assert_called_once_with("task")
+
+
+# ---------------------------------------------------------------------------
+# 9. stream flag is only on run parser, NOT on subcommand parsers
+# ---------------------------------------------------------------------------
+
+
+def test_stream_not_on_analyze_parser():
+    """--stream is not a recognised flag on the analyze parser."""
+    from manus_use.cli import _build_analyze_parser
+
+    parser = _build_analyze_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" not in action_dests
+
+
+def test_stream_not_on_discover_parser():
+    """--stream is not a recognised flag on the discover parser."""
+    from manus_use.cli import _build_discover_parser
+
+    parser = _build_discover_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" not in action_dests
+
+
+def test_stream_not_on_history_parser():
+    """--stream is not a recognised flag on the history parser."""
+    from manus_use.cli import _build_history_parser
+
+    parser = _build_history_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" not in action_dests
+
+
+def test_stream_not_on_init_parser():
+    """--stream is not a recognised flag on the init parser."""
+    from manus_use.cli import _build_init_parser
+
+    parser = _build_init_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" not in action_dests
+
+
+def test_stream_not_on_doctor_parser():
+    """--stream is not a recognised flag on the doctor parser."""
+    from manus_use.cli import _build_doctor_parser
+
+    parser = _build_doctor_parser()
+    action_dests = {a.dest for a in parser._actions}
+    assert "stream" not in action_dests
+
+
+# ---------------------------------------------------------------------------
+# 10. _run_single_shot stream=True, non-iterable non-str result → fallback warn
+# ---------------------------------------------------------------------------
+
+
+def test_stream_fallback_buffered_warning_for_non_iterable():
+    """Non-iterable result in fallback path prints buffered-output warning."""
+    from manus_use import cli
+
+    # A plain object that is not iterable and not a string
+    class _Opaque:
+        def __str__(self):
+            return "opaque result"
+
+    fake_agent = mock.MagicMock(return_value=_Opaque())
+    fake_config = mock.MagicMock()
+
+    stderr_capture = StringIO()
+
+    import builtins
+    real_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        fromlist = args[2] if len(args) > 2 else []
+        if name == "strands.handlers" and "PrintingCallbackHandler" in fromlist:
+            raise ImportError("mocked")
+        return real_import(name, *args, **kwargs)
+
+    with mock.patch("builtins.__import__", side_effect=mock_import):
+        with mock.patch("manus_use.cli._make_agent", return_value=fake_agent):
+            with mock.patch("manus_use.cli._append_history"):
+                with mock.patch("sys.stderr", stderr_capture):
+                    with mock.patch("manus_use.cli.console"):
+                        rc = cli._run_single_shot(
+                            "task",
+                            mode="single",
+                            agent_type="manus",
+                            show_plan=False,
+                            output=None,
+                            fmt="text",
+                            no_history=True,
+                            config=fake_config,
+                            stream=True,
+                        )
+
+    assert rc == 0
+    warn = stderr_capture.getvalue()
+    assert "[warn]" in warn
+    assert "buffered" in warn

--- a/tests/test_init_doctor.py
+++ b/tests/test_init_doctor.py
@@ -325,7 +325,7 @@ class TestBackwardCompat:
 
         captured = {}
 
-        def fake_ss(task, *, mode, agent_type, show_plan, output, fmt, no_history, config):
+        def fake_ss(task, *, mode, agent_type, show_plan, output, fmt, no_history, config, stream=False):
             captured["task"] = task
             return 0
 


### PR DESCRIPTION
## Summary
Add `--stream` flag to single-shot mode for real-time token output.

## What's new
- `--stream` flag on the default run parser: `manus-use --stream "task"`
- When streaming is available (strands `PrintingCallbackHandler`), tokens print as they arrive
- Graceful fallback when `_make_agent` raises `TypeError` (agent doesn't accept `callback_handler`): buffered output + stderr warning
- Generator-aware fallback: if the agent returns a `types.GeneratorType`, chunks are iterated and flushed in real time
- `--stream` + `--format json` combination: warns to stderr and falls back to buffered JSON (streaming and structured output are incompatible)
- `_make_agent` now accepts `**agent_kwargs` forwarded to agent constructors
- `tests/test_cli_stream.py` — 19 tests covering flag parsing, stream routing, fallback paths, JSON incompatibility, generator iteration, subcommand isolation
- Updated `fake_single_shot` signatures in `test_cli.py` and `test_init_doctor.py` for backward compat

## Usage
```bash
manus-use --stream "Summarize CVE-2024-3094"
manus-use --stream --agent manus "Write a Python hello-world"
```

## Quality gates
- `ruff check src/manus_use/cli.py tests/test_cli_stream.py` — clean ✓
- `python3 -m pytest tests/test_cli_stream.py tests/test_cli.py -x -q` — 51 passed ✓
- Full suite: 254 passed, 1 pre-existing failure (live OpenAI API call in `test_vd_agent_discover_integration`)