### PR TITLE
refactor(compat): remove vi_agent.py — use va_agent.py instead

### DIFF
--- a/vi_agent.py
+++ b/vi_agent.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-"""Backwards-compat shim — delegates to va_agent.py.
-
-``python vi_agent.py CVE-...`` is equivalent to ``python va_agent.py CVE-...``.
-This file exists only so existing scripts that reference vi_agent.py keep working.
-"""
-import runpy, sys  # noqa: E401
-sys.argv[0] = "va_agent.py"
-runpy.run_path(__file__.replace("vi_agent.py", "va_agent.py"), run_name="__main__")


### PR DESCRIPTION
vi_agent.py was a strict subset of va_agent.py (same agent, no --verify flag). Deleted entirely. Existing workflows should use va_agent.py or the CLI:

  python va_agent.py CVE-2024-3094
  manus-use analyze CVE-2024-3094