### PR TITLE
ci: add PyPI publish workflow, .pre-commit-config.yaml, and 32 living-doc tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,142 @@
+# Publish manus-use to PyPI on version tags (e.g. v0.1.0).
+#
+# Uses PyPI Trusted Publishing (OIDC) — no long-lived API tokens needed.
+# To enable, create a Trusted Publisher on https://pypi.org with:
+#   Owner:    manus-use
+#   Repo:     manus-use
+#   Workflow: publish.yml
+#   Environment: pypi
+#
+# Usage:
+#   git tag v0.1.0 && git push origin v0.1.0
+#
+# The workflow will:
+#   1. Build source distribution and wheel with `hatch build`
+#   2. Upload artifacts to PyPI via Trusted Publishing
+#   3. Create a GitHub Release with auto-generated release notes
+#   4. Upload the same artifacts as GitHub Release assets
+
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
+
+permissions:
+  contents: write   # needed to create GitHub Releases
+  id-token: write   # needed for OIDC-based Trusted Publishing
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false  # never cancel an in-flight publish
+
+jobs:
+  # ──────────────────────────────────────────────────────────────
+  # 1. Validate: run the full test suite before touching PyPI
+  # ──────────────────────────────────────────────────────────────
+  validate:
+    name: Validate (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Lint (ruff)
+        run: |
+          ruff check .
+          ruff format --check .
+
+      - name: Run tests
+        run: pytest tests/ -v -m "not integration"
+
+  # ──────────────────────────────────────────────────────────────
+  # 2. Build: produce sdist + wheel
+  # ──────────────────────────────────────────────────────────────
+  build:
+    name: Build distribution packages
+    runs-on: ubuntu-latest
+    needs: validate
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install build tools
+        run: pip install hatch
+
+      - name: Build sdist and wheel
+        run: hatch build
+
+      - name: Check distribution contents
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  # ──────────────────────────────────────────────────────────────
+  # 3. Publish: upload to PyPI via Trusted Publishing
+  # ──────────────────────────────────────────────────────────────
+  publish-pypi:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: pypi
+      url: https://pypi.org/project/manus-use/
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ──────────────────────────────────────────────────────────────
+  # 4. Release: create a GitHub Release with release notes
+  # ──────────────────────────────────────────────────────────────
+  github-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    needs: publish-pypi
+
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: dist/*
+          draft: false
+          prerelease: ${{ contains(github.ref, '-') }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,48 @@
+# Pre-commit hooks for manus-use.
+#
+# Install:
+#   pip install pre-commit          # already in [dev] deps
+#   pre-commit install              # register the git hook
+#
+# Run manually against all files:
+#   pre-commit run --all-files
+#
+# Hooks run automatically on every `git commit` to catch issues before CI.
+
+repos:
+  # ── ruff: linting + auto-fix ─────────────────────────────────────────────
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Keep in sync with the `ruff` version in pyproject.toml [dev] deps.
+    rev: v0.4.4
+    hooks:
+      - id: ruff
+        args: [--fix]
+        name: ruff (lint + autofix)
+      - id: ruff-format
+        name: ruff (format)
+
+  # ── standard trailing-whitespace / EOF hygiene ───────────────────────────
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+        exclude: "^tests/|^docs/"
+      - id: end-of-file-fixer
+        exclude: "^tests/|^docs/"
+      - id: check-yaml
+        name: validate YAML files
+      - id: check-toml
+        name: validate TOML files
+      - id: check-merge-conflict
+      - id: debug-statements
+        name: detect debug statements (pdb, breakpoint)
+
+  # ── mypy: static type checking ────────────────────────────────────────────
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.15.0
+    hooks:
+      - id: mypy
+        name: mypy (type check)
+        args: [--ignore-missing-imports]
+        additional_dependencies: [pydantic>=2.0.0, toml>=0.10.2]
+        files: ^src/

--- a/src/manus_use/agents/__init__.py
+++ b/src/manus_use/agents/__init__.py
@@ -8,8 +8,8 @@ from manus_use.agents.data_analysis import DataAnalysisAgent
 from manus_use.agents.manus import ManusAgent
 from manus_use.agents.mcp import MCPAgent
 from manus_use.agents.remediation_agent import RemediationAgent
-from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
 from manus_use.agents.variant_agent import VariantAnalysisAgent
+from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
 from manus_use.agents.vi_agent import VulnerabilityIntelligenceAgent
 from manus_use.config import Config
 

--- a/src/manus_use/agents/remediation_agent.py
+++ b/src/manus_use/agents/remediation_agent.py
@@ -98,8 +98,7 @@ class RemediationAgent:
             from strands import Agent
         except ImportError as exc:  # pragma: no cover
             raise ImportError(
-                "strands-agents is required for RemediationAgent. "
-                "Install it with: pip install strands-agents"
+                "strands-agents is required for RemediationAgent. Install it with: pip install strands-agents"
             ) from exc
 
         self.config = config or Config.from_file()
@@ -145,9 +144,7 @@ class RemediationAgent:
         # Context management — use agentic mode when the SDK supports it.
         context_manager = getattr(self.config, "agent", None)
         context_manager_val = (
-            getattr(context_manager, "context_manager", "agentic")
-            if context_manager is not None
-            else "agentic"
+            getattr(context_manager, "context_manager", "agentic") if context_manager is not None else "agentic"
         )
 
         agent_kwargs: dict[str, Any] = {
@@ -208,6 +205,7 @@ class RemediationAgent:
 # ---------------------------------------------------------------------------
 # Thin backwards-compatible entry point (mirrors root remediation_agent.py)
 # ---------------------------------------------------------------------------
+
 
 def _main() -> None:
     """CLI entry-point kept for backwards compatibility.

--- a/src/manus_use/agents/vd_agent.py
+++ b/src/manus_use/agents/vd_agent.py
@@ -231,9 +231,7 @@ class VulnerabilityDiscoveryAgent:
                     system_prompt=_CAPTURE_SYSTEM_PROMPT,
                     tools=[obtain_cves_mod, submit_cves_mod],
                 )
-                result = agent(
-                    f"Please obtain and submit CVEs in the time slice: {time_slice}"
-                )
+                result = agent(f"Please obtain and submit CVEs in the time slice: {time_slice}")
                 print(f"[capture_cves] Slice agent result: {result}")
 
                 summary: Submission = agent.structured_output(
@@ -311,6 +309,4 @@ class VulnerabilityDiscoveryAgent:
         dry_run: bool = False,
     ) -> str:
         """Convenience wrapper: build the request and run the workflow."""
-        return self.handle_request(
-            self.build_request(since=since, min_epss=min_epss, dry_run=dry_run)
-        )
+        return self.handle_request(self.build_request(since=since, min_epss=min_epss, dry_run=dry_run))

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -27,27 +27,28 @@ console = Console()
 # Complexity heuristic
 # ---------------------------------------------------------------------------
 
+
 def is_complex_task(user_input: str) -> bool:
     """Determine if a task requires multi-agent orchestration."""
     complex_indicators = [
-        r'\band\b.*\band\b',
-        r'\bthen\b',
-        r'\bafter\b',
-        r'\banalyze\b.*\b(create|generate|build)',
-        r'\bcompare\b.*\bsummarize',
-        r'\bmultiple\b',
-        r'\bsteps?\b',
-        r'\bworkflow\b',
-        r'(first|second|third|finally)',
-        r'\b(visuali[sz]e|chart|graph)\b.*\b(analyze|data)',
-        r'\bbrowse\b.*\b(extract|analyze)',
-        r'\bresearch\b.*\b(implement|create)',
+        r"\band\b.*\band\b",
+        r"\bthen\b",
+        r"\bafter\b",
+        r"\banalyze\b.*\b(create|generate|build)",
+        r"\bcompare\b.*\bsummarize",
+        r"\bmultiple\b",
+        r"\bsteps?\b",
+        r"\bworkflow\b",
+        r"(first|second|third|finally)",
+        r"\b(visuali[sz]e|chart|graph)\b.*\b(analyze|data)",
+        r"\bbrowse\b.*\b(extract|analyze)",
+        r"\bresearch\b.*\b(implement|create)",
     ]
 
     if len(user_input.split()) > 30:
         return True
 
-    if len(re.split(r'[.;]', user_input)) > 2:
+    if len(re.split(r"[.;]", user_input)) > 2:
         return True
 
     for pattern in complex_indicators:
@@ -60,6 +61,7 @@ def is_complex_task(user_input: str) -> bool:
 # ---------------------------------------------------------------------------
 # Execution plan display
 # ---------------------------------------------------------------------------
+
 
 def display_task_plan(tasks) -> None:
     """Display the execution plan in a formatted table."""
@@ -85,6 +87,7 @@ def display_task_plan(tasks) -> None:
 # Agent factory
 # ---------------------------------------------------------------------------
 
+
 def _make_agent(agent_type: str, config: Config, **agent_kwargs):
     """Instantiate the requested agent type.
 
@@ -93,21 +96,26 @@ def _make_agent(agent_type: str, config: Config, **agent_kwargs):
     """
     if agent_type == "browser":
         from .agents import BrowserUseAgent
+
         return BrowserUseAgent(config=config, **agent_kwargs)
     if agent_type == "data":
         from .agents import DataAnalysisAgent
+
         return DataAnalysisAgent(config=config, **agent_kwargs)
     if agent_type == "mcp":
         from .agents import MCPAgent
+
         return MCPAgent(config=config, **agent_kwargs)
     # default: manus
     from .agents import ManusAgent
+
     return ManusAgent(config=config, **agent_kwargs)
 
 
 # ---------------------------------------------------------------------------
 # Single-shot and interactive runners
 # ---------------------------------------------------------------------------
+
 
 def _build_analyze_parser() -> argparse.ArgumentParser:
     """Build the argument parser for the `analyze` subcommand."""
@@ -184,16 +192,10 @@ def _run_analyze(
 
         console.print_json(json.dumps({"cve": cve_id, "report": result_text}))
     elif output == "lark":
-        console.print(
-            "[dim]Report delivered to Lark (see create_lark_document output above).[/dim]"
-        )
-        console.print(
-            Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green")
-        )
+        console.print("[dim]Report delivered to Lark (see create_lark_document output above).[/dim]")
+        console.print(Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green"))
     else:
-        console.print(
-            Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green")
-        )
+        console.print(Panel(result_text, title=f"[bold green]{cve_id}[/bold green]", border_style="green"))
 
     return 0
 
@@ -241,6 +243,7 @@ def _append_history(
     }
     with _HISTORY_PATH.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+
 
 # ---------------------------------------------------------------------------
 # manus-use discover
@@ -314,11 +317,7 @@ def _run_discover(
         return 1
 
     since_display = since or "4 weeks ago"
-    console.print(
-        f"[bold blue]Discovering CVEs[/bold blue] "
-        f"since [cyan]{since_display}[/cyan] "
-        f"(min-epss={min_epss})"
-    )
+    console.print(f"[bold blue]Discovering CVEs[/bold blue] since [cyan]{since_display}[/cyan] (min-epss={min_epss})")
     if dry_run:
         console.print("[dim]Dry-run mode: CVEs will NOT be submitted.[/dim]")
 
@@ -366,7 +365,6 @@ def _run_discover(
         )
 
     return 0
-
 
 
 # ---------------------------------------------------------------------------
@@ -493,15 +491,21 @@ def _run_single_shot(
 
         if not workflow_result.success:
             error_msg = f"Task failed: {workflow_result.error}"
-            console.print(Panel(
-                error_msg,
-                title="[bold red]Error[/bold red]",
-                border_style="red",
-            ))
+            console.print(
+                Panel(
+                    error_msg,
+                    title="[bold red]Error[/bold red]",
+                    border_style="red",
+                )
+            )
             if not no_history:
                 _append_history(
-                    task, error_msg,
-                    agent_type=agent_type, mode=mode, success=False, format=fmt,
+                    task,
+                    error_msg,
+                    agent_type=agent_type,
+                    mode=mode,
+                    success=False,
+                    format=fmt,
                 )
             return 1
         result_text = workflow_result.output
@@ -510,8 +514,7 @@ def _run_single_shot(
             # --stream + --format json are incompatible: warn and fall back.
             if fmt == "json":
                 sys.stderr.write(
-                    "[warn] --stream is incompatible with --format json;"
-                    " falling back to buffered JSON output\n"
+                    "[warn] --stream is incompatible with --format json; falling back to buffered JSON output\n"
                 )
 
             # Try to use PrintingCallbackHandler for real-time output.
@@ -548,8 +551,7 @@ def _run_single_shot(
                     result_text = "".join(chunks)
                 else:
                     sys.stderr.write(
-                        "[warn] streaming not supported by this agent/model,"
-                        " falling back to buffered output\n"
+                        "[warn] streaming not supported by this agent/model, falling back to buffered output\n"
                     )
                     result_text = str(response)
         else:
@@ -568,8 +570,12 @@ def _run_single_shot(
             console.print(f"[dim]Output saved to {output}[/dim]")
         if not no_history:
             _append_history(
-                task, result_text,
-                agent_type=agent_type, mode=mode, success=True, format=fmt,
+                task,
+                result_text,
+                agent_type=agent_type,
+                mode=mode,
+                success=True,
+                format=fmt,
             )
         return 0
 
@@ -588,9 +594,7 @@ def _run_single_shot(
         # Rich's print_json adds colours that break pipe consumers; use sys.stdout.
         sys.stdout.write(payload + "\n")
     else:
-        console.print(
-            Panel(result_text, title="[bold green]Result[/bold green]", border_style="green")
-        )
+        console.print(Panel(result_text, title="[bold green]Result[/bold green]", border_style="green"))
 
     if output is not None:
         output.parent.mkdir(parents=True, exist_ok=True)
@@ -602,8 +606,12 @@ def _run_single_shot(
 
     if not no_history:
         _append_history(
-            task, result_text,
-            agent_type=agent_type, mode=mode, success=True, format=fmt,
+            task,
+            result_text,
+            agent_type=agent_type,
+            mode=mode,
+            success=True,
+            format=fmt,
         )
 
     return 0
@@ -642,9 +650,7 @@ def _run_interactive(
                 console.print("\n[bold blue]Goodbye![/bold blue]")
                 break
 
-            use_multi_agent = mode == "multi" or (
-                mode == "auto" and is_complex_task(user_input)
-            )
+            use_multi_agent = mode == "multi" or (mode == "auto" and is_complex_task(user_input))
 
             if use_multi_agent and orchestrator:
                 console.print("\n[bold green]Orchestrator[/bold green]: Planning execution…\n")
@@ -665,17 +671,21 @@ def _run_interactive(
                     progress.update(_ptask, completed=True)
 
                 if result.success:
-                    console.print(Panel(
-                        result.output,
-                        title="[bold green]Result[/bold green]",
-                        border_style="green",
-                    ))
+                    console.print(
+                        Panel(
+                            result.output,
+                            title="[bold green]Result[/bold green]",
+                            border_style="green",
+                        )
+                    )
                 else:
-                    console.print(Panel(
-                        f"Task failed: {result.error}",
-                        title="[bold red]Error[/bold red]",
-                        border_style="red",
-                    ))
+                    console.print(
+                        Panel(
+                            f"Task failed: {result.error}",
+                            title="[bold red]Error[/bold red]",
+                            border_style="red",
+                        )
+                    )
             else:
                 console.print("\n[bold green]Agent[/bold green]: ", end="")
                 with console.status("Thinking…", spinner="dots"):
@@ -706,18 +716,18 @@ _DEFAULT_CONFIG_PATH = Path.home() / ".manus-use" / "config.toml"
 
 def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
     """Guided interactive config generator."""
-    console.print(Panel(
-        "[bold]Welcome to [cyan]manus-use init[/cyan]![/bold]\n"
-        "This wizard will create a [yellow]config.toml[/yellow] for you.",
-        border_style="blue",
-    ))
+    console.print(
+        Panel(
+            "[bold]Welcome to [cyan]manus-use init[/cyan]![/bold]\n"
+            "This wizard will create a [yellow]config.toml[/yellow] for you.",
+            border_style="blue",
+        )
+    )
 
     # Destination path
     dest: Path = args.output or _DEFAULT_CONFIG_PATH
     if dest.exists() and not args.force:
-        overwrite = Confirm.ask(
-            f"[yellow]{dest}[/yellow] already exists. Overwrite?", default=False
-        )
+        overwrite = Confirm.ask(f"[yellow]{dest}[/yellow] already exists. Overwrite?", default=False)
         if not overwrite:
             console.print("[dim]Aborted – existing config left unchanged.[/dim]")
             return 0
@@ -801,12 +811,14 @@ def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
     with open(dest, "w", encoding="utf-8") as fh:
         toml.dump(config_data, fh)
 
-    console.print(Panel(
-        f"[green]✓ Config written to[/green] [bold]{dest}[/bold]\n\n"
-        f"Run [cyan]manus-use doctor[/cyan] to verify your setup.",
-        border_style="green",
-        title="[bold green]Done![/bold green]",
-    ))
+    console.print(
+        Panel(
+            f"[green]✓ Config written to[/green] [bold]{dest}[/bold]\n\n"
+            f"Run [cyan]manus-use doctor[/cyan] to verify your setup.",
+            border_style="green",
+            title="[bold green]Done![/bold green]",
+        )
+    )
     return 0
 
 
@@ -833,6 +845,7 @@ _ALWAYS_CHECK: list[tuple[str, str, str]] = [
 def _check_import(package: str) -> bool:
     """Return True if *package* is importable."""
     import importlib
+
     try:
         importlib.import_module(package)
         return True
@@ -842,10 +855,12 @@ def _check_import(package: str) -> bool:
 
 def _cmd_doctor(args: argparse.Namespace) -> int:
     """Check packages, config, and environment variables."""
-    console.print(Panel(
-        "[bold cyan]manus-use doctor[/bold cyan] – environment diagnostics",
-        border_style="blue",
-    ))
+    console.print(
+        Panel(
+            "[bold cyan]manus-use doctor[/bold cyan] – environment diagnostics",
+            border_style="blue",
+        )
+    )
 
     issues: list[str] = []
 
@@ -887,10 +902,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
             issues.append(f"Config parse error: {exc}")
             config = Config()
     else:
-        console.print(
-            "  [yellow]![/yellow] No config file found "
-            "(run [cyan]manus-use init[/cyan] to create one)"
-        )
+        console.print("  [yellow]![/yellow] No config file found (run [cyan]manus-use init[/cyan] to create one)")
         config = Config()
 
     # ------------------------------------------------------------------
@@ -931,10 +943,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
             src = "config" if (not val and in_config) else "env"
             console.print(f"  [green]✓[/green] {env_var} ([dim]{src}[/dim])")
         elif required:
-            console.print(
-                f"  [red]✗[/red] {env_var} not set "
-                "(required – set it or store in config.toml)"
-            )
+            console.print(f"  [red]✗[/red] {env_var} not set (required – set it or store in config.toml)")
             issues.append(f"Missing env var: {env_var}")
         else:
             console.print(f"  [yellow]![/yellow] {env_var} not set (optional for Bedrock)")
@@ -957,9 +966,8 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     # Docker daemon reachable?
     if shutil.which("docker"):
         import subprocess
-        result = subprocess.run(
-            ["docker", "info"], capture_output=True, timeout=5
-        )
+
+        result = subprocess.run(["docker", "info"], capture_output=True, timeout=5)
         if result.returncode == 0:
             console.print("  [green]✓[/green] Docker daemon reachable")
         else:
@@ -970,18 +978,21 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     # ------------------------------------------------------------------
     console.print()
     if not issues:
-        console.print(Panel(
-            "[bold green]All checks passed![/bold green] "
-            "Your environment looks ready.",
-            border_style="green",
-        ))
+        console.print(
+            Panel(
+                "[bold green]All checks passed![/bold green] Your environment looks ready.",
+                border_style="green",
+            )
+        )
         return 0
     else:
         issue_list = "\n".join(f"  • {i}" for i in issues)
-        console.print(Panel(
-            f"[bold red]{len(issues)} issue(s) found:[/bold red]\n{issue_list}",
-            border_style="red",
-        ))
+        console.print(
+            Panel(
+                f"[bold red]{len(issues)} issue(s) found:[/bold red]\n{issue_list}",
+                border_style="red",
+            )
+        )
         return 1
 
 
@@ -1042,11 +1053,11 @@ def _build_run_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  # Single-shot (non-interactive)\n"
-            "  manus-use \"Create a factorial function in Python\"\n"
-            "  manus-use --agent browser \"Find the top 5 trending GitHub repos today\"\n"
-            "  manus-use --output result.txt \"Summarise the latest AI news\"\n"
-            "  manus-use --format json \"List prime numbers up to 50\"\n"
-            "  manus-use --format json \"task\" | jq .result\n\n"
+            '  manus-use "Create a factorial function in Python"\n'
+            '  manus-use --agent browser "Find the top 5 trending GitHub repos today"\n'
+            '  manus-use --output result.txt "Summarise the latest AI news"\n'
+            '  manus-use --format json "List prime numbers up to 50"\n'
+            '  manus-use --format json "task" | jq .result\n\n'
             "  # Interactive REPL\n"
             "  manus-use\n"
             "  manus-use --mode multi\n\n"
@@ -1058,10 +1069,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
             "  manus-use analyze CVE-2024-3094 --verify --output json\n"
-            "  \n"\
-            "  # CVE discovery\n"\
-            "  manus-use discover\n"\
-            "  manus-use discover --since 2025-06-01 --min-epss 0.7 --output json\n"\
+            "  \n"
+            "  # CVE discovery\n"
+            "  manus-use discover\n"
+            "  manus-use discover --since 2025-06-01 --min-epss 0.7 --output json\n"
             "  manus-use discover --dry-run\n"
             "  \n"
             "  # CVE remediation guidance\n"
@@ -1214,9 +1225,7 @@ def _cmd_history(args: argparse.Namespace) -> int:
         return 0
 
     if not _HISTORY_PATH.exists():
-        console.print(
-            "[dim]No history yet – run a task with [cyan]manus-use 'task...'[/cyan] first.[/dim]"
-        )
+        console.print("[dim]No history yet – run a task with [cyan]manus-use 'task...'[/cyan] first.[/dim]")
         return 0
 
     records = []
@@ -1305,12 +1314,14 @@ def main() -> None:
         idx = argv.index("analyze")
         analyze_args = _build_analyze_parser().parse_args(argv[idx + 1 :])
         config = Config.from_file(analyze_args.config)
-        sys.exit(_run_analyze(
-            cve_id=analyze_args.cve_id,
-            verify=analyze_args.verify,
-            output=analyze_args.output,
-            config=config,
-        ))
+        sys.exit(
+            _run_analyze(
+                cve_id=analyze_args.cve_id,
+                verify=analyze_args.verify,
+                output=analyze_args.output,
+                config=config,
+            )
+        )
 
     if first_positional == "history":
         idx = argv.index("history")
@@ -1325,23 +1336,27 @@ def main() -> None:
         idx = argv.index("discover")
         discover_args = _build_discover_parser().parse_args(argv[idx + 1 :])
         config = Config.from_file(discover_args.config)
-        sys.exit(_run_discover(
-            since=discover_args.since,
-            min_epss=discover_args.min_epss,
-            output=discover_args.output,
-            dry_run=discover_args.dry_run,
-            config=config,
-        ))
+        sys.exit(
+            _run_discover(
+                since=discover_args.since,
+                min_epss=discover_args.min_epss,
+                output=discover_args.output,
+                dry_run=discover_args.dry_run,
+                config=config,
+            )
+        )
 
     if first_positional == "remediate":
         idx = argv.index("remediate")
         remediate_args = _build_remediate_parser().parse_args(argv[idx + 1 :])
         config = Config.from_file(remediate_args.config)
-        sys.exit(_run_remediate(
-            cve_id=remediate_args.cve_id,
-            output=remediate_args.output,
-            config=config,
-        ))
+        sys.exit(
+            _run_remediate(
+                cve_id=remediate_args.cve_id,
+                output=remediate_args.output,
+                config=config,
+            )
+        )
 
     # Default: run / interactive
     run_parser = _build_run_parser()

--- a/src/manus_use/multi_agents/workflow_agent.py
+++ b/src/manus_use/multi_agents/workflow_agent.py
@@ -4,7 +4,6 @@ Strands Agent that uses the workflow tool to handle complex tasks
 with headless=False for browser operations
 """
 
-
 # Import Strands SDK
 from strands import Agent
 
@@ -12,6 +11,7 @@ from strands import Agent
 import manus_use.tools.workflow_tool as workflow_tool
 
 # Create custom tools for the workflow agent
+
 
 class WorkflowAgent:
     """Agent that manages complex workflows using multiple agent types"""
@@ -47,25 +47,22 @@ Always ensure workflows are well-structured and tasks are properly sequenced.
 """
 
         # Initialize the agent with tools
-        self.agent = Agent(
-            model=model_name,
-            system_prompt=self.system_prompt,
-            tools=[workflow_tool]
-        )
+        self.agent = Agent(model=model_name, system_prompt=self.system_prompt, tools=[workflow_tool])
 
     def handle_request(self, request: str) -> str:
         """Handle a user request by creating and executing appropriate workflows"""
         response = self.agent(request)
         return response
 
+
 # Example usage
 def main():
     """Example of using the WorkflowAgent"""
     print("=== Workflow Agent Example ===")
-    #print(f"Workflow directory: {WORKFLOW_DIR}")
+    # print(f"Workflow directory: {WORKFLOW_DIR}")
 
     # Ensure workflow directory exists
-    #os.makedirs(WORKFLOW_DIR, exist_ok=True)
+    # os.makedirs(WORKFLOW_DIR, exist_ok=True)
 
     # Create the agent
     agent = WorkflowAgent()
@@ -83,6 +80,7 @@ if __name__ == "__main__":
     # Check if we're running with a configured model
     try:
         from manus_use.config import Config
+
         config = Config.from_file()
         if config.llm.provider == "bedrock":
             print("Using AWS Bedrock configuration")

--- a/src/manus_use/tools/create_lark_document.py
+++ b/src/manus_use/tools/create_lark_document.py
@@ -97,11 +97,12 @@ TOOL_SPEC = {
                 "cwe_info",
                 "cvss_score",
                 "recommendations",
-                "background"
+                "background",
             ],
         }
     },
 }
+
 
 def create_lark_document(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
@@ -110,22 +111,25 @@ def create_lark_document(tool: ToolUse, **kwargs: Any) -> ToolResult:
     default_is_openclaw = os.environ.get("OPENCLAW", "").lower() == "true"
     tool["input"]["is_openclaw"] = tool["input"].get("is_openclaw", default_is_openclaw)
     import requests
+
     config = Config.from_file()
-    url = getattr(getattr(config, 'lark', None), 'document_url', None)
+    url = getattr(getattr(config, "lark", None), "document_url", None)
     if not url:
         url = os.environ.get("LARK_DOCUMENT_URL")
     if not url:
-        raise ValueError("Lark document API URL not set in config or environment. Please set [lark] document_url in your config.toml or the LARK_DOCUMENT_URL environment variable.")
-    api_token = getattr(getattr(config, 'lark', None), 'api_token', None)
+        raise ValueError(
+            "Lark document API URL not set in config or environment. Please set [lark] document_url in your config.toml or the LARK_DOCUMENT_URL environment variable."
+        )
+    api_token = getattr(getattr(config, "lark", None), "api_token", None)
     if not api_token:
         api_token = os.environ.get("LARK_API_TOKEN")
     if not api_token:
-        raise ValueError("Lark API token not set in config or environment. Please set [lark] api_token in your config.toml or the LARK_API_TOKEN environment variable.")
-    headers = {
-        "Authorization": f"Bearer {api_token}"
-    }
+        raise ValueError(
+            "Lark API token not set in config or environment. Please set [lark] api_token in your config.toml or the LARK_API_TOKEN environment variable."
+        )
+    headers = {"Authorization": f"Bearer {api_token}"}
     try:
-        response = requests.post(url, headers=headers, json=tool['input'])
+        response = requests.post(url, headers=headers, json=tool["input"])
         response.raise_for_status()  # Raises an HTTPError if the response status code is 4XX/5XX
         print(response.text)
         return {
@@ -134,14 +138,14 @@ def create_lark_document(tool: ToolUse, **kwargs: Any) -> ToolResult:
             "content": [{"text": f"Created lark document at {title}"}],
         }
     except requests.exceptions.HTTPError as http_err:
-        print(f'HTTP error occurred: {http_err}')
+        print(f"HTTP error occurred: {http_err}")
         return {
             "toolUseId": tool_use_id,
             "status": "error",
             "content": [{"text": f"Failed to create lark document: {http_err}"}],
         }
     except Exception as err:
-        print(f'Other error occurred: {err}')
+        print(f"Other error occurred: {err}")
         return {
             "toolUseId": tool_use_id,
             "status": "error",

--- a/src/manus_use/tools/get_github_advisory.py
+++ b/src/manus_use/tools/get_github_advisory.py
@@ -37,10 +37,7 @@ def get_github_advisory(cve_id: str) -> dict[str, Any]:
     except Exception:
         github_token = os.environ.get("GITHUB_TOKEN")
 
-    headers = {
-        "Accept": "application/vnd.github+json",
-        "X-GitHub-Api-Version": "2022-11-28"
-    }
+    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
     if github_token:
         headers["Authorization"] = f"token {github_token}"
 

--- a/src/manus_use/tools/search_for_exploits.py
+++ b/src/manus_use/tools/search_for_exploits.py
@@ -34,6 +34,7 @@ TOOL_SPEC = {
     },
 }
 
+
 def search_for_exploits(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
@@ -72,7 +73,7 @@ def search_for_exploits(tool: ToolUse, **kwargs: Any) -> ToolResult:
             result = {
                 "toolUseId": tool_use_id,
                 "status": "success",
-                "content": [{"json": {"summary": f"No public exploits found on GitHub for {cve_id}.", "links": []}}]
+                "content": [{"json": {"summary": f"No public exploits found on GitHub for {cve_id}.", "links": []}}],
             }
             log_tool_output_size("search_for_exploits", result)
             return result
@@ -80,32 +81,46 @@ def search_for_exploits(tool: ToolUse, **kwargs: Any) -> ToolResult:
         # Extract relevant information for the top 5 results.
         top_results: list[dict[str, Any]] = []
         for item in data["items"][:5]:
-            top_results.append({
-                "name": item["full_name"],
-                "url": item["html_url"],
-                "description": item["description"],
-                "stars": item["stargazers_count"],
-                "last_updated": item["updated_at"],
-            })
+            top_results.append(
+                {
+                    "name": item["full_name"],
+                    "url": item["html_url"],
+                    "description": item["description"],
+                    "stars": item["stargazers_count"],
+                    "last_updated": item["updated_at"],
+                }
+            )
 
         summary = f"Found {data['total_count']} potential exploits on GitHub for {cve_id}. Returning the top 5 most recently updated."
         result = {
             "toolUseId": tool_use_id,
             "status": "success",
-            "content": [{"json": {"summary": summary, "links": top_results}}]
+            "content": [{"json": {"summary": summary, "links": top_results}}],
         }
         log_tool_output_size("search_for_exploits", result)
         return result
 
     except requests.exceptions.RequestException as e:
-        result = {"toolUseId": tool_use_id, "status": "error", "content": [{"text": f"Request to GitHub API failed: {e}"}]}
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Request to GitHub API failed: {e}"}],
+        }
         log_tool_output_size("search_for_exploits", result)
         return result
     except json.JSONDecodeError:
-        result = {"toolUseId": tool_use_id, "status": "error", "content": [{"text": "Failed to parse JSON response from GitHub API."}]}
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Failed to parse JSON response from GitHub API."}],
+        }
         log_tool_output_size("search_for_exploits", result)
         return result
     except Exception as e:
-        result = {"toolUseId": tool_use_id, "status": "error", "content": [{"text": f"An unexpected error occurred: {e}"}]}
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"An unexpected error occurred: {e}"}],
+        }
         log_tool_output_size("search_for_exploits", result)
         return result

--- a/src/manus_use/tools/submit_cves.py
+++ b/src/manus_use/tools/submit_cves.py
@@ -30,6 +30,7 @@ def _get_mcp_tools():
         _mcp_tools = []
     return _mcp_tools
 
+
 TOOL_SPEC = {
     "name": "submit_cves",
     "description": "Submits a discovered CVE, along with its associated intelligence data, to a downstream system or webhook.",
@@ -45,43 +46,40 @@ TOOL_SPEC = {
                         "properties": {
                             "cve_id": {
                                 "type": "string",
-                                "description": "The unique identifier for the vulnerability (e.g., 'CVE-2025-12345')."
+                                "description": "The unique identifier for the vulnerability (e.g., 'CVE-2025-12345').",
                             },
                             "cvss_score": {
                                 "type": "string",
-                                "description": "The CVSS score and vector, formatted as 'Severity(Score),Vector' (e.g., 'Critical(9.8),CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H')."
+                                "description": "The CVSS score and vector, formatted as 'Severity(Score),Vector' (e.g., 'Critical(9.8),CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H').",
                             },
                             "cisa_kev": {
                                 "type": "boolean",
-                                "description": "Indicates if the vulnerability is in the CISA Known Exploited Vulnerabilities (KEV) catalog."
+                                "description": "Indicates if the vulnerability is in the CISA Known Exploited Vulnerabilities (KEV) catalog.",
                             },
                             "exploited": {
                                 "type": "boolean",
-                                "description": "Indicates if the vulnerability is exploited in the wild, based on OTX or other threat intelligence."
+                                "description": "Indicates if the vulnerability is exploited in the wild, based on OTX or other threat intelligence.",
                             },
                             "epss_score": {
                                 "type": "string",
-                                "description": "The Exploit Prediction Scoring System (EPSS) score (e.g., 0.94577)."
+                                "description": "The Exploit Prediction Scoring System (EPSS) score (e.g., 0.94577).",
                             },
-                            "epss_percentile": {
-                                "type": "string",
-                                "description": "The EPSS percentile (e.g., 0.999)."
-                            },
+                            "epss_percentile": {"type": "string", "description": "The EPSS percentile (e.g., 0.999)."},
                             "affected_products": {
                                 "type": "string",
-                                "description": "A single, comma-separated string listing the products including vendors, packages, or components confirmed to be affected by the CVE."
+                                "description": "A single, comma-separated string listing the products including vendors, packages, or components confirmed to be affected by the CVE.",
                             },
                             "affected_versions": {
                                 "type": "string",
-                                "description": "A single string containing a comma-separated list of affected product versions."
+                                "description": "A single string containing a comma-separated list of affected product versions.",
                             },
                             "cwe": {
                                 "type": "string",
-                                "description": "The Common Weakness Enumeration (CWE) identifier (e.g., 'CWE-79')."
+                                "description": "The Common Weakness Enumeration (CWE) identifier (e.g., 'CWE-79').",
                             },
                             "public_disclosure_date": {
                                 "type": "string",
-                                "description": "The date when the vulnerability was publicly disclosed (YYYY-MM-DD)."
+                                "description": "The date when the vulnerability was publicly disclosed (YYYY-MM-DD).",
                             },
                             "description": {
                                 "type": "string",
@@ -94,38 +92,48 @@ TOOL_SPEC = {
                                 - 'HIGH': CVE affects widely used applications, libraries, or components (e.g., Chrome, Log4j, jQuery).
                                 - 'MEDIUM': CVE affects moderately popular software or libraries, but not universally adopted.
                                 - 'LOW': CVE affects niche, specialized, or rarely used software or components.
-                                Always consider both the primary software and any included third-party dependencies when assigning this value."""
-                            }
+                                Always consider both the primary software and any included third-party dependencies when assigning this value.""",
+                            },
                         },
-                        "required": ["cve_id", "priority", "cvss_score", "epss_score", "epss_percentile", "affected_products", "cisa_kev", "exploited", "cwe", "cpe"]
-                    }
+                        "required": [
+                            "cve_id",
+                            "priority",
+                            "cvss_score",
+                            "epss_score",
+                            "epss_percentile",
+                            "affected_products",
+                            "cisa_kev",
+                            "exploited",
+                            "cwe",
+                            "cpe",
+                        ],
+                    },
                 }
             },
             "required": ["cve_list"],
         }
-
     },
 }
+
 
 def analyze_affected_assets(cves):
     for cve in cves:
         agent = Agent(tools=_get_mcp_tools())
-        result = agent(
-            f"please submit a match asset task for {cve}."
-        )
+        result = agent(f"please submit a match asset task for {cve}.")
         print(result)
     # return result
 
+
 def submit_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
-    #cve_list = tool["input"]
+    # cve_list = tool["input"]
     cve_list = tool["input"].get("cve_list", [])
     print("============================")
     if not cve_list:
         return {
             "toolUseId": tool_use_id,
             "status": "error",
-            "content": [{"text": "The 'cve_list' parameter cannot be empty."}]
+            "content": [{"text": "The 'cve_list' parameter cannot be empty."}],
         }
 
     print(f"Submitting {len(cve_list)} CVEs to webhook...")
@@ -141,46 +149,41 @@ def submit_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
     """
     # Main webhook (Lark)
     config = Config.from_file()
-    url = getattr(getattr(config, 'webhooks', None), 'cve_submit_url', None)
+    url = getattr(getattr(config, "webhooks", None), "cve_submit_url", None)
     if not url:
         url = os.environ.get("CVE_SUBMIT_URL")
     if not url:
-        raise ValueError("CVE submission webhook URL not set in config or environment. Please set [webhooks] cve_submit_url in your config.toml or the CVE_SUBMIT_URL environment variable.")
+        raise ValueError(
+            "CVE submission webhook URL not set in config or environment. Please set [webhooks] cve_submit_url in your config.toml or the CVE_SUBMIT_URL environment variable."
+        )
     headers = {"Content-Type": "application/json"}
 
-    critical_cves = list(map(lambda y: y.get('cve_id', 'Unknown'), filter(lambda x: 'CRITICAL' in x.get('priority','') or 'HIGH' in x.get('priority',''), cve_list)))
+    critical_cves = list(
+        map(
+            lambda y: y.get("cve_id", "Unknown"),
+            filter(lambda x: "CRITICAL" in x.get("priority", "") or "HIGH" in x.get("priority", ""), cve_list),
+        )
+    )
     print(f"{len(critical_cves)} critival vulnerabilities")
     try:
         for cve in cve_list:
-            #if cve_analyzed.get(cve.get('cve_id', 'Unknown'), None):
+            # if cve_analyzed.get(cve.get('cve_id', 'Unknown'), None):
             #   cve = cve | cve_analyzed.get(cve.get('cve_id', 'Unknown'))
             #    print(f"Critical: f{cve}")
             response = requests.post(url, headers=headers, json=cve)
             response.raise_for_status()
-        submitted_ids = [cve.get('cve_id', 'Unknown') for cve in cve_list]
+        submitted_ids = [cve.get("cve_id", "Unknown") for cve in cve_list]
         success_message = f"Successfully submitted {len(cve_list)} CVEs: {', '.join(submitted_ids)}"
         print(success_message)
 
         analyze_affected_assets(critical_cves)
 
-        return {
-            "toolUseId": tool_use_id,
-            "status": "success",
-            "content": [{"text": success_message}]
-        }
+        return {"toolUseId": tool_use_id, "status": "success", "content": [{"text": success_message}]}
     except requests.exceptions.HTTPError as http_err:
         error_message = f"HTTP error occurred while submitting CVEs: {http_err}"
         print(error_message)
-        return {
-            "toolUseId": tool_use_id,
-            "status": "error",
-            "content": [{"text": error_message}]
-        }
+        return {"toolUseId": tool_use_id, "status": "error", "content": [{"text": error_message}]}
     except Exception as err:
         error_message = f"An unexpected error occurred: {err}"
         print(error_message)
-        return {
-            "toolUseId": tool_use_id,
-            "status": "error",
-            "content": [{"text": error_message}]
-        }
+        return {"toolUseId": tool_use_id, "status": "error", "content": [{"text": error_message}]}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -215,6 +215,7 @@ def test_run_single_shot_no_output_file(tmp_path):
 # --format flag (CLI parsing)
 # ---------------------------------------------------------------------------
 
+
 def test_format_default_is_text():
     """fmt defaults to 'text' when --format is not passed."""
     captured = _invoke_main(["some task"])
@@ -248,6 +249,7 @@ def test_no_history_flag():
 # ---------------------------------------------------------------------------
 # --format json in _run_single_shot (output to stdout/file)
 # ---------------------------------------------------------------------------
+
 
 def test_run_single_shot_json_format_stdout(tmp_path, capsys):
     """--format json writes a valid JSON object to stdout."""
@@ -311,6 +313,7 @@ def test_run_single_shot_json_format_writes_json_to_file(tmp_path):
 # ---------------------------------------------------------------------------
 # _append_history
 # ---------------------------------------------------------------------------
+
 
 def test_append_history_creates_file(tmp_path):
     """_append_history creates the history file and writes a valid JSON record."""
@@ -418,6 +421,7 @@ def test_history_flag_calls_append(tmp_path):
 # ---------------------------------------------------------------------------
 # manus-use history subcommand
 # ---------------------------------------------------------------------------
+
 
 def _invoke_history(argv):
     """Call cli.main() with history subcommand argv."""

--- a/tests/test_cli_stream.py
+++ b/tests/test_cli_stream.py
@@ -217,9 +217,7 @@ def test_stream_true_uses_printing_callback_handler():
     with mock.patch("manus_use.cli._make_agent", side_effect=capturing_make_agent):
         with mock.patch("manus_use.cli._append_history"):
             with mock.patch("sys.stdout", StringIO()):
-                with mock.patch(
-                    "strands.handlers.PrintingCallbackHandler", mock_handler_class
-                ):
+                with mock.patch("strands.handlers.PrintingCallbackHandler", mock_handler_class):
                     cli._run_single_shot(
                         "task",
                         mode="single",
@@ -312,6 +310,7 @@ def test_stream_generator_result_iterates_chunks():
     stderr_capture = StringIO()
 
     import builtins
+
     real_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):
@@ -447,6 +446,7 @@ def test_stream_fallback_buffered_warning_for_non_iterable():
     stderr_capture = StringIO()
 
     import builtins
+
     real_import = builtins.__import__
 
     def mock_import(name, *args, **kwargs):

--- a/tests/test_packageability.py
+++ b/tests/test_packageability.py
@@ -28,6 +28,7 @@ import sys
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _fresh_import(module_name: str):
     """Import *module_name* from scratch (drop any cached version first)."""
     # Remove the module and any sub-modules from the cache so the import is
@@ -94,9 +95,7 @@ class TestModuleImports:
         # should NOT have been inserted by the module.
         new_entries = [p for p in sys.path if p not in original_path]
         src_injections = [p for p in new_entries if p.endswith("/src")]
-        assert src_injections == [], (
-            f"workflow_agent injected unexpected sys.path entries: {src_injections}"
-        )
+        assert src_injections == [], f"workflow_agent injected unexpected sys.path entries: {src_injections}"
 
 
 # ---------------------------------------------------------------------------
@@ -124,8 +123,7 @@ def test_no_src_prefix_imports_in_package(tmp_path):
 
     assert violations == [], (
         "Found 'from src.' imports in the following files — "
-        "these break the installed package:\n  "
-        + "\n  ".join(violations)
+        "these break the installed package:\n  " + "\n  ".join(violations)
     )
 
 
@@ -151,6 +149,5 @@ def test_no_sys_path_src_injection_in_package():
 
     assert violations == [], (
         "Found sys.path.insert('src') calls in the following files — "
-        "these break the installed package:\n  "
-        + "\n  ".join(violations)
+        "these break the installed package:\n  " + "\n  ".join(violations)
     )

--- a/tests/test_readme_cli.py
+++ b/tests/test_readme_cli.py
@@ -227,9 +227,7 @@ class TestAnalyzeSubcommand:
         with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
             with mock.patch("manus_use.cli.Config") as m_cfg:
                 m_cfg.from_file.return_value = mock.MagicMock()
-                with mock.patch.object(
-                    sys, "argv", ["manus-use", "analyze", "CVE-2025-6554"]
-                ):
+                with mock.patch.object(sys, "argv", ["manus-use", "analyze", "CVE-2025-6554"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -250,9 +248,7 @@ class TestAnalyzeSubcommand:
         with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
             with mock.patch("manus_use.cli.Config") as m_cfg:
                 m_cfg.from_file.return_value = mock.MagicMock()
-                with mock.patch.object(
-                    sys, "argv", ["manus-use", "analyze", "CVE-2025-6554", "--verify"]
-                ):
+                with mock.patch.object(sys, "argv", ["manus-use", "analyze", "CVE-2025-6554", "--verify"]):
                     with pytest.raises(SystemExit):
                         cli.main()
 

--- a/tests/test_release_infra.py
+++ b/tests/test_release_infra.py
@@ -1,0 +1,241 @@
+"""Living-doc tests for the release infrastructure.
+
+These tests guard two files:
+  - .github/workflows/publish.yml  — PyPI publish workflow
+  - .pre-commit-config.yaml        — pre-commit hooks configuration
+
+The tests verify structural properties (file exists, keys present, triggers
+correct) without requiring network access or external tool execution.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+PUBLISH_YML = ROOT / ".github" / "workflows" / "publish.yml"
+PRE_COMMIT_CFG = ROOT / ".pre-commit-config.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(path: Path) -> dict:
+    """Parse YAML from *path* and return the top-level dict."""
+    try:
+        import yaml  # type: ignore[import]
+    except ImportError:
+        pytest.skip("pyyaml not installed; skipping YAML-parse checks")
+    with path.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+# ===========================================================================
+# TestPublishWorkflow
+# ===========================================================================
+
+
+class TestPublishWorkflow:
+    """Guards .github/workflows/publish.yml."""
+
+    def test_file_exists(self):
+        assert PUBLISH_YML.exists(), (
+            f"{PUBLISH_YML} not found — create .github/workflows/publish.yml to enable automated PyPI releases"
+        )
+
+    def test_parses_as_valid_yaml(self):
+        data = _load_yaml(PUBLISH_YML)
+        assert isinstance(data, dict), "publish.yml must be a YAML mapping"
+
+    def test_triggers_on_version_tags(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        # Must mention tag-based push trigger
+        assert "tags:" in content, "publish.yml must have a tags: trigger so it fires on version tags"
+        # Must match semver-style tags (v0.1.0 etc.)
+        assert re.search(r"v\[0-9\]", content), "publish.yml tags pattern must match semver tags like v0.1.0"
+
+    def test_has_validate_job(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "validate" in content, "publish.yml must have a validate job that runs tests before publishing"
+
+    def test_has_build_job(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "build" in content, "publish.yml must have a build job that produces sdist + wheel"
+
+    def test_has_publish_pypi_job(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "publish" in content.lower(), "publish.yml must have a job that uploads to PyPI"
+
+    def test_uses_trusted_publishing(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "pypa/gh-action-pypi-publish" in content, (
+            "publish.yml must use pypa/gh-action-pypi-publish for OIDC Trusted Publishing "
+            "(no long-lived API tokens required)"
+        )
+
+    def test_has_github_release_job(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "github-release" in content or "softprops/action-gh-release" in content, (
+            "publish.yml should create a GitHub Release with release notes and build artifacts"
+        )
+
+    def test_requires_id_token_write_permission(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "id-token: write" in content, (
+            "publish.yml must grant id-token: write permission for OIDC Trusted Publishing"
+        )
+
+    def test_requires_contents_write_permission(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "contents: write" in content, (
+            "publish.yml must grant contents: write permission to create GitHub Releases"
+        )
+
+    def test_uses_official_checkout_action(self):
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "actions/checkout@v4" in content, "publish.yml should use actions/checkout@v4 (pinned major version)"
+
+    def test_validates_before_publish(self):
+        """Build job must depend on validate completing first."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        # needs: validate must appear in the build job section
+        assert re.search(r"needs:.*validate", content), (
+            "The build job must declare 'needs: validate' so tests always run before publishing"
+        )
+
+    def test_publish_depends_on_build(self):
+        """Publish job must depend on build job."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        # needs: build must appear in the publish section
+        assert re.search(r"needs:.*build", content), (
+            "The publish job must declare 'needs: build' so artifacts are ready before upload"
+        )
+
+    def test_prerelease_detection_for_tagged_prereleases(self):
+        """Pre-release tags (e.g. v0.1.0-rc1) should be marked as GitHub pre-release."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "prerelease:" in content, (
+            "publish.yml should detect pre-release tags (v0.1.0-rc1) and mark the GitHub Release as a pre-release"
+        )
+
+    def test_no_long_lived_api_token(self):
+        """Ensure we rely on Trusted Publishing, not a hardcoded PYPI_API_TOKEN."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "PYPI_API_TOKEN" not in content and "PYPI_TOKEN" not in content, (
+            "publish.yml must not reference PYPI_API_TOKEN — use OIDC Trusted Publishing instead"
+        )
+
+    def test_concurrency_cancel_in_progress_false(self):
+        """An in-flight publish must never be cancelled."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "cancel-in-progress: false" in content, (
+            "publish.yml concurrency group must set cancel-in-progress: false "
+            "— cancelling an in-flight PyPI upload can leave the release in a broken state"
+        )
+
+    def test_uses_hatch_build(self):
+        """hatch is already the build backend; the workflow should use it."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "hatch build" in content, (
+            "publish.yml should build with 'hatch build' — consistent with pyproject.toml "
+            "which uses hatchling as the build-backend"
+        )
+
+    def test_runs_twine_check(self):
+        """twine check catches malformed metadata before upload."""
+        content = PUBLISH_YML.read_text(encoding="utf-8")
+        assert "twine check" in content, (
+            "publish.yml should run 'twine check dist/*' after building "
+            "to catch malformed package metadata before uploading to PyPI"
+        )
+
+
+# ===========================================================================
+# TestPreCommitConfig
+# ===========================================================================
+
+
+class TestPreCommitConfig:
+    """Guards .pre-commit-config.yaml."""
+
+    def test_file_exists(self):
+        assert PRE_COMMIT_CFG.exists(), (
+            f"{PRE_COMMIT_CFG} not found — pre-commit is listed as a dev dep "
+            "in pyproject.toml but has no config; create .pre-commit-config.yaml"
+        )
+
+    def test_parses_as_valid_yaml(self):
+        data = _load_yaml(PRE_COMMIT_CFG)
+        assert isinstance(data, dict), ".pre-commit-config.yaml must be a YAML mapping"
+
+    def test_has_repos_key(self):
+        data = _load_yaml(PRE_COMMIT_CFG)
+        assert "repos" in data, ".pre-commit-config.yaml must have a top-level 'repos' key"
+
+    def test_repos_is_list(self):
+        data = _load_yaml(PRE_COMMIT_CFG)
+        assert isinstance(data.get("repos"), list), "'repos' must be a list of hook repos"
+
+    def test_has_ruff_hook(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "ruff" in content, (
+            ".pre-commit-config.yaml must include ruff hooks — ruff is already "
+            "the configured linter/formatter in pyproject.toml"
+        )
+
+    def test_uses_astral_ruff_pre_commit(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "astral-sh/ruff-pre-commit" in content, "use the official astral-sh/ruff-pre-commit repo for ruff hooks"
+
+    def test_has_ruff_format_hook(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "ruff-format" in content, ".pre-commit-config.yaml must include ruff-format so commits stay formatted"
+
+    def test_has_yaml_check(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "check-yaml" in content, (
+            ".pre-commit-config.yaml should include check-yaml to catch broken workflow files"
+        )
+
+    def test_has_toml_check(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "check-toml" in content, (
+            ".pre-commit-config.yaml should include check-toml to catch malformed pyproject.toml"
+        )
+
+    def test_has_end_of_file_fixer(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "end-of-file-fixer" in content, (
+            ".pre-commit-config.yaml should include end-of-file-fixer for consistent line endings"
+        )
+
+    def test_has_merge_conflict_check(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "check-merge-conflict" in content, (
+            ".pre-commit-config.yaml should include check-merge-conflict to prevent committing unresolved merge markers"
+        )
+
+    def test_ruff_hook_has_fix_arg(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "--fix" in content, "ruff hook should include '--fix' to auto-correct lint violations on commit"
+
+    def test_rev_pinned_for_ruff(self):
+        """ruff hook must have a pinned rev (not 'latest')."""
+        data = _load_yaml(PRE_COMMIT_CFG)
+        for repo in data.get("repos", []):
+            if "ruff" in repo.get("repo", ""):
+                rev = repo.get("rev", "")
+                assert rev and rev != "latest", f"ruff-pre-commit rev must be pinned (e.g. 'v0.4.4'), got: {rev!r}"
+                assert rev.startswith("v"), f"ruff-pre-commit rev should start with 'v', got: {rev!r}"
+
+    def test_debug_statements_hook(self):
+        content = PRE_COMMIT_CFG.read_text(encoding="utf-8")
+        assert "debug-statements" in content, (
+            ".pre-commit-config.yaml should include debug-statements hook to prevent "
+            "committing stray pdb.set_trace() / breakpoint() calls"
+        )

--- a/tests/test_remediation_agent.py
+++ b/tests/test_remediation_agent.py
@@ -260,9 +260,7 @@ def test_main_dispatches_remediate_with_json_flag(monkeypatch):
     """main() passes --output json through to _run_remediate."""
     from manus_use import cli
 
-    monkeypatch.setattr(
-        sys, "argv", ["manus-use", "remediate", "CVE-2024-3094", "--output", "json"]
-    )
+    monkeypatch.setattr(sys, "argv", ["manus-use", "remediate", "CVE-2024-3094", "--output", "json"])
 
     with mock.patch("manus_use.cli._run_remediate", return_value=0) as mock_run:
         with pytest.raises(SystemExit) as exc_info:

--- a/tests/test_vd_agent.py
+++ b/tests/test_vd_agent.py
@@ -206,9 +206,7 @@ def test_run_discover_calls_handle_request():
     from manus_use.agents.vd_agent import VulnerabilityDiscoveryAgent
 
     with mock.patch.object(VulnerabilityDiscoveryAgent, "__init__", return_value=None):
-        with mock.patch.object(
-            VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULTS"
-        ) as m_handle:
+        with mock.patch.object(VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULTS") as m_handle:
             rc = cli._run_discover(
                 since="2025-06-01",
                 min_epss=0.5,
@@ -247,9 +245,7 @@ def test_run_discover_output_json():
     json_calls = []
 
     with mock.patch.object(VulnerabilityDiscoveryAgent, "__init__", return_value=None):
-        with mock.patch.object(
-            VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULT"
-        ):
+        with mock.patch.object(VulnerabilityDiscoveryAgent, "handle_request", return_value="RESULT"):
             with mock.patch.object(cli.console, "print_json", side_effect=json_calls.append):
                 rc = cli._run_discover(
                     since="2025-06-01",

--- a/variant_analysis_agent.py
+++ b/variant_analysis_agent.py
@@ -8,6 +8,7 @@ Usage::
 Or via CLI::
     manus-use variants CVE-2024-3094
 """
+
 import sys
 import warnings
 


### PR DESCRIPTION
## What & Why

manus-use has a PyPI badge in the README and `hatchling` as its build backend — but there has never been an automated path from `git tag v0.1.0` to a published package. There is also no `.pre-commit-config.yaml` despite `pre-commit` being listed as a dev dependency since the project was created.

This PR closes both gaps and adds 32 living-doc tests to guard the new files.

## Changes

### `.github/workflows/publish.yml` (new)
Four-job pipeline triggered on semver version tags (`v0.1.0`, `v0.2.0-rc1`, etc.):

| Job | What it does |
|-----|-------------|
| **validate** | `ruff check` + `ruff format --check` + `pytest -m "not integration"` on Python 3.11 & 3.12 |
| **build** | `hatch build` (sdist + wheel) → `twine check dist/*` → upload artifact |
| **publish-pypi** | OIDC **Trusted Publishing** via `pypa/gh-action-pypi-publish` — no long-lived API tokens |
| **github-release** | `softprops/action-gh-release` with auto-generated notes + build artifacts |

Other design choices:
- `cancel-in-progress: false` — never cancel an in-flight PyPI upload
- Pre-release tags (`v0.1.0-rc1`) auto-marked as GitHub pre-releases
- `needs: validate` → `needs: build` enforces ordering

### `.pre-commit-config.yaml` (new)
Wires up `pre-commit` (already a dev dep) with:
- `ruff` lint (`--fix`) + `ruff-format`
- `pre-commit-hooks`: trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-merge-conflict, debug-statements
- `mypy` type-check on `src/`

### `tests/test_release_infra.py` (new, 32 tests)
Living-doc tests:
- `TestPublishWorkflow` (18 tests): file exists, YAML valid, tag trigger, 4 jobs, OIDC, permissions, dependency chain, pre-release detection, no hardcoded tokens, concurrency guard, hatch build, twine check
- `TestPreCommitConfig` (14 tests): file exists, YAML valid, ruff hooks, ruff-format, check-yaml, check-toml, EOF fixer, merge-conflict, --fix, pinned rev, debug-statements

### chore: fix pre-existing ruff violations
- `I001` import-sort in `src/manus_use/agents/__init__.py`
- `ruff format` on 16 files with formatting drift

## Tests

- **338 passed**, 3 deselected (integration), 0 ruff violations — up from 306 on main
- 32 new tests in `tests/test_release_infra.py`

## Setup (one-time, by maintainer)

Create a Trusted Publisher on https://pypi.org:
- Owner: `manus-use` | Repo: `manus-use` | Workflow: `publish.yml` | Environment: `pypi`

Then release: `git tag v0.1.0 && git push origin v0.1.0`