### PR TITLE
feat(tools): patch diff summariser — get_patch_diff tool + manus-use patch-diff subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,36 @@ been weaponised or picked up by active threat actors.
 | `--days N` | `30` | Days of EPSS history to retrieve (max 365) |
 | `--output {text,json}` | `text` | Output format; `json` includes the full time-series |
 
+### `manus-use patch-diff <CVE-ID>` — Patch diff summariser
+
+```bash
+# Fetch the fixing commit(s) for a CVE and summarise what changed
+manus-use patch-diff CVE-2024-3094
+
+# Machine-readable output
+manus-use patch-diff CVE-2024-3094 --output json | jq .commit_summaries
+```
+
+Finds the GitHub fixing commit(s) for a CVE (via the
+[GitHub Security Advisory database](https://github.com/advisories) and NVD
+reference links), fetches the raw unified diff, and produces a structured
+summary:
+- **Files and functions changed** — where in the codebase the fix landed
+- **Bug class** — detected from diff keywords (e.g. `auth_bypass`, `sql_injection`,
+  `buffer_overflow`, `use_after_free`, `input_validation`, …)
+- **Reproduction condition hints** — added guard/validation lines that reveal the
+  minimal condition required to trigger the vulnerability
+- **Commit URL** — direct link to the fixing commit on GitHub
+
+Useful for understanding *how* a vulnerability was introduced and fixed without
+having to read the raw diff yourself. Composable with `analyze` and `epss-trend`.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format; `json` includes the full commit summary |
+
 ### `manus-use variants <CVE-ID>` — Variant analysis
 
 ```bash
@@ -455,6 +485,10 @@ manus-use epss-trend CVE-2024-3094
 
 # Check 90-day EPSS history in JSON
 manus-use epss-trend CVE-2025-6554 --days 90 --output json
+
+# Summarise the fixing commit (files changed, bug class, reproduction hints)
+manus-use patch-diff CVE-2024-3094
+manus-use patch-diff CVE-2024-3094 --output json | jq .commit_summaries
 
 # Generate remediation steps
 manus-use remediate CVE-2024-3094

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -86,13 +86,21 @@ Your process is optimized to build a comprehensive picture from authoritative, f
     - Based on your analysis, classify the PoC. Is it a confirmed RCE? A DoS? A simple vulnerability checker?
     - In your final report, create a dedicated section for this analysis, clearly stating your confidence in the PoC's functionality and impact.
 
-**Step 6: Analyze Weakness**
+**Step 6: Patch Diff Analysis**
+- Call `get_patch_diff` with the CVE ID. If a fixing commit is found, include in the report:
+  - Which files and functions were modified.
+  - The primary bug class identified from the diff (e.g. `auth_bypass`, `sql_injection`, `buffer_overflow`).
+  - The reproduction condition hints extracted from the added lines.
+  - A direct link to the commit on GitHub.
+  If no commit is found (private repo or non-GitHub), note this and proceed.
+
+**Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
-**Step 7: Final Threat Intelligence Check**
+**Step 8: Final Threat Intelligence Check**
 - Use `query_threat_intelligence_feeds` to see if the CVE is being discussed by threat actors, which provides context beyond whether it is just "exploited".
 
-**Step 8: Final Quality Assurance and Report Generation**
+**Step 9: Final Quality Assurance and Report Generation**
 - **Data Completeness Check**: Verify all critical fields are populated.
 - **Information Consistency**: Ensure the technical description, CVSS vector, and exploitability analysis are consistent.
 - **Generate Report**: Once all checks pass, use the `create_lark_document` tool to synthesize all validated findings. Keep `technical_details` concise and focused on vulnerability mechanics, affected components, exploitation prerequisites or scenarios, impact, and detection guidance. Structure `technical_details` with these exact Markdown subsection headers where the corresponding content is present: `### Detection guidance`, `### Exploitability Analysis`, `### Expected impact`, and `### Affected conditions`. Prefix those subsection headers with `### ` exactly, and do not render those labels as plain text or bold-only labels. Avoid one large paragraph; use short paragraphs separated by blank lines, and use bullet points when listing components, prerequisites, impacts, or detection indicators. Use Markdown syntax only when needed, especially the required `### ` subsection headers and inline code for files, functions, variables, commands, CVE/CWE identifiers, or other technical names; avoid decorative formatting such as bold-only section labels. The report must include a dedicated section on Exploitability Analysis and a Sources section listing all URLs. Recommendations section must consist of concise, actionable, and purely proactive technical steps for remediation or mitigation. Each step should be a bullet point starting with an asterisk "*" and ending with a new line character "\\n", without using full sentences or terminal punctuation. Recommendations section should exclude all non-technical actions, such as policy reviews, procedural updates, or post-implementation verification and validation steps. Do not include any passive recommendations.
@@ -178,6 +186,7 @@ class VulnerabilityIntelligenceAgent:
 
             from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
+            from manus_use.tools.get_patch_diff import get_patch_diff
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -230,6 +239,7 @@ class VulnerabilityIntelligenceAgent:
             get_github_advisory,
             "manus_use.tools.verify_exploit",
             get_epss_trend,
+            get_patch_diff,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1041,7 +1041,7 @@ def _run_variants(argv: list[str]) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend", "patch-diff"}
 
 
 # ---------------------------------------------------------------------------
@@ -1139,6 +1139,74 @@ def _run_epss_trend(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# patch-diff subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_patch_diff_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use patch-diff",
+        description=(
+            "Fetch the fixing-commit diff for a CVE from GitHub and produce a\n"
+            "structured summary: files changed, functions touched, bug class,\n"
+            "and reproduction condition hints."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_patch_diff(argv: list[str]) -> int:
+    parser = _build_patch_diff_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    payload = fetch_and_summarise(cve_id)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    # --- text output ---
+    print(payload["message"])
+    if payload["not_found"]:
+        return 0
+
+    for idx, s in enumerate(payload["commit_summaries"], 1):
+        print(f"\nCommit {idx}: {s['commit_url']}")
+        if s["files_changed"]:
+            print(f"  Files changed    : {', '.join(s['files_changed'][:8])}")
+        if s["functions_touched"]:
+            print(f"  Functions touched: {', '.join(s['functions_touched'][:8])}")
+        print(f"  Lines +{s['added_lines']} / -{s['removed_lines']}")
+        print(f"  Primary bug class: {s['primary_bug_class']}")
+        if len(s["matched_bug_classes"]) > 1:
+            print(f"  All bug classes  : {', '.join(s['matched_bug_classes'])}")
+        if s["reproduction_condition_hints"]:
+            print("  Reproduction hints:")
+            for hint in s["reproduction_condition_hints"]:
+                print(f"    • {hint}")
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -1164,6 +1232,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # EPSS trend analysis\n"
             "  manus-use epss-trend CVE-2024-3094\n"
             "  manus-use epss-trend CVE-2024-3094 --days 90 --output json\n"
+            "\n"
+            "  # Patch diff summariser (fixing-commit analysis)\n"
+            "  manus-use patch-diff CVE-2024-3094\n"
+            "  manus-use patch-diff CVE-2024-3094 --output json\n"
             "\n"
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
@@ -1434,6 +1506,10 @@ def main() -> None:
     if first_positional == "epss-trend":
         idx = argv.index("epss-trend")
         sys.exit(_run_epss_trend(argv[idx + 1 :]))
+
+    if first_positional == "patch-diff":
+        idx = argv.index("patch-diff")
+        sys.exit(_run_patch_diff(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/get_patch_diff.py
+++ b/src/manus_use/tools/get_patch_diff.py
@@ -1,0 +1,514 @@
+"""
+Tool for fetching and summarising the fixing commit diff for a CVE.
+
+Given a CVE identifier, this tool:
+1. Looks up the GitHub Security Advisory to find the patching repository / commit.
+2. Falls back to searching for references in the NVD advisory (GitHub commit URLs).
+3. Fetches the raw unified diff from GitHub's API.
+4. Produces a structured summary: which function(s) changed, what class of bug
+   was fixed, and the minimal condition required to trigger it.
+
+Only public GitHub repositories (unauthenticated or via GITHUB_TOKEN) are
+supported.  Private repositories and non-GitHub hosting return a descriptive
+"not_found" result rather than an error.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Bug-class keyword mapping (applied to the unified diff text)
+# ---------------------------------------------------------------------------
+_BUG_CLASSES: list[tuple[str, list[str]]] = [
+    (
+        "sql_injection",
+        ["sql", "query", "execute", "cursor", "select ", "insert ", "update ", "delete ", "where "],
+    ),
+    (
+        "command_injection",
+        ["os.system", "subprocess", "shell=True", "exec(", "eval(", "popen", "execv"],
+    ),
+    (
+        "path_traversal",
+        ["../", "..\\", "os.path.join", "realpath", "abspath", "traverse", "chroot"],
+    ),
+    (
+        "buffer_overflow",
+        ["memcpy", "strcpy", "strcat", "sprintf", "gets(", "scanf", "overflow", "struct.pack", "ctypes"],
+    ),
+    (
+        "integer_overflow",
+        ["integer overflow", "int overflow", "wrap around", "wraparound", "size_t", "ssize_t", "uint"],
+    ),
+    (
+        "use_after_free",
+        ["use after free", "use-after-free", "uaf", "free(", "kfree(", "dangling"],
+    ),
+    (
+        "null_dereference",
+        ["null check", "nullptr", "null pointer", "is None", "if not ", "== null", "!= null"],
+    ),
+    (
+        "auth_bypass",
+        [
+            "authentication",
+            "authoriz",
+            "auth",
+            "permission",
+            "privilege",
+            "access control",
+            "bypass",
+            "check_permission",
+            "is_authenticated",
+        ],
+    ),
+    (
+        "deserialization",
+        ["deserializ", "pickle", "yaml.load", "json.loads", "unmarshal", "unserializ", "objectinputstream"],
+    ),
+    (
+        "xss",
+        ["escape", "sanitize", "sanitise", "html.escape", "encode", "htmlentities", "innerhtml", "xss"],
+    ),
+    (
+        "ssrf",
+        ["ssrf", "urlopen", "requests.get", "fetch(", "curl", "allowed_hosts", "internal", "localhost"],
+    ),
+    (
+        "input_validation",
+        ["validate", "validation", "sanitize", "sanitise", "allowlist", "whitelist", "blacklist", "regex", "pattern"],
+    ),
+    (
+        "race_condition",
+        ["race condition", "toctou", "time-of-check", "mutex", "lock(", "synchronized", "atomic"],
+    ),
+    (
+        "cryptographic",
+        ["encrypt", "decrypt", "cipher", "hash", "random", "entropy", "tls", "ssl", "hmac", "signature"],
+    ),
+    (
+        "memory_leak",
+        ["memory leak", "leak", "free(", "kfree(", "dealloc", "release("],
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Helpers for GitHub URL parsing
+# ---------------------------------------------------------------------------
+
+_GITHUB_COMMIT_RE = re.compile(
+    r"https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/commit/(?P<sha>[0-9a-f]{7,40})",
+    re.IGNORECASE,
+)
+
+_GITHUB_PR_RE = re.compile(
+    r"https?://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/pull/(?P<pr>\d+)",
+    re.IGNORECASE,
+)
+
+
+def _github_headers() -> dict[str, str]:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def _fetch_json(url: str, timeout: int = 15) -> dict[str, Any] | list[Any] | None:
+    """GET *url* and return parsed JSON, or None on any error."""
+    try:
+        resp = requests.get(url, headers=_github_headers(), timeout=timeout)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+    except Exception:
+        return None
+
+
+def _fetch_text(url: str, timeout: int = 20) -> str | None:
+    """GET *url* and return response text, or None on any error."""
+    try:
+        resp = requests.get(url, headers=_github_headers(), timeout=timeout)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.text
+    except Exception:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Step 1: find commit candidates
+# ---------------------------------------------------------------------------
+
+
+def _commits_from_ghsa(cve_id: str) -> list[dict[str, str]]:
+    """
+    Query the GitHub Security Advisory REST API for *cve_id* and collect any
+    commit/PR references embedded in the advisory text and references list.
+    Returns a list of dicts: {"owner": ..., "repo": ..., "sha": ...}
+    """
+    url = f"https://api.github.com/advisories?cve_id={cve_id}"
+    data = _fetch_json(url)
+    if not data or not isinstance(data, list):
+        return []
+
+    candidates: list[dict[str, str]] = []
+    text_blob = ""
+
+    advisory = data[0]
+    # Collect all text fields
+    for field in ("description", "summary"):
+        text_blob += advisory.get(field, "") + "\n"
+    for ref in advisory.get("references", []):
+        text_blob += ref + "\n"
+
+    # Also check vulnerabilities → patched_versions (repos are in identifiers / cwes)
+    for vuln in advisory.get("vulnerabilities", []):
+        pkg = vuln.get("package", {})
+        ecosystem = pkg.get("ecosystem", "")
+        name = pkg.get("name", "")
+        if "/" in name and ecosystem.lower() in ("github_actions", "other", ""):
+            # name may be "owner/repo"
+            parts = name.split("/", 1)
+            if len(parts) == 2:
+                text_blob += f"https://github.com/{parts[0]}/{parts[1]}/\n"
+
+    candidates.extend(_extract_commits_from_text(text_blob))
+    return candidates
+
+
+def _commits_from_nvd(cve_id: str) -> list[dict[str, str]]:
+    """
+    Query the NVD CVE API for *cve_id* and mine reference URLs for GitHub
+    commit/PR links.
+    """
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    data = _fetch_json(url, timeout=15)
+    if not data or not isinstance(data, dict):
+        return []
+
+    text_blob = ""
+    for vuln in data.get("vulnerabilities", []):
+        cve_obj = vuln.get("cve", {})
+        for ref in cve_obj.get("references", []):
+            text_blob += ref.get("url", "") + "\n"
+        # descriptions
+        for desc in cve_obj.get("descriptions", []):
+            text_blob += desc.get("value", "") + "\n"
+
+    return _extract_commits_from_text(text_blob)
+
+
+def _extract_commits_from_text(text: str) -> list[dict[str, str]]:
+    """Return unique commit dicts extracted from *text* (commit and PR URLs)."""
+    seen: set[str] = set()
+    results: list[dict[str, str]] = []
+
+    for m in _GITHUB_COMMIT_RE.finditer(text):
+        key = f"{m['owner']}/{m['repo']}@{m['sha']}"
+        if key not in seen:
+            seen.add(key)
+            results.append({"owner": m["owner"], "repo": m["repo"], "sha": m["sha"]})
+
+    # For PR refs, resolve to the merge commit
+    for m in _GITHUB_PR_RE.finditer(text):
+        pr_url = f"https://api.github.com/repos/{m['owner']}/{m['repo']}/pulls/{m['pr']}"
+        pr_data = _fetch_json(pr_url)
+        if pr_data and isinstance(pr_data, dict):
+            sha = (pr_data.get("merge_commit_sha") or "")[:40]
+            if sha:
+                key = f"{m['owner']}/{m['repo']}@{sha}"
+                if key not in seen:
+                    seen.add(key)
+                    results.append({"owner": m["owner"], "repo": m["repo"], "sha": sha})
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Step 2: fetch and analyse the diff
+# ---------------------------------------------------------------------------
+
+
+def _fetch_diff(owner: str, repo: str, sha: str) -> str | None:
+    """
+    Fetch the unified diff for *sha* using the GitHub commits API
+    (Accept: application/vnd.github.diff).
+    """
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits/{sha}"
+    headers = _github_headers()
+    headers["Accept"] = "application/vnd.github.diff"
+    try:
+        resp = requests.get(url, headers=headers, timeout=30)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.text
+    except Exception:
+        return None
+
+
+def _summarise_diff(diff: str, owner: str, repo: str, sha: str) -> dict[str, Any]:
+    """
+    Analyse *diff* and return a structured summary dict.
+    """
+    lines = diff.splitlines()
+
+    # --- Files changed ---
+    files_changed: list[str] = []
+    for line in lines:
+        if line.startswith("diff --git "):
+            # diff --git a/path b/path  →  strip "b/" prefix
+            parts = line.split(" b/", 1)
+            if len(parts) == 2:
+                files_changed.append(parts[1].strip())
+
+    # --- Functions / methods changed (hunk headers: @@ ... @@ funcname) ---
+    func_re = re.compile(r"^@@[^@]+@@\s+(.+)$")
+    functions_touched: list[str] = []
+    seen_funcs: set[str] = set()
+    for line in lines:
+        m = func_re.match(line)
+        if m:
+            func_hint = m.group(1).strip()
+            # Truncate to the first paren or brace
+            func_hint = re.split(r"[({]", func_hint)[0].strip()
+            if func_hint and func_hint not in seen_funcs:
+                seen_funcs.add(func_hint)
+                functions_touched.append(func_hint)
+
+    # --- Added / removed line counts ---
+    added_lines = sum(1 for ln in lines if ln.startswith("+") and not ln.startswith("+++"))
+    removed_lines = sum(1 for ln in lines if ln.startswith("-") and not ln.startswith("---"))
+
+    # --- Bug class detection (scan the diff text) ---
+    diff_lower = diff.lower()
+    matched_classes: list[str] = []
+    for cls_name, keywords in _BUG_CLASSES:
+        if any(kw in diff_lower for kw in keywords):
+            matched_classes.append(cls_name)
+
+    # --- Infer primary bug class ---
+    # Prefer the class whose keywords have the most hits in the diff
+    def _keyword_hits(keywords: list[str]) -> int:
+        return sum(diff_lower.count(kw) for kw in keywords)
+
+    if matched_classes:
+        primary_bug_class = max(
+            matched_classes,
+            key=lambda c: _keyword_hits(dict(_BUG_CLASSES)[c]),
+        )
+    else:
+        primary_bug_class = "unknown"
+
+    # --- Extract a "minimal reproduction condition" hint ---
+    # Look at added lines around bounds / condition checks
+    repro_hint_lines: list[str] = []
+    for line in lines:
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        stripped = line[1:].strip()
+        if not stripped:
+            continue
+        lower = stripped.lower()
+        if any(
+            kw in lower
+            for kw in [
+                "if ",
+                "raise ",
+                "throw ",
+                "assert ",
+                "validate",
+                "check",
+                "verify",
+                "limit",
+                "max",
+                "min",
+                "length",
+                "size",
+                "bound",
+                "sanitize",
+                "sanitise",
+                "escape",
+                "allow",
+                "deny",
+                "block",
+            ]
+        ):
+            repro_hint_lines.append(stripped)
+
+    # Keep top-5 most informative lines (longest, as a heuristic)
+    repro_hints = sorted(set(repro_hint_lines), key=len, reverse=True)[:5]
+
+    # --- Build commit URL ---
+    commit_url = f"https://github.com/{owner}/{repo}/commit/{sha}"
+
+    return {
+        "owner": owner,
+        "repo": repo,
+        "sha": sha[:12],
+        "commit_url": commit_url,
+        "files_changed": files_changed[:20],  # cap at 20
+        "functions_touched": functions_touched[:15],
+        "added_lines": added_lines,
+        "removed_lines": removed_lines,
+        "matched_bug_classes": matched_classes,
+        "primary_bug_class": primary_bug_class,
+        "reproduction_condition_hints": repro_hints,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public helper (used by CLI)
+# ---------------------------------------------------------------------------
+
+
+def fetch_and_summarise(cve_id: str) -> dict[str, Any]:
+    """
+    Top-level helper: find the fixing commit(s) for *cve_id* and return a
+    list of diff summaries.  Returns a dict with keys:
+        cve_id, commit_summaries, not_found (bool), message (str)
+    """
+    cve_upper = cve_id.upper()
+
+    # Collect commit candidates from GHSA then NVD
+    candidates = _commits_from_ghsa(cve_upper)
+    if not candidates:
+        candidates = _commits_from_nvd(cve_upper)
+
+    if not candidates:
+        return {
+            "cve_id": cve_upper,
+            "not_found": True,
+            "message": (
+                f"No GitHub fixing-commit references found for {cve_upper} "
+                "in the GitHub Security Advisory database or NVD reference list. "
+                "The fix may be in a private repository, a non-GitHub host, or not yet linked."
+            ),
+            "commit_summaries": [],
+        }
+
+    summaries: list[dict[str, Any]] = []
+    for c in candidates[:3]:  # analyse at most 3 commits
+        diff = _fetch_diff(c["owner"], c["repo"], c["sha"])
+        if diff:
+            summaries.append(_summarise_diff(diff, c["owner"], c["repo"], c["sha"]))
+
+    if not summaries:
+        return {
+            "cve_id": cve_upper,
+            "not_found": True,
+            "message": (
+                f"Found commit reference(s) for {cve_upper} but could not fetch the diff. "
+                "The repository may be private or the commit may have been force-pushed away."
+            ),
+            "commit_summaries": [],
+        }
+
+    return {
+        "cve_id": cve_upper,
+        "not_found": False,
+        "message": f"Found {len(summaries)} fixing commit(s) for {cve_upper}.",
+        "commit_summaries": summaries,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool spec + handler
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "get_patch_diff",
+    "description": (
+        "Finds the fixing commit(s) for a CVE on GitHub (via the GitHub Security Advisory "
+        "database and NVD reference links), fetches the raw unified diff, and returns a "
+        "structured summary: which files and functions were changed, how many lines were "
+        "added/removed, what class of bug was fixed (e.g. sql_injection, auth_bypass, "
+        "buffer_overflow), and hints about the minimal condition required to trigger the "
+        "vulnerability. Use this after get_nvd_data to understand the mechanics of the fix "
+        "without having to read the raw diff yourself."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2024-3094').",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+def get_patch_diff(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Fetch the fixing-commit diff for a CVE and return a structured summary."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("get_patch_diff", result)
+        return result
+
+    payload = fetch_and_summarise(cve_id)
+
+    if payload["not_found"]:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [
+                {"text": payload["message"]},
+                {"json": payload},
+            ],
+        }
+        log_tool_output_size("get_patch_diff", result)
+        return result
+
+    # Build a human-readable summary for the first commit
+    lines: list[str] = [payload["message"]]
+    for idx, s in enumerate(payload["commit_summaries"], 1):
+        lines.append(f"\nCommit {idx}: {s['commit_url']}")
+        lines.append(f"  Files changed    : {', '.join(s['files_changed'][:5]) or 'N/A'}")
+        if s["functions_touched"]:
+            lines.append(f"  Functions touched: {', '.join(s['functions_touched'][:5])}")
+        lines.append(f"  Lines +{s['added_lines']} / -{s['removed_lines']}")
+        lines.append(f"  Primary bug class: {s['primary_bug_class']}")
+        if s["matched_bug_classes"]:
+            lines.append(f"  All bug classes  : {', '.join(s['matched_bug_classes'])}")
+        if s["reproduction_condition_hints"]:
+            lines.append("  Reproduction hints:")
+            for hint in s["reproduction_condition_hints"]:
+                lines.append(f"    • {hint}")
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": "\n".join(lines)},
+            {"json": payload},
+        ],
+    }
+    log_tool_output_size("get_patch_diff", result)
+    return result

--- a/tests/test_patch_diff.py
+++ b/tests/test_patch_diff.py
@@ -229,10 +229,7 @@ class TestSummariseDiff:
     def test_files_changed_capped_at_20(self):
         from manus_use.tools.get_patch_diff import _summarise_diff
 
-        many_files_diff = "\n".join(
-            f"diff --git a/file{i}.py b/file{i}.py\nindex 000..111 100644\n"
-            for i in range(25)
-        )
+        many_files_diff = "\n".join(f"diff --git a/file{i}.py b/file{i}.py\nindex 000..111 100644\n" for i in range(25))
         result = _summarise_diff(many_files_diff, "owner", "repo", "abc1234")
         assert len(result["files_changed"]) <= 20
 

--- a/tests/test_patch_diff.py
+++ b/tests/test_patch_diff.py
@@ -1,0 +1,631 @@
+"""
+Tests for src/manus_use/tools/get_patch_diff.py and the patch-diff CLI subcommand.
+
+All network calls are mocked — no real HTTP requests are made.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FAKE_DIFF = """\
+diff --git a/src/myapp/auth.py b/src/myapp/auth.py
+index abc1234..def5678 100644
+--- a/src/myapp/auth.py
++++ b/src/myapp/auth.py
+@@ -45,7 +45,11 @@ def check_permission(user, resource):
+     if user is None:
+         raise ValueError("user must not be None")
++    if not user.is_authenticated:
++        raise PermissionError("Authentication required")
++    if resource not in user.allowed_resources:
++        raise PermissionError(f"Access denied to {resource}")
+     return True
+"""
+
+_FAKE_DIFF_SQL = """\
+diff --git a/db/queries.py b/db/queries.py
+index 111..222 100644
+--- a/db/queries.py
++++ b/db/queries.py
+@@ -10,5 +10,6 @@ def get_user(user_id):
+-    cursor.execute(f"SELECT * FROM users WHERE id = {user_id}")
++    cursor.execute("SELECT * FROM users WHERE id = ?", (user_id,))
++    # validate input before SQL query
+     return cursor.fetchone()
+"""
+
+_FAKE_DIFF_OVERFLOW = """\
+diff --git a/c/parser.c b/c/parser.c
+index aaa..bbb 100644
+--- a/c/parser.c
++++ b/c/parser.c
+@@ -22,4 +22,7 @@ void parse(char *input, size_t len) {
+-    memcpy(buf, input, len);
++    if (len > sizeof(buf)) {
++        return;
++    }
++    memcpy(buf, input, len);
+ }
+"""
+
+
+def _make_ghsa_response(text_blob: str) -> list[dict[str, Any]]:
+    return [
+        {
+            "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+            "summary": "Test advisory",
+            "description": text_blob,
+            "references": [],
+            "vulnerabilities": [],
+        }
+    ]
+
+
+def _make_nvd_response(ref_urls: list[str]) -> dict[str, Any]:
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-99999",
+                    "descriptions": [{"lang": "en", "value": "Test vulnerability"}],
+                    "references": [{"url": u} for u in ref_urls],
+                }
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _extract_commits_from_text
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCommitsFromText:
+    def test_extracts_commit_url(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        text = "Fix: https://github.com/owner/repo/commit/abc1234def5678901234"
+        results = _extract_commits_from_text(text)
+        assert len(results) == 1
+        assert results[0]["owner"] == "owner"
+        assert results[0]["repo"] == "repo"
+        assert results[0]["sha"] == "abc1234def5678901234"
+
+    def test_deduplicates_same_commit(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        url = "https://github.com/owner/repo/commit/abc1234def5678901234"
+        text = f"{url}\n{url}"
+        results = _extract_commits_from_text(text)
+        assert len(results) == 1
+
+    def test_multiple_commits(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        text = (
+            "https://github.com/owner/repo/commit/aaaaaaaabbbbbbbbcccccccc\n"
+            "https://github.com/owner/repo/commit/ddddddddeeeeeeeeffffffff\n"
+        )
+        results = _extract_commits_from_text(text)
+        assert len(results) == 2
+
+    def test_no_commits_returns_empty(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        results = _extract_commits_from_text("Nothing here at all.")
+        assert results == []
+
+    def test_extracts_pr_and_resolves_merge_commit(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        text = "See https://github.com/owner/repo/pull/42 for details"
+        pr_data = {"merge_commit_sha": "deadbeefdeadbeef01234567"}
+        with patch("manus_use.tools.get_patch_diff._fetch_json", return_value=pr_data):
+            results = _extract_commits_from_text(text)
+        assert len(results) == 1
+        assert results[0]["sha"] == "deadbeefdeadbeef01234567"
+
+    def test_pr_without_merge_commit_skipped(self):
+        from manus_use.tools.get_patch_diff import _extract_commits_from_text
+
+        text = "See https://github.com/owner/repo/pull/99 for details"
+        with patch("manus_use.tools.get_patch_diff._fetch_json", return_value={"merge_commit_sha": None}):
+            results = _extract_commits_from_text(text)
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _summarise_diff
+# ---------------------------------------------------------------------------
+
+
+class TestSummariseDiff:
+    def test_detects_auth_bypass_class(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234")
+        assert "auth_bypass" in result["matched_bug_classes"]
+        assert result["primary_bug_class"] == "auth_bypass"
+
+    def test_detects_sql_injection_class(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF_SQL, "owner", "repo", "abc1234")
+        assert "sql_injection" in result["matched_bug_classes"]
+
+    def test_detects_buffer_overflow_class(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF_OVERFLOW, "owner", "repo", "abc1234")
+        assert "buffer_overflow" in result["matched_bug_classes"]
+
+    def test_files_changed_extracted(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234")
+        assert "src/myapp/auth.py" in result["files_changed"]
+
+    def test_functions_touched_extracted(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234")
+        # The hunk header contains "check_permission"
+        assert any("check_permission" in f for f in result["functions_touched"])
+
+    def test_line_counts(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234")
+        assert result["added_lines"] > 0
+        assert result["removed_lines"] == 0  # only additions in _FAKE_DIFF
+
+    def test_sha_truncated_to_12(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234def567890")
+        assert result["sha"] == "abc1234def56"
+
+    def test_commit_url_constructed(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "myowner", "myrepo", "abc1234")
+        assert result["commit_url"] == "https://github.com/myowner/myrepo/commit/abc1234"
+
+    def test_reproduction_hints_extracted(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        result = _summarise_diff(_FAKE_DIFF, "owner", "repo", "abc1234")
+        # Lines with 'authentication', 'allowed' should be picked up as hints
+        hints = result["reproduction_condition_hints"]
+        assert len(hints) >= 1
+        assert any("authenticated" in h or "allowed" in h for h in hints)
+
+    def test_unknown_bug_class_for_empty_diff(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        empty_diff = (
+            "diff --git a/foo.py b/foo.py\n"
+            "index 111..222 100644\n"
+            "--- a/foo.py\n"
+            "+++ b/foo.py\n"
+            "@@ -1 +1 @@\n"
+            "-x = 1\n"
+            "+x = 2\n"
+        )
+        result = _summarise_diff(empty_diff, "owner", "repo", "abc1234")
+        assert result["primary_bug_class"] == "unknown"
+        assert result["matched_bug_classes"] == []
+
+    def test_files_changed_capped_at_20(self):
+        from manus_use.tools.get_patch_diff import _summarise_diff
+
+        many_files_diff = "\n".join(
+            f"diff --git a/file{i}.py b/file{i}.py\nindex 000..111 100644\n"
+            for i in range(25)
+        )
+        result = _summarise_diff(many_files_diff, "owner", "repo", "abc1234")
+        assert len(result["files_changed"]) <= 20
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: fetch_and_summarise (top-level, with mocks)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAndSummarise:
+    def _mock_chain(self, diff_text: str = _FAKE_DIFF):
+        """Return a context manager that stubs network calls for a successful flow."""
+        commit_url = "https://github.com/owner/repo/commit/abc1234def5678901234"
+        ghsa = _make_ghsa_response(commit_url)
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return ghsa
+            return None
+
+        def fake_fetch_text(url: str, timeout: int = 20):
+            return None  # not used in this path
+
+        def fake_fetch_diff(owner, repo, sha):
+            return diff_text
+
+        return (fake_fetch_json, fake_fetch_diff)
+
+    def test_returns_commit_summary_on_success(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        fake_fetch_json, fake_fetch_diff = self._mock_chain()
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", side_effect=fake_fetch_diff),
+        ):
+            result = fetch_and_summarise("CVE-2024-99999")
+
+        assert result["not_found"] is False
+        assert len(result["commit_summaries"]) == 1
+        assert result["commit_summaries"][0]["primary_bug_class"] == "auth_bypass"
+
+    def test_uppercases_cve_id(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        fake_fetch_json, fake_fetch_diff = self._mock_chain()
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", side_effect=fake_fetch_diff),
+        ):
+            result = fetch_and_summarise("cve-2024-99999")  # lowercase input
+
+        assert result["cve_id"] == "CVE-2024-99999"
+
+    def test_falls_back_to_nvd_when_ghsa_empty(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        commit_url = "https://github.com/owner/repo/commit/abc1234def5678901234"
+        nvd_resp = _make_nvd_response([commit_url])
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return []  # no GHSA results
+            if "nvd.nist.gov" in url:
+                return nvd_resp
+            return None
+
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", return_value=_FAKE_DIFF),
+        ):
+            result = fetch_and_summarise("CVE-2024-99999")
+
+        assert result["not_found"] is False
+        assert len(result["commit_summaries"]) >= 1
+
+    def test_not_found_when_no_commit_references(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return []
+            if "nvd.nist.gov" in url:
+                return _make_nvd_response([])
+            return None
+
+        with patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json):
+            result = fetch_and_summarise("CVE-2024-99999")
+
+        assert result["not_found"] is True
+        assert result["commit_summaries"] == []
+        assert "CVE-2024-99999" in result["message"]
+
+    def test_not_found_when_diff_unavailable(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        commit_url = "https://github.com/owner/repo/commit/abc1234def5678901234"
+        ghsa = _make_ghsa_response(commit_url)
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return ghsa
+            return None
+
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", return_value=None),
+        ):
+            result = fetch_and_summarise("CVE-2024-99999")
+
+        assert result["not_found"] is True
+
+    def test_analyses_at_most_3_commits(self):
+        from manus_use.tools.get_patch_diff import fetch_and_summarise
+
+        # Advisory has 5 commit URLs
+        many_urls = " ".join(
+            f"https://github.com/owner/repo/commit/{sha}"
+            for sha in [
+                "aaaaaaaaaaaaaaaa",
+                "bbbbbbbbbbbbbbbb",
+                "cccccccccccccccc",
+                "dddddddddddddddd",
+                "eeeeeeeeeeeeeeee",
+            ]
+        )
+        ghsa = _make_ghsa_response(many_urls)
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return ghsa
+            return None
+
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", return_value=_FAKE_DIFF),
+        ):
+            result = fetch_and_summarise("CVE-2024-99999")
+
+        assert len(result["commit_summaries"]) <= 3
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Strands ToolResult (get_patch_diff handler)
+# ---------------------------------------------------------------------------
+
+
+class TestGetPatchDiffTool:
+    def _make_tool_use(self, cve_id: str) -> dict:
+        return {"toolUseId": "test-id-001", "input": {"cve_id": cve_id}}
+
+    def test_invalid_cve_returns_error(self):
+        from manus_use.tools.get_patch_diff import get_patch_diff
+
+        tool_use = self._make_tool_use("NOT-A-CVE")
+        result = get_patch_diff(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid CVE ID" in result["content"][0]["text"]
+
+    def test_empty_cve_returns_error(self):
+        from manus_use.tools.get_patch_diff import get_patch_diff
+
+        tool_use = self._make_tool_use("")
+        result = get_patch_diff(tool_use)
+        assert result["status"] == "error"
+
+    def test_success_returns_success_status(self):
+        from manus_use.tools.get_patch_diff import get_patch_diff
+
+        tool_use = self._make_tool_use("CVE-2024-99999")
+
+        commit_url = "https://github.com/owner/repo/commit/abc1234def5678901234"
+        ghsa = _make_ghsa_response(commit_url)
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return ghsa
+            return None
+
+        with (
+            patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json),
+            patch("manus_use.tools.get_patch_diff._fetch_diff", return_value=_FAKE_DIFF),
+        ):
+            result = get_patch_diff(tool_use)
+
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-id-001"
+        # Should have text and json blocks
+        content_types = {list(c.keys())[0] for c in result["content"]}
+        assert "text" in content_types
+        assert "json" in content_types
+
+    def test_not_found_returns_success_with_message(self):
+        from manus_use.tools.get_patch_diff import get_patch_diff
+
+        tool_use = self._make_tool_use("CVE-2024-99999")
+
+        def fake_fetch_json(url: str, timeout: int = 15):
+            if "api.github.com/advisories" in url:
+                return []
+            if "nvd.nist.gov" in url:
+                return _make_nvd_response([])
+            return None
+
+        with patch("manus_use.tools.get_patch_diff._fetch_json", side_effect=fake_fetch_json):
+            result = get_patch_diff(tool_use)
+
+        assert result["status"] == "success"
+        json_block = next(c["json"] for c in result["content"] if "json" in c)
+        assert json_block["not_found"] is True
+
+    def test_tool_use_id_echoed(self):
+        from manus_use.tools.get_patch_diff import get_patch_diff
+
+        tool_use = self._make_tool_use("NOT-A-CVE")
+        result = get_patch_diff(tool_use)
+        assert result["toolUseId"] == "test-id-001"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: CLI subcommand (patch-diff)
+# ---------------------------------------------------------------------------
+
+
+class TestPatchDiffCLI:
+    def test_patch_diff_registered_in_subcommands(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "patch-diff" in _SUBCOMMANDS
+
+    def test_build_patch_diff_parser_exists(self):
+        from manus_use.cli import _build_patch_diff_parser
+
+        p = _build_patch_diff_parser()
+        assert p is not None
+
+    def test_patch_diff_requires_cve_arg(self):
+        from manus_use.cli import _build_patch_diff_parser
+
+        p = _build_patch_diff_parser()
+        with pytest.raises(SystemExit):
+            p.parse_args([])
+
+    def test_patch_diff_default_output_text(self):
+        from manus_use.cli import _build_patch_diff_parser
+
+        args = _build_patch_diff_parser().parse_args(["CVE-2024-3094"])
+        assert args.output == "text"
+
+    def test_patch_diff_output_json(self):
+        from manus_use.cli import _build_patch_diff_parser
+
+        args = _build_patch_diff_parser().parse_args(["CVE-2024-3094", "--output", "json"])
+        assert args.output == "json"
+
+    def test_run_patch_diff_text_output(self, capsys):
+        from manus_use.cli import _run_patch_diff
+
+        payload = {
+            "cve_id": "CVE-2024-99999",
+            "not_found": False,
+            "message": "Found 1 fixing commit(s) for CVE-2024-99999.",
+            "commit_summaries": [
+                {
+                    "owner": "owner",
+                    "repo": "repo",
+                    "sha": "abc1234",
+                    "commit_url": "https://github.com/owner/repo/commit/abc1234",
+                    "files_changed": ["src/auth.py"],
+                    "functions_touched": ["check_permission"],
+                    "added_lines": 4,
+                    "removed_lines": 0,
+                    "matched_bug_classes": ["auth_bypass"],
+                    "primary_bug_class": "auth_bypass",
+                    "reproduction_condition_hints": ["if not user.is_authenticated:"],
+                }
+            ],
+        }
+
+        with patch("manus_use.tools.get_patch_diff.fetch_and_summarise", return_value=payload):
+            rc = _run_patch_diff(["CVE-2024-99999"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "CVE-2024-99999" in captured.out
+        assert "auth_bypass" in captured.out
+        assert "check_permission" in captured.out
+
+    def test_run_patch_diff_json_output(self, capsys):
+        from manus_use.cli import _run_patch_diff
+
+        payload = {
+            "cve_id": "CVE-2024-99999",
+            "not_found": True,
+            "message": "No GitHub fixing-commit references found for CVE-2024-99999.",
+            "commit_summaries": [],
+        }
+
+        with patch("manus_use.tools.get_patch_diff.fetch_and_summarise", return_value=payload):
+            rc = _run_patch_diff(["CVE-2024-99999", "--output", "json"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["cve_id"] == "CVE-2024-99999"
+        assert parsed["not_found"] is True
+
+    def test_run_patch_diff_not_found_exits_zero(self, capsys):
+        from manus_use.cli import _run_patch_diff
+
+        payload = {
+            "cve_id": "CVE-2024-99999",
+            "not_found": True,
+            "message": "No references found.",
+            "commit_summaries": [],
+        }
+
+        with patch("manus_use.tools.get_patch_diff.fetch_and_summarise", return_value=payload):
+            rc = _run_patch_diff(["CVE-2024-99999"])
+
+        assert rc == 0
+
+    def test_run_patch_diff_missing_import_exits_one(self, capsys):
+        from manus_use.cli import _run_patch_diff
+
+        with patch.dict(sys.modules, {"manus_use.tools.get_patch_diff": None}):
+            rc = _run_patch_diff(["CVE-2024-99999"])
+
+        assert rc == 1
+
+    def test_main_dispatches_patch_diff(self):
+        """main() should dispatch 'patch-diff' to _run_patch_diff."""
+        from manus_use import cli
+
+        payload = {
+            "cve_id": "CVE-2024-99999",
+            "not_found": True,
+            "message": "Not found.",
+            "commit_summaries": [],
+        }
+
+        with (
+            patch("manus_use.tools.get_patch_diff.fetch_and_summarise", return_value=payload),
+            patch("sys.argv", ["manus-use", "patch-diff", "CVE-2024-99999"]),
+            pytest.raises(SystemExit) as exc,
+        ):
+            cli.main()
+
+        assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: vi_agent integration (tool list includes get_patch_diff)
+# ---------------------------------------------------------------------------
+
+
+class TestVIAgentIncludesPatchDiff:
+    def test_vi_agent_imports_get_patch_diff(self):
+        """VulnerabilityIntelligenceAgent should import get_patch_diff without error."""
+        # Just verify the import path resolves
+        from manus_use.tools.get_patch_diff import get_patch_diff  # noqa: F401
+
+        assert callable(get_patch_diff)
+
+    def test_get_patch_diff_in_vi_agent_source(self):
+        """vi_agent.py source must reference get_patch_diff."""
+        import inspect
+
+        from manus_use.agents import vi_agent
+
+        src = inspect.getsource(vi_agent)
+        assert "get_patch_diff" in src
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: README documents patch-diff
+# ---------------------------------------------------------------------------
+
+
+class TestReadmeDocsPatchDiff:
+    def _get_readme(self) -> str:
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[1]
+        return (repo_root / "README.md").read_text()
+
+    def test_readme_has_patch_diff_section(self):
+        assert "patch-diff" in self._get_readme()
+
+    def test_readme_documents_patch_diff_output_flag(self):
+        readme = self._get_readme()
+        assert "--output" in readme and "patch-diff" in readme
+
+    def test_readme_has_patch_diff_example(self):
+        readme = self._get_readme()
+        assert "manus-use patch-diff CVE" in readme


### PR DESCRIPTION
## What & Why

Vulnerability researchers need to understand *how* a bug was fixed to assess exploitability — which function changed, what guard was added, what the minimal trigger condition was. Today that requires reading a raw diff manually. This PR closes that gap.

`get_patch_diff` finds the fixing commit(s) for a CVE on GitHub (via the GHSA database and NVD reference links), fetches the raw unified diff, and produces a structured machine-readable summary — no raw diff reading required.

Composable with the existing pipeline:

```bash
manus-use analyze CVE-2024-3094          # full intel report
manus-use epss-trend CVE-2024-3094       # exploitation trajectory
manus-use patch-diff CVE-2024-3094       # how was it fixed?
```

## Changes

- **`src/manus_use/tools/get_patch_diff.py`** — new Strands tool:
  - Queries GitHub Security Advisory REST API for fixing commit references
  - Falls back to NVD reference list when GHSA returns nothing
  - Resolves PR URLs to their merge commit SHA
  - Fetches raw unified diff via `Accept: application/vnd.github.diff`
  - Analyses diff for: files changed, functions touched (hunk headers), bug class (14 classes: `sql_injection`, `auth_bypass`, `buffer_overflow`, `use_after_free`, `xss`, `ssrf`, `deserialization`, `race_condition`, `cryptographic`, …), reproduction condition hints extracted from added guard/validation lines
  - Returns both human-readable text and structured JSON

- **`src/manus_use/cli.py`** — `manus-use patch-diff CVE-XXXX-YYYY` subcommand with `--output {text,json}`; registered in `_SUBCOMMANDS`; added to help epilog

- **`src/manus_use/agents/vi_agent.py`** — `get_patch_diff` imported and added to tool list as Step 6 of the analysis pipeline (between EPSS trend and CWE lookup); system prompt updated to guide the agent to surface commit URL, bug class, and reproduction hints in the report

- **`README.md`** — full `patch-diff` CLI Reference section added; security examples updated

## Tests

43 new tests in `tests/test_patch_diff.py` (100% mocked, zero real HTTP calls):
- Commit/PR URL regex extraction, deduplication, PR→merge-SHA resolution
- Bug class detection for auth_bypass, sql_injection, buffer_overflow, unknown
- Files/functions extraction, line counts, SHA truncation, reproduction hints
- GHSA→NVD fallback chain, not-found paths, 3-commit cap
- Strands ToolResult shape, error/empty CVE handling, toolUseId echo
- CLI parser defaults, text/JSON output, exit codes, `main()` dispatch
- VI agent source reference + README coverage

**483 passed (was 440), 0 failed.**