### PR TITLE
feat(tools): EPSS trend tracker with spike detection + epss-trend CLI subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,31 @@ manus-use remediate CVE-2024-3094 --output json
 | `--output {text,json}` | `text` | Report format |
 | `--config FILE` | — | Override config |
 
+### `manus-use epss-trend <CVE-ID>` — EPSS score history
+
+```bash
+# Show 30-day EPSS score history and detect exploitation spikes
+manus-use epss-trend CVE-2024-3094
+
+# Show 90 days of history
+manus-use epss-trend CVE-2024-3094 --days 90
+
+# Machine-readable output
+manus-use epss-trend CVE-2024-3094 --output json | jq .analysis.spike_detected
+```
+
+Fetches daily EPSS (Exploit Prediction Scoring System) scores from the
+[FIRST.org API](https://www.first.org/epss/) and detects significant jumps.
+A spike of ≥ 0.10 in a 7-day window indicates the vulnerability has recently
+been weaponised or picked up by active threat actors.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--days N` | `30` | Days of EPSS history to retrieve (max 365) |
+| `--output {text,json}` | `text` | Output format; `json` includes the full time-series |
+
 ### `manus-use variants <CVE-ID>` — Variant analysis
 
 ```bash
@@ -424,6 +449,12 @@ manus-use analyze CVE-2024-3094 --output json | jq .cvss_score
 
 # Verify exploitability in a Docker sandbox, then write a Lark report
 manus-use analyze CVE-2025-6554 --verify --output lark
+
+# Check 30-day EPSS trend and detect exploitation spikes
+manus-use epss-trend CVE-2024-3094
+
+# Check 90-day EPSS history in JSON
+manus-use epss-trend CVE-2025-6554 --days 90 --output json
 
 # Generate remediation steps
 manus-use remediate CVE-2024-3094

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -50,9 +50,10 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 - Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
 - Call `get_github_advisory` to get advisory information from GitHub.
 
-**Step 2: Check for Known Exploitation**
+**Step 2: Check for Known Exploitation and EPSS Trend**
 - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
+- Call `get_epss_trend` with the CVE ID (default 30 days of history). A `spike_detected=true` result (>0.10 jump in 7 days) indicates the vulnerability has recently been weaponised or discovered by attackers — flag this prominently in the report with the spike date and magnitude.
 
 **Step 3: Gather Public Exploits and Advisories**
 - First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week — note this in your analysis.
@@ -175,6 +176,7 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
@@ -227,6 +229,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.query_threat_intelligence_feeds",
             get_github_advisory,
             "manus_use.tools.verify_exploit",
+            get_epss_trend,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1041,7 +1041,102 @@ def _run_variants(argv: list[str]) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend"}
+
+
+# ---------------------------------------------------------------------------
+# epss-trend subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_epss_trend_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use epss-trend",
+        description=(
+            "Fetch EPSS (Exploit Prediction Scoring System) score history for a CVE \n"
+            "and flag significant spikes that indicate new exploitation activity."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--days",
+        type=int,
+        default=30,
+        metavar="N",
+        help="Days of EPSS history to retrieve (default: 30, max: 365)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_epss_trend(argv: list[str]) -> int:
+    parser = _build_epss_trend_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_use.tools.get_epss_trend import _analyse_series, _fetch_epss_time_series
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        raw = _fetch_epss_time_series(cve_id, args.days)
+    except Exception as exc:
+        print(f"[error] EPSS API request failed: {exc}", file=sys.stderr)
+        return 1
+
+    data_entries = raw.get("data", [])
+    if not data_entries:
+        print(f"[error] No EPSS data found for {cve_id.upper()}", file=sys.stderr)
+        return 1
+
+    entry = data_entries[0]
+    time_series = list(entry.get("time-series", []))
+    current_point = {
+        "date": entry.get("date", ""),
+        "epss": entry.get("epss", "0"),
+        "percentile": entry.get("percentile", "0"),
+    }
+    if current_point["date"] and not any(p["date"] == current_point["date"] for p in time_series):
+        time_series = [current_point] + time_series
+
+    analysis = _analyse_series(time_series)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps({"cve_id": cve_id.upper(), "analysis": analysis}, indent=2))
+        return 0
+
+    # Text output
+    spike_flag = "\u26a0\ufe0f  SPIKE DETECTED" if analysis["spike_detected"] else "\u2705  No significant spike"
+    current_pct = float(analysis.get("current_percentile", 0))
+    print(f"EPSS trend for {cve_id.upper()}  ({len(analysis['points'])} days)")
+    print(f"  Current score   : {analysis.get('current_epss', 'N/A'):.4f}  (percentile {current_pct:.1%})")
+    print(f"  Oldest score    : {analysis.get('oldest_epss', 'N/A'):.4f}  (date: {analysis.get('oldest_date', 'N/A')})")
+    print(f"  Latest date     : {analysis.get('latest_date', 'N/A')}")
+    print(f"  Trend           : {analysis['trend']}")
+    print(
+        f"  Max 7-day jump  : {analysis['max_7d_jump']:.4f}"
+        + (f"  (peaked {analysis['max_7d_jump_end_date']})" if analysis["max_7d_jump_end_date"] else "")
+    )
+    print(f"  {spike_flag}")
+    if analysis["points"]:
+        print()
+        print("  Date         EPSS     Percentile")
+        print("  ----------   ------   ----------")
+        for pt in analysis["points"][-15:]:  # show last 15 rows
+            print(f"  {pt['date']}   {pt['epss']:.4f}   {pt['percentile']:.4f}")
+    return 0
 
 
 def _build_run_parser() -> argparse.ArgumentParser:
@@ -1065,6 +1160,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  manus-use init           # create ~/.manus-use/config.toml interactively\n"
             "  manus-use doctor         # check packages, config, and API keys\n"
             "  manus-use history        # show recent runs (use --help for filters)\n"
+            "\n"
+            "  # EPSS trend analysis\n"
+            "  manus-use epss-trend CVE-2024-3094\n"
+            "  manus-use epss-trend CVE-2024-3094 --days 90 --output json\n"
             "\n"
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
@@ -1331,6 +1430,10 @@ def main() -> None:
     if first_positional == "variants":
         idx = argv.index("variants")
         sys.exit(_run_variants(argv[idx + 1 :]))
+
+    if first_positional == "epss-trend":
+        idx = argv.index("epss-trend")
+        sys.exit(_run_epss_trend(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/get_epss_trend.py
+++ b/src/manus_use/tools/get_epss_trend.py
@@ -1,0 +1,216 @@
+"""
+Tool for fetching EPSS (Exploit Prediction Scoring System) score history for a CVE.
+
+Uses the FIRST.org EPSS API time-series endpoint to retrieve historical scores,
+then analyses the trend to flag significant jumps that indicate new exploitation activity.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# Threshold: a jump of this magnitude in a single week is flagged as a significant spike
+_SPIKE_THRESHOLD = 0.10
+
+TOOL_SPEC = {
+    "name": "get_epss_trend",
+    "description": (
+        "Fetches the EPSS (Exploit Prediction Scoring System) score history for a given CVE "
+        "using the FIRST.org time-series API. Returns a chronological list of daily scores, "
+        "the current score, the maximum observed jump (spike) between consecutive days, "
+        "and a flag indicating whether a significant spike was detected (suggesting new "
+        "exploitation activity). Use this after get_nvd_data to understand whether exploitation "
+        "risk is rising or stable."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2024-3094').",
+                },
+                "days": {
+                    "type": "integer",
+                    "description": (
+                        "How many days of history to return. Defaults to 30. Maximum is 365 (the FIRST.org API limit)."
+                    ),
+                    "default": 30,
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+def _fetch_epss_time_series(cve_id: str, days: int) -> dict[str, Any]:
+    """Call the FIRST.org EPSS API and return parsed JSON."""
+    url = "https://api.first.org/data/v1/epss"
+    params: dict[str, Any] = {
+        "cve": cve_id.upper(),
+        "scope": "time-series",
+    }
+    if days and days > 0:
+        # The API returns up to `limit` data points; each point is one day
+        params["limit"] = min(days, 365)
+
+    response = requests.get(url, params=params, timeout=20)
+    response.raise_for_status()
+    return response.json()
+
+
+def _analyse_series(series: list[dict[str, str]]) -> dict[str, Any]:
+    """
+    Given a list of {"epss": "0.xxx", "percentile": "0.xxx", "date": "YYYY-MM-DD"} dicts
+    (already sorted newest-first by the API), compute trend metrics.
+    """
+    # Normalise to floats and sort oldest-first for analysis
+    points = sorted(
+        [
+            {
+                "date": pt["date"],
+                "epss": float(pt["epss"]),
+                "percentile": float(pt["percentile"]),
+            }
+            for pt in series
+        ],
+        key=lambda x: x["date"],
+    )
+
+    if not points:
+        return {"points": [], "spike_detected": False, "max_jump": 0.0, "trend": "unknown"}
+
+    scores = [p["epss"] for p in points]
+
+    # Largest single-day jump (absolute)
+    jumps = [scores[i + 1] - scores[i] for i in range(len(scores) - 1)]
+    max_jump = max(jumps) if jumps else 0.0
+    max_jump_idx = jumps.index(max_jump) if jumps else -1
+    max_jump_date = points[max_jump_idx + 1]["date"] if max_jump_idx >= 0 else None
+
+    # Largest 7-day jump (sliding window)
+    max_7d_jump = 0.0
+    max_7d_end_date = None
+    for i in range(len(scores) - 1):
+        for j in range(i + 1, min(i + 8, len(scores))):
+            delta = scores[j] - scores[i]
+            if delta > max_7d_jump:
+                max_7d_jump = delta
+                max_7d_end_date = points[j]["date"]
+
+    spike_detected = max_7d_jump >= _SPIKE_THRESHOLD
+
+    # Simple trend: compare first half vs second half averages
+    mid = len(scores) // 2
+    first_half_avg = sum(scores[:mid]) / mid if mid else scores[0]
+    second_half_avg = sum(scores[mid:]) / (len(scores) - mid) if (len(scores) - mid) else scores[-1]
+
+    if second_half_avg > first_half_avg + 0.02:
+        trend = "rising"
+    elif second_half_avg < first_half_avg - 0.02:
+        trend = "falling"
+    else:
+        trend = "stable"
+
+    return {
+        "points": points,
+        "current_epss": scores[-1],
+        "current_percentile": points[-1]["percentile"],
+        "oldest_epss": scores[0],
+        "oldest_date": points[0]["date"],
+        "latest_date": points[-1]["date"],
+        "max_single_day_jump": round(max_jump, 6),
+        "max_single_day_jump_date": max_jump_date,
+        "max_7d_jump": round(max_7d_jump, 6),
+        "max_7d_jump_end_date": max_7d_end_date,
+        "spike_detected": spike_detected,
+        "spike_threshold_used": _SPIKE_THRESHOLD,
+        "trend": trend,
+    }
+
+
+def get_epss_trend(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Fetch EPSS time-series for a CVE and analyse trend / spikes."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+    days = int(tool_input.get("days", 30))
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("get_epss_trend", result)
+        return result
+
+    try:
+        raw = _fetch_epss_time_series(cve_id, days)
+    except requests.exceptions.RequestException as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"FIRST.org EPSS API request failed: {exc}"}],
+        }
+        log_tool_output_size("get_epss_trend", result)
+        return result
+
+    data_entries = raw.get("data", [])
+    if not data_entries:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"No EPSS data found for {cve_id.upper()}. The CVE may be too recent or unknown."}],
+        }
+        log_tool_output_size("get_epss_trend", result)
+        return result
+
+    entry = data_entries[0]
+    time_series = entry.get("time-series", [])
+
+    # The top-level entry is the current/most-recent score; include it in the series
+    current_point = {
+        "date": entry.get("date", ""),
+        "epss": entry.get("epss", "0"),
+        "percentile": entry.get("percentile", "0"),
+    }
+    if current_point["date"] and not any(p["date"] == current_point["date"] for p in time_series):
+        time_series = [current_point] + list(time_series)
+
+    analysis = _analyse_series(time_series)
+
+    # Build a human-readable summary
+    spike_flag = "⚠️  SPIKE DETECTED" if analysis["spike_detected"] else "✅  No significant spike"
+    summary_lines = [
+        f"EPSS trend for {cve_id.upper()} ({len(analysis['points'])} days)",
+        f"  Current score : {analysis.get('current_epss', 'N/A'):.4f}  "
+        f"(percentile {float(analysis.get('current_percentile', 0)):.1%})",
+        f"  Trend         : {analysis['trend']}",
+        f"  Max 7-day jump: {analysis['max_7d_jump']:.4f}"
+        + (f" (peaked {analysis['max_7d_jump_end_date']})" if analysis["max_7d_jump_end_date"] else ""),
+        f"  {spike_flag}",
+    ]
+    summary = "\n".join(summary_lines)
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": summary},
+            {
+                "json": {
+                    "cve_id": cve_id.upper(),
+                    "analysis": analysis,
+                }
+            },
+        ],
+    }
+    log_tool_output_size("get_epss_trend", result)
+    return result

--- a/tests/test_epss_trend.py
+++ b/tests/test_epss_trend.py
@@ -1,0 +1,441 @@
+"""Tests for the EPSS trend tool and epss-trend CLI subcommand.
+
+All tests are unit tests that mock the FIRST.org API; no network calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SAMPLE_TIME_SERIES = [
+    {"epss": "0.050000", "percentile": "0.850000", "date": "2026-06-24"},
+    {"epss": "0.040000", "percentile": "0.820000", "date": "2026-06-23"},
+    {"epss": "0.035000", "percentile": "0.810000", "date": "2026-06-22"},
+    {"epss": "0.030000", "percentile": "0.800000", "date": "2026-06-21"},
+    {"epss": "0.025000", "percentile": "0.790000", "date": "2026-06-20"},
+    {"epss": "0.020000", "percentile": "0.770000", "date": "2026-06-19"},
+    {"epss": "0.010000", "percentile": "0.700000", "date": "2026-06-18"},
+]
+
+_SPIKE_TIME_SERIES = [
+    {"epss": "0.900000", "percentile": "0.998000", "date": "2026-06-24"},
+    {"epss": "0.850000", "percentile": "0.997000", "date": "2026-06-23"},
+    {"epss": "0.750000", "percentile": "0.995000", "date": "2026-06-22"},
+    {"epss": "0.600000", "percentile": "0.990000", "date": "2026-06-21"},
+    {"epss": "0.500000", "percentile": "0.985000", "date": "2026-06-20"},
+    {"epss": "0.050000", "percentile": "0.850000", "date": "2026-06-19"},
+    {"epss": "0.010000", "percentile": "0.700000", "date": "2026-06-18"},
+]
+
+_MOCK_API_RESPONSE = {
+    "status": "OK",
+    "data": [
+        {
+            "cve": "CVE-2024-3094",
+            "epss": "0.050000",
+            "percentile": "0.850000",
+            "date": "2026-06-25",
+            "time-series": _SAMPLE_TIME_SERIES,
+        }
+    ],
+}
+
+_MOCK_SPIKE_RESPONSE = {
+    "status": "OK",
+    "data": [
+        {
+            "cve": "CVE-2024-3094",
+            "epss": "0.900000",
+            "percentile": "0.998000",
+            "date": "2026-06-25",
+            "time-series": _SPIKE_TIME_SERIES,
+        }
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# Tool module imports
+# ---------------------------------------------------------------------------
+
+
+def test_get_epss_trend_module_imports():
+    """The module must be importable without strands."""
+    import manus_use.tools.get_epss_trend as m
+
+    assert hasattr(m, "get_epss_trend")
+    assert hasattr(m, "TOOL_SPEC")
+    assert hasattr(m, "_analyse_series")
+    assert hasattr(m, "_fetch_epss_time_series")
+
+
+def test_tool_spec_has_required_fields():
+    from manus_use.tools.get_epss_trend import TOOL_SPEC
+
+    assert TOOL_SPEC["name"] == "get_epss_trend"
+    assert "cve_id" in TOOL_SPEC["inputSchema"]["json"]["properties"]
+    assert "days" in TOOL_SPEC["inputSchema"]["json"]["properties"]
+    assert TOOL_SPEC["inputSchema"]["json"]["required"] == ["cve_id"]
+
+
+# ---------------------------------------------------------------------------
+# _analyse_series unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_analyse_series_empty():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    result = _analyse_series([])
+    assert result["spike_detected"] is False
+    assert result["max_jump"] == 0.0
+    assert result["trend"] == "unknown"
+
+
+def test_analyse_series_stable():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    series = [{"date": f"2026-06-{10 + i:02d}", "epss": "0.500000", "percentile": "0.900000"} for i in range(10)]
+    result = _analyse_series(series)
+    assert result["trend"] == "stable"
+    assert result["spike_detected"] is False
+
+
+def test_analyse_series_rising():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    series = [
+        {"date": f"2026-06-{10 + i:02d}", "epss": f"{0.1 + i * 0.05:.6f}", "percentile": "0.900000"} for i in range(10)
+    ]
+    result = _analyse_series(series)
+    assert result["trend"] == "rising"
+
+
+def test_analyse_series_falling():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    series = [
+        {"date": f"2026-06-{10 + i:02d}", "epss": f"{0.8 - i * 0.05:.6f}", "percentile": "0.900000"} for i in range(10)
+    ]
+    result = _analyse_series(series)
+    assert result["trend"] == "falling"
+
+
+def test_analyse_series_spike_detected():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    result = _analyse_series(_SPIKE_TIME_SERIES)
+    assert result["spike_detected"] is True
+    assert result["max_7d_jump"] >= 0.10
+
+
+def test_analyse_series_no_spike():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    result = _analyse_series(_SAMPLE_TIME_SERIES)
+    assert result["spike_detected"] is False
+
+
+def test_analyse_series_returns_sorted_points():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    shuffled = list(reversed(_SAMPLE_TIME_SERIES))
+    result = _analyse_series(shuffled)
+    dates = [p["date"] for p in result["points"]]
+    assert dates == sorted(dates), "Points must be sorted oldest-first"
+
+
+def test_analyse_series_current_and_oldest():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    result = _analyse_series(_SAMPLE_TIME_SERIES)
+    assert result["oldest_date"] == "2026-06-18"
+    assert result["latest_date"] == "2026-06-24"
+    assert abs(result["current_epss"] - 0.05) < 1e-6
+    assert abs(result["oldest_epss"] - 0.01) < 1e-6
+
+
+def test_analyse_series_single_point():
+    from manus_use.tools.get_epss_trend import _analyse_series
+
+    result = _analyse_series([{"date": "2026-06-24", "epss": "0.300000", "percentile": "0.900000"}])
+    assert result["spike_detected"] is False
+    assert result["max_7d_jump"] == 0.0
+    assert len(result["points"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# get_epss_trend tool function
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_use(cve_id: str, days: int = 30) -> dict:
+    return {"toolUseId": "test-id-001", "input": {"cve_id": cve_id, "days": days}}
+
+
+def test_tool_returns_error_for_invalid_cve():
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    result = get_epss_trend(_make_tool_use("NOTACVE"))
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_tool_returns_error_for_empty_cve():
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    result = get_epss_trend(_make_tool_use(""))
+    assert result["status"] == "error"
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_success_returns_text_and_json(mock_fetch):
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    mock_fetch.return_value = _MOCK_API_RESPONSE
+
+    result = get_epss_trend(_make_tool_use("CVE-2024-3094"))
+    assert result["status"] == "success"
+    # Should have text summary + json analysis
+    content_types = [list(c.keys())[0] for c in result["content"]]
+    assert "text" in content_types
+    assert "json" in content_types
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_success_json_contains_analysis(mock_fetch):
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    mock_fetch.return_value = _MOCK_API_RESPONSE
+
+    result = get_epss_trend(_make_tool_use("CVE-2024-3094"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["cve_id"] == "CVE-2024-3094"
+    assert "analysis" in json_block
+    assert "spike_detected" in json_block["analysis"]
+    assert "trend" in json_block["analysis"]
+    assert "points" in json_block["analysis"]
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_spike_detected_flag(mock_fetch):
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    mock_fetch.return_value = _MOCK_SPIKE_RESPONSE
+
+    result = get_epss_trend(_make_tool_use("CVE-2024-3094"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["analysis"]["spike_detected"] is True
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_no_data_returns_error(mock_fetch):
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    mock_fetch.return_value = {"status": "OK", "data": []}
+
+    result = get_epss_trend(_make_tool_use("CVE-9999-9999"))
+    assert result["status"] == "error"
+    assert "No EPSS data" in result["content"][0]["text"]
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_api_failure_returns_error(mock_fetch):
+    import requests
+
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    mock_fetch.side_effect = requests.exceptions.ConnectionError("network unreachable")
+
+    result = get_epss_trend(_make_tool_use("CVE-2024-3094"))
+    assert result["status"] == "error"
+    assert "EPSS API request failed" in result["content"][0]["text"]
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_tool_normalises_cve_to_uppercase(mock_fetch):
+    from manus_use.tools.get_epss_trend import get_epss_trend
+
+    response_copy = {
+        "status": "OK",
+        "data": [
+            {
+                "cve": "CVE-2024-3094",
+                "epss": "0.860000",
+                "percentile": "0.997000",
+                "date": "2026-06-25",
+                "time-series": _SAMPLE_TIME_SERIES,
+            }
+        ],
+    }
+    mock_fetch.return_value = response_copy
+
+    result = get_epss_trend(_make_tool_use("cve-2024-3094"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["cve_id"] == "CVE-2024-3094"
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+def test_epss_trend_subcommand_registered_in_main():
+    from manus_use.cli import _SUBCOMMANDS
+
+    assert "epss-trend" in _SUBCOMMANDS
+
+
+def test_epss_trend_help_exits_zero():
+    from manus_use.cli import _build_epss_trend_parser
+
+    parser = _build_epss_trend_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_epss_trend_missing_cve_is_error():
+    from manus_use.cli import _build_epss_trend_parser
+
+    parser = _build_epss_trend_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code != 0
+
+
+def test_epss_trend_parser_defaults():
+    from manus_use.cli import _build_epss_trend_parser
+
+    parser = _build_epss_trend_parser()
+    args = parser.parse_args(["CVE-2024-3094"])
+    assert args.cve_id == "CVE-2024-3094"
+    assert args.days == 30
+    assert args.output == "text"
+
+
+def test_epss_trend_parser_custom_days():
+    from manus_use.cli import _build_epss_trend_parser
+
+    parser = _build_epss_trend_parser()
+    args = parser.parse_args(["CVE-2024-3094", "--days", "90"])
+    assert args.days == 90
+
+
+def test_epss_trend_parser_json_output():
+    from manus_use.cli import _build_epss_trend_parser
+
+    parser = _build_epss_trend_parser()
+    args = parser.parse_args(["CVE-2024-3094", "--output", "json"])
+    assert args.output == "json"
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_trend_text_output(mock_fetch, capsys):
+    from manus_use.cli import _run_epss_trend
+
+    mock_fetch.return_value = _MOCK_API_RESPONSE
+    rc = _run_epss_trend(["CVE-2024-3094"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CVE-2024-3094" in out
+    assert "EPSS trend" in out
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_trend_json_output(mock_fetch, capsys):
+    from manus_use.cli import _run_epss_trend
+
+    mock_fetch.return_value = _MOCK_API_RESPONSE
+    rc = _run_epss_trend(["CVE-2024-3094", "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["cve_id"] == "CVE-2024-3094"
+    assert "analysis" in data
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_trend_spike_shown_in_text(mock_fetch, capsys):
+    from manus_use.cli import _run_epss_trend
+
+    mock_fetch.return_value = _MOCK_SPIKE_RESPONSE
+    rc = _run_epss_trend(["CVE-2024-3094"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "SPIKE" in out
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_trend_no_data_returns_nonzero(mock_fetch):
+    from manus_use.cli import _run_epss_trend
+
+    mock_fetch.return_value = {"status": "OK", "data": []}
+    rc = _run_epss_trend(["CVE-9999-9999"])
+    assert rc != 0
+
+
+@patch("manus_use.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_trend_api_error_returns_nonzero(mock_fetch):
+    import requests
+
+    from manus_use.cli import _run_epss_trend
+
+    mock_fetch.side_effect = requests.exceptions.ConnectionError("down")
+    rc = _run_epss_trend(["CVE-2024-3094"])
+    assert rc != 0
+
+
+# ---------------------------------------------------------------------------
+# vi_agent integration: get_epss_trend is in the tool list
+# ---------------------------------------------------------------------------
+
+
+def test_vi_agent_imports_get_epss_trend():
+    """get_epss_trend module must be importable and have the expected interface."""
+    from manus_use.tools.get_epss_trend import TOOL_SPEC, get_epss_trend
+
+    assert callable(get_epss_trend)
+    assert TOOL_SPEC["name"] == "get_epss_trend"
+
+
+# ---------------------------------------------------------------------------
+# README coverage
+# ---------------------------------------------------------------------------
+
+
+def test_readme_documents_epss_trend():
+    """README must document the epss-trend subcommand."""
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "epss-trend" in content, "README must mention the epss-trend subcommand"
+    assert "EPSS" in content, "README must mention EPSS"
+
+
+def test_readme_epss_trend_has_options_table():
+    """README epss-trend section must document --days and --output flags."""
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "--days" in content
+    assert "--output" in content
+
+
+def test_readme_epss_trend_example_commands():
+    """README must include example commands for epss-trend."""
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "manus-use epss-trend CVE-" in content


### PR DESCRIPTION
## What & Why

EPSS (Exploit Prediction Scoring System) scores are already used in `manus-use discover` to filter CVEs by current risk. But a single point-in-time score misses the most important signal: **is this CVE getting more dangerous?** A CVE that jumps from EPSS 0.01 → 0.85 in 72 hours is being actively weaponised right now. That spike is often the earliest public signal before a CISA KEV listing or threat actor attribution.

This PR adds a dedicated EPSS history tool and CLI subcommand that surfaces exactly that signal.

## Changes

- **`src/manus_use/tools/get_epss_trend.py`** — new Strands tool that fetches daily EPSS history via the FIRST.org time-series API, computes trend direction, and detects exploitation spikes (≥0.10 jump in 7 days)
- **`src/manus_use/cli.py`** — new `manus-use epss-trend <CVE-ID>` subcommand with `--days N` and `--output {text,json}`
- **`src/manus_use/agents/vi_agent.py`** — `get_epss_trend` added to the VI agent tool list; Step 2 of system prompt updated to call it and flag spikes prominently
- **`README.md`** — documents the new subcommand with options table and examples

## Tests

34 new unit tests in `tests/test_epss_trend.py` (all mocked, no network calls). 440 total tests pass, 0 failures, ruff clean.