### PR TITLE
feat(tools): CVE side-by-side comparison — compare_cves tool + manus-use compare subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,40 @@ manus-use variants CVE-2024-3094 --output json
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Report format |
 
+### `manus-use compare <CVE-A> <CVE-B>` — Side-by-side CVE comparison
+
+```bash
+# Compare two CVEs and get a prioritisation recommendation
+manus-use compare CVE-2024-3094 CVE-2021-44228
+
+# Machine-readable output
+manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
+```
+
+Fetches NVD, EPSS, and CISA KEV data for both CVEs in parallel and produces a
+structured side-by-side comparison across:
+
+- **CVSS score and severity** (v3.1 preferred, falls back to v3.0 then v2)
+- **EPSS exploitation probability** (current score and percentile)
+- **CISA KEV membership** (confirmed active exploitation)
+- **CWE weakness class**
+- **Attack vector, privileges required, user interaction** (exploitability factors)
+- **Affected vendor / product**
+
+Each CVE is assigned a composite priority score using a weighted rubric (KEV
+membership: +10, Critical CVSS: +8, high EPSS: +8, network attack vector: +3,
+etc.) and the output includes a plain-English recommendation with confidence
+level: *strong*, *moderate*, or *weak*.
+
+Useful for triage: quickly answer "should I patch A or B first?" without manually
+cross-referencing three data sources.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format; `json` includes the full comparison |
+
 ### `manus-use discover` — CVE discovery
 
 ```bash
@@ -492,6 +526,10 @@ manus-use patch-diff CVE-2024-3094 --output json | jq .commit_summaries
 
 # Generate remediation steps
 manus-use remediate CVE-2024-3094
+
+# Compare two CVEs side-by-side for triage prioritisation
+manus-use compare CVE-2024-3094 CVE-2021-44228
+manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1041,7 +1041,7 @@ def _run_variants(argv: list[str]) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend", "patch-diff"}
+_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend", "patch-diff", "compare"}
 
 
 # ---------------------------------------------------------------------------
@@ -1204,6 +1204,80 @@ def _run_patch_diff(argv: list[str]) -> int:
             print("  Reproduction hints:")
             for hint in s["reproduction_condition_hints"]:
                 print(f"    • {hint}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# compare subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_compare_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use compare",
+        description=(
+            "Compare two CVEs side-by-side across CVSS, EPSS, CISA KEV, CWE,\n"
+            "attack vector, and other dimensions.  Outputs a prioritisation\n"
+            "recommendation: which CVE poses the greater immediate risk and why."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id_a", metavar="CVE-ID-A", help="First CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument("cve_id_b", metavar="CVE-ID-B", help="Second CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_compare(argv: list[str]) -> int:
+    parser = _build_compare_parser()
+    args = parser.parse_args(argv)
+
+    cve_id_a = args.cve_id_a.strip()
+    cve_id_b = args.cve_id_b.strip()
+
+    for cid in (cve_id_a, cve_id_b):
+        if not cid.upper().startswith("CVE-"):
+            print(f"[error] Invalid CVE ID '{cid}'. Must be like 'CVE-YYYY-NNNN'.", file=sys.stderr)
+            return 1
+
+    try:
+        from manus_use.tools.compare_cves import (
+            _build_comparison,
+            _build_cve_profile,
+            _fetch_kev,
+            _render_text,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import concurrent.futures
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        future_a = executor.submit(_build_cve_profile, cve_id_a)
+        future_b = executor.submit(_build_cve_profile, cve_id_b)
+        future_kev_a = executor.submit(_fetch_kev, cve_id_a)
+        future_kev_b = executor.submit(_fetch_kev, cve_id_b)
+        profile_a = future_a.result()
+        profile_b = future_b.result()
+        kev_a = future_kev_a.result()
+        kev_b = future_kev_b.result()
+
+    comparison = _build_comparison(profile_a, kev_a, profile_b, kev_b)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(comparison, indent=2))
+        return 0
+
+    # Text output
+    print(_render_text(comparison))
     return 0
 
 
@@ -1510,6 +1584,10 @@ def main() -> None:
     if first_positional == "patch-diff":
         idx = argv.index("patch-diff")
         sys.exit(_run_patch_diff(argv[idx + 1 :]))
+
+    if first_positional == "compare":
+        idx = argv.index("compare")
+        sys.exit(_run_compare(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1041,7 +1041,18 @@ def _run_variants(argv: list[str]) -> int:
 # main() entry point
 # ---------------------------------------------------------------------------
 
-_SUBCOMMANDS = {"init", "doctor", "analyze", "history", "discover", "remediate", "variants", "epss-trend", "patch-diff", "compare"}
+_SUBCOMMANDS = {
+    "init",
+    "doctor",
+    "analyze",
+    "history",
+    "discover",
+    "remediate",
+    "variants",
+    "epss-trend",
+    "patch-diff",
+    "compare",
+}
 
 
 # ---------------------------------------------------------------------------

--- a/src/manus_use/tools/compare_cves.py
+++ b/src/manus_use/tools/compare_cves.py
@@ -1,0 +1,474 @@
+"""
+Tool for comparing two CVEs side-by-side across multiple vulnerability intelligence dimensions.
+
+Fetches NVD, EPSS, and CISA KEV data for both CVEs in parallel and produces a structured
+comparison report useful for prioritisation decisions.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+TOOL_SPEC = {
+    "name": "compare_cves",
+    "description": (
+        "Compares two CVEs side-by-side across multiple vulnerability intelligence dimensions: "
+        "CVSS base score and severity, EPSS exploitation-probability score, CISA KEV membership, "
+        "CWE weakness class, affected vendor/product, and published date. "
+        "Returns a structured comparison with a prioritisation recommendation — "
+        "which CVE poses the greater immediate risk and why. "
+        "Use this when you need to triage two vulnerabilities against each other."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id_a": {
+                    "type": "string",
+                    "description": "First CVE identifier to compare (e.g., 'CVE-2024-3094').",
+                },
+                "cve_id_b": {
+                    "type": "string",
+                    "description": "Second CVE identifier to compare (e.g., 'CVE-2021-44228').",
+                },
+            },
+            "required": ["cve_id_a", "cve_id_b"],
+        }
+    },
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Data-fetch helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _fetch_nvd(cve_id: str) -> dict[str, Any]:
+    """Return the CVE sub-record from NVD, or an error dict."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return {"error": f"No NVD record found for {cve_id}"}
+        return vulns[0].get("cve", {})
+    except requests.RequestException as exc:
+        return {"error": f"NVD request failed: {exc}"}
+
+
+def _fetch_epss(cve_id: str) -> dict[str, Any]:
+    """Return the current EPSS score dict for a CVE, or an error dict."""
+    url = "https://api.first.org/data/v1/epss"
+    try:
+        resp = requests.get(url, params={"cve": cve_id.upper()}, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        entries = data.get("data", [])
+        if not entries:
+            return {"error": f"No EPSS data for {cve_id}"}
+        return entries[0]
+    except requests.RequestException as exc:
+        return {"error": f"EPSS request failed: {exc}"}
+
+
+def _fetch_kev(cve_id: str) -> dict[str, Any]:
+    """Return the KEV catalog entry for a CVE, or {"in_kev": False} if absent."""
+    url = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    try:
+        resp = requests.get(url, timeout=20)
+        resp.raise_for_status()
+        catalog = resp.json()
+    except requests.RequestException as exc:
+        return {"in_kev": False, "error": f"KEV request failed: {exc}"}
+
+    cid = cve_id.upper()
+    for entry in catalog.get("vulnerabilities", []):
+        if entry.get("cveID", "").upper() == cid:
+            return {
+                "in_kev": True,
+                "date_added": entry.get("dateAdded"),
+                "vendor_project": entry.get("vendorProject"),
+                "product": entry.get("product"),
+                "required_action": entry.get("requiredAction"),
+                "due_date": entry.get("dueDate"),
+            }
+    return {"in_kev": False}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Data-extraction helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _extract_cvss(nvd_record: dict[str, Any]) -> dict[str, Any]:
+    """
+    Extract the highest-version available CVSS score from an NVD CVE record.
+    Prefers CVSSv3.1 → CVSSv3.0 → CVSSv2.
+    """
+    metrics = nvd_record.get("metrics", {})
+
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            cv = entries[0].get("cvssData", {})
+            return {
+                "version": cv.get("version", key[-3:]),
+                "score": cv.get("baseScore"),
+                "severity": cv.get("baseSeverity"),
+                "vector": cv.get("vectorString"),
+                "attack_vector": cv.get("attackVector"),
+                "privileges_required": cv.get("privilegesRequired"),
+                "user_interaction": cv.get("userInteraction"),
+            }
+
+    entries = metrics.get("cvssMetricV2", [])
+    if entries:
+        cv = entries[0].get("cvssData", {})
+        return {
+            "version": "2.0",
+            "score": cv.get("baseScore"),
+            "severity": entries[0].get("baseSeverity"),
+            "vector": cv.get("vectorString"),
+            "attack_vector": cv.get("accessVector"),
+            "privileges_required": None,
+            "user_interaction": None,
+        }
+
+    return {"version": None, "score": None, "severity": None, "vector": None,
+            "attack_vector": None, "privileges_required": None, "user_interaction": None}
+
+
+def _extract_cwe(nvd_record: dict[str, Any]) -> list[str]:
+    """Return a list of CWE IDs from the NVD record."""
+    cwes: list[str] = []
+    for weakness in nvd_record.get("weaknesses", []):
+        for desc in weakness.get("description", []):
+            val = desc.get("value", "")
+            if val and val not in ("NVD-CWE-Other", "NVD-CWE-noinfo"):
+                cwes.append(val)
+    return cwes
+
+
+def _extract_affected(nvd_record: dict[str, Any]) -> str:
+    """Return a short 'Vendor / Product' string from the NVD record."""
+    for config in nvd_record.get("configurations", []):
+        for node in config.get("nodes", []):
+            for cpe_match in node.get("cpeMatch", []):
+                uri = cpe_match.get("criteria", "")
+                parts = uri.split(":")
+                if len(parts) >= 5:
+                    vendor = parts[3].replace("_", " ").title()
+                    product = parts[4].replace("_", " ").title()
+                    return f"{vendor} / {product}"
+    return "Unknown"
+
+
+def _extract_published(nvd_record: dict[str, Any]) -> str:
+    """Return the published date (YYYY-MM-DD) from the NVD record."""
+    raw = nvd_record.get("published", "")
+    return raw[:10] if raw else "Unknown"
+
+
+def _extract_description(nvd_record: dict[str, Any]) -> str:
+    """Return the English description from the NVD record, truncated to 200 chars."""
+    for desc in nvd_record.get("descriptions", []):
+        if desc.get("lang") == "en":
+            val = desc.get("value", "")
+            return val[:200] + ("…" if len(val) > 200 else "")
+    return ""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Comparison and prioritisation logic
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _score_cve(profile: dict[str, Any]) -> tuple[float, list[str]]:
+    """
+    Assign a composite priority score (higher = more urgent) and list the reasons.
+
+    Scoring rubric:
+      +10   in CISA KEV (actively exploited, confirmed)
+      +8    CVSS score ≥ 9.0 (Critical)
+      +5    CVSS score 7.0–8.9 (High)
+      +2    CVSS score 4.0–6.9 (Medium)
+      +8    EPSS ≥ 0.70 (very likely to be exploited)
+      +5    EPSS 0.40–0.69
+      +2    EPSS 0.10–0.39
+      +3    Attack vector = NETWORK
+      +2    Privileges required = NONE
+      +1    User interaction = NONE
+    """
+    score = 0.0
+    reasons: list[str] = []
+
+    if profile.get("kev", {}).get("in_kev"):
+        score += 10
+        reasons.append("in CISA KEV (actively exploited in the wild)")
+
+    cvss_score = profile.get("cvss", {}).get("score")
+    if cvss_score is not None:
+        cs = float(cvss_score)
+        if cs >= 9.0:
+            score += 8
+            reasons.append(f"CVSS {cs:.1f} (Critical)")
+        elif cs >= 7.0:
+            score += 5
+            reasons.append(f"CVSS {cs:.1f} (High)")
+        elif cs >= 4.0:
+            score += 2
+            reasons.append(f"CVSS {cs:.1f} (Medium)")
+
+    epss_val = profile.get("epss", {}).get("epss")
+    if epss_val is not None:
+        ev = float(epss_val)
+        if ev >= 0.70:
+            score += 8
+            reasons.append(f"EPSS {ev:.3f} (very high exploitation probability)")
+        elif ev >= 0.40:
+            score += 5
+            reasons.append(f"EPSS {ev:.3f} (high exploitation probability)")
+        elif ev >= 0.10:
+            score += 2
+            reasons.append(f"EPSS {ev:.3f} (elevated exploitation probability)")
+
+    av = (profile.get("cvss", {}).get("attack_vector") or "").upper()
+    if av == "NETWORK":
+        score += 3
+        reasons.append("remotely exploitable (network attack vector)")
+
+    pr = (profile.get("cvss", {}).get("privileges_required") or "").upper()
+    if pr == "NONE":
+        score += 2
+        reasons.append("no privileges required")
+
+    ui = (profile.get("cvss", {}).get("user_interaction") or "").upper()
+    if ui == "NONE":
+        score += 1
+        reasons.append("no user interaction required")
+
+    return score, reasons
+
+
+def _build_cve_profile(cve_id: str) -> dict[str, Any]:
+    """Fetch NVD and EPSS data for a CVE and return a normalised profile dict."""
+    cid = cve_id.upper()
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        nvd_future = executor.submit(_fetch_nvd, cid)
+        epss_future = executor.submit(_fetch_epss, cid)
+        nvd_data = nvd_future.result()
+        epss_data = epss_future.result()
+
+    has_nvd_error = "error" in nvd_data
+    cvss = _extract_cvss(nvd_data) if not has_nvd_error else {
+        "version": None, "score": None, "severity": None, "vector": None,
+        "attack_vector": None, "privileges_required": None, "user_interaction": None,
+    }
+    cwe = _extract_cwe(nvd_data) if not has_nvd_error else []
+    affected = _extract_affected(nvd_data) if not has_nvd_error else "Unknown"
+    published = _extract_published(nvd_data) if not has_nvd_error else "Unknown"
+    description = _extract_description(nvd_data) if not has_nvd_error else ""
+
+    return {
+        "cve_id": cid,
+        "nvd_error": nvd_data.get("error"),
+        "epss_error": epss_data.get("error"),
+        "cvss": cvss,
+        "epss": {
+            "epss": epss_data.get("epss"),
+            "percentile": epss_data.get("percentile"),
+        } if not epss_data.get("error") else {},
+        "cwe": cwe,
+        "affected": affected,
+        "published": published,
+        "description": description,
+    }
+
+
+def _build_comparison(
+    profile_a: dict[str, Any],
+    kev_a: dict[str, Any],
+    profile_b: dict[str, Any],
+    kev_b: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the final comparison dict with a prioritisation recommendation."""
+    profile_a["kev"] = kev_a
+    profile_b["kev"] = kev_b
+
+    score_a, reasons_a = _score_cve(profile_a)
+    score_b, reasons_b = _score_cve(profile_b)
+
+    if score_a > score_b:
+        winner = profile_a["cve_id"]
+        winner_score = score_a
+        loser_score = score_b
+        winner_reasons = reasons_a
+    elif score_b > score_a:
+        winner = profile_b["cve_id"]
+        winner_score = score_b
+        loser_score = score_a
+        winner_reasons = reasons_b
+    else:
+        winner = "tie"
+        winner_score = score_a
+        loser_score = score_b
+        winner_reasons = ["scores are equal — review manually"]
+
+    if winner != "tie":
+        margin = winner_score - loser_score
+        if margin >= 10:
+            confidence = "strong"
+        elif margin >= 5:
+            confidence = "moderate"
+        else:
+            confidence = "weak"
+        recommendation = (
+            f"Prioritise {winner} ({confidence} recommendation, "
+            f"composite score {winner_score:.0f} vs {loser_score:.0f}). "
+            f"Key factors: {'; '.join(winner_reasons[:3])}."
+        )
+    else:
+        confidence = "tie"
+        recommendation = (
+            "Both CVEs score equally. Review manually using CVSS vector, "
+            "EPSS trajectory, and operational context."
+        )
+
+    return {
+        "cve_a": profile_a,
+        "cve_b": profile_b,
+        "priority_score_a": score_a,
+        "priority_score_b": score_b,
+        "higher_priority": winner,
+        "confidence": confidence,
+        "recommendation": recommendation,
+        "winner_reasons": winner_reasons,
+    }
+
+
+def _render_text(comparison: dict[str, Any]) -> str:
+    """Render the comparison as a human-readable aligned table."""
+
+    def _fmt_epss(e: dict[str, Any]) -> str:
+        epss = e.get("epss")
+        pct = e.get("percentile")
+        if epss is None:
+            return "N/A"
+        pct_str = f"  ({float(pct):.1%} pct)" if pct is not None else ""
+        return f"{float(epss):.4f}{pct_str}"
+
+    def _fmt_cvss(c: dict[str, Any]) -> str:
+        score = c.get("score")
+        sev = c.get("severity") or ""
+        ver = c.get("version") or ""
+        if score is None:
+            return "N/A"
+        ver_str = f"  (v{ver})" if ver else ""
+        return f"{score}  {sev}{ver_str}"
+
+    def _fmt_kev(k: dict[str, Any]) -> str:
+        if k.get("in_kev"):
+            return f"YES — added {k.get('date_added', '?')} (due {k.get('due_date', '?')})"
+        return "No"
+
+    pa = comparison["cve_a"]
+    pb = comparison["cve_b"]
+    col_w = 40
+
+    def row(label: str, val_a: str, val_b: str) -> str:
+        return f"  {label:<24}  {val_a:<{col_w}}  {val_b}\n"
+
+    lines: list[str] = []
+    sep = "─" * 100
+    lines.append(f"\n{sep}\n")
+    lines.append(f"  {'DIMENSION':<24}  {pa['cve_id']:<{col_w}}  {pb['cve_id']}\n")
+    lines.append(f"{sep}\n")
+    lines.append(row("Published", pa["published"], pb["published"]))
+    lines.append(row("Affected", pa["affected"][:col_w], pb["affected"]))
+    lines.append(row("CVSS", _fmt_cvss(pa.get("cvss", {})), _fmt_cvss(pb.get("cvss", {}))))
+    lines.append(row("EPSS score", _fmt_epss(pa.get("epss", {})), _fmt_epss(pb.get("epss", {}))))
+    lines.append(row("CISA KEV", _fmt_kev(pa.get("kev", {})), _fmt_kev(pb.get("kev", {}))))
+    lines.append(row("CWE", ", ".join(pa.get("cwe", [])) or "N/A", ", ".join(pb.get("cwe", [])) or "N/A"))
+    lines.append(row(
+        "Attack vector",
+        pa.get("cvss", {}).get("attack_vector") or "N/A",
+        pb.get("cvss", {}).get("attack_vector") or "N/A",
+    ))
+    lines.append(row(
+        "Privileges req.",
+        pa.get("cvss", {}).get("privileges_required") or "N/A",
+        pb.get("cvss", {}).get("privileges_required") or "N/A",
+    ))
+    lines.append(row(
+        "User interaction",
+        pa.get("cvss", {}).get("user_interaction") or "N/A",
+        pb.get("cvss", {}).get("user_interaction") or "N/A",
+    ))
+    lines.append(row("Priority score", str(int(comparison["priority_score_a"])), str(int(comparison["priority_score_b"]))))
+    lines.append(f"{sep}\n")
+    lines.append(f"\n  RECOMMENDATION\n  {comparison['recommendation']}\n")
+
+    if pa.get("description"):
+        lines.append(f"\n  {pa['cve_id']} — {pa['description']}\n")
+    if pb.get("description"):
+        lines.append(f"  {pb['cve_id']} — {pb['description']}\n")
+
+    return "".join(lines)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Strands tool entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def compare_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Fetch data for two CVEs in parallel and return a side-by-side comparison."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+
+    cve_id_a = str(tool_input.get("cve_id_a", "")).strip()
+    cve_id_b = str(tool_input.get("cve_id_b", "")).strip()
+
+    for cid in (cve_id_a, cve_id_b):
+        if not cid.upper().startswith("CVE-"):
+            result: ToolResult = {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Invalid CVE ID '{cid}'. Must be like 'CVE-YYYY-NNNN'."}],
+            }
+            log_tool_output_size("compare_cves", result)
+            return result
+
+    # Fetch both profiles and both KEV entries concurrently
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
+        future_a = executor.submit(_build_cve_profile, cve_id_a)
+        future_b = executor.submit(_build_cve_profile, cve_id_b)
+        future_kev_a = executor.submit(_fetch_kev, cve_id_a)
+        future_kev_b = executor.submit(_fetch_kev, cve_id_b)
+
+        profile_a = future_a.result()
+        profile_b = future_b.result()
+        kev_a = future_kev_a.result()
+        kev_b = future_kev_b.result()
+
+    comparison = _build_comparison(profile_a, kev_a, profile_b, kev_b)
+    text_report = _render_text(comparison)
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": text_report},
+            {"json": comparison},
+        ],
+    }
+    log_tool_output_size("compare_cves", result)
+    return result

--- a/src/manus_use/tools/compare_cves.py
+++ b/src/manus_use/tools/compare_cves.py
@@ -141,8 +141,15 @@ def _extract_cvss(nvd_record: dict[str, Any]) -> dict[str, Any]:
             "user_interaction": None,
         }
 
-    return {"version": None, "score": None, "severity": None, "vector": None,
-            "attack_vector": None, "privileges_required": None, "user_interaction": None}
+    return {
+        "version": None,
+        "score": None,
+        "severity": None,
+        "vector": None,
+        "attack_vector": None,
+        "privileges_required": None,
+        "user_interaction": None,
+    }
 
 
 def _extract_cwe(nvd_record: dict[str, Any]) -> list[str]:
@@ -268,10 +275,19 @@ def _build_cve_profile(cve_id: str) -> dict[str, Any]:
         epss_data = epss_future.result()
 
     has_nvd_error = "error" in nvd_data
-    cvss = _extract_cvss(nvd_data) if not has_nvd_error else {
-        "version": None, "score": None, "severity": None, "vector": None,
-        "attack_vector": None, "privileges_required": None, "user_interaction": None,
-    }
+    cvss = (
+        _extract_cvss(nvd_data)
+        if not has_nvd_error
+        else {
+            "version": None,
+            "score": None,
+            "severity": None,
+            "vector": None,
+            "attack_vector": None,
+            "privileges_required": None,
+            "user_interaction": None,
+        }
+    )
     cwe = _extract_cwe(nvd_data) if not has_nvd_error else []
     affected = _extract_affected(nvd_data) if not has_nvd_error else "Unknown"
     published = _extract_published(nvd_data) if not has_nvd_error else "Unknown"
@@ -285,7 +301,9 @@ def _build_cve_profile(cve_id: str) -> dict[str, Any]:
         "epss": {
             "epss": epss_data.get("epss"),
             "percentile": epss_data.get("percentile"),
-        } if not epss_data.get("error") else {},
+        }
+        if not epss_data.get("error")
+        else {},
         "cwe": cwe,
         "affected": affected,
         "published": published,
@@ -338,8 +356,7 @@ def _build_comparison(
     else:
         confidence = "tie"
         recommendation = (
-            "Both CVEs score equally. Review manually using CVSS vector, "
-            "EPSS trajectory, and operational context."
+            "Both CVEs score equally. Review manually using CVSS vector, EPSS trajectory, and operational context."
         )
 
     return {
@@ -397,22 +414,30 @@ def _render_text(comparison: dict[str, Any]) -> str:
     lines.append(row("EPSS score", _fmt_epss(pa.get("epss", {})), _fmt_epss(pb.get("epss", {}))))
     lines.append(row("CISA KEV", _fmt_kev(pa.get("kev", {})), _fmt_kev(pb.get("kev", {}))))
     lines.append(row("CWE", ", ".join(pa.get("cwe", [])) or "N/A", ", ".join(pb.get("cwe", [])) or "N/A"))
-    lines.append(row(
-        "Attack vector",
-        pa.get("cvss", {}).get("attack_vector") or "N/A",
-        pb.get("cvss", {}).get("attack_vector") or "N/A",
-    ))
-    lines.append(row(
-        "Privileges req.",
-        pa.get("cvss", {}).get("privileges_required") or "N/A",
-        pb.get("cvss", {}).get("privileges_required") or "N/A",
-    ))
-    lines.append(row(
-        "User interaction",
-        pa.get("cvss", {}).get("user_interaction") or "N/A",
-        pb.get("cvss", {}).get("user_interaction") or "N/A",
-    ))
-    lines.append(row("Priority score", str(int(comparison["priority_score_a"])), str(int(comparison["priority_score_b"]))))
+    lines.append(
+        row(
+            "Attack vector",
+            pa.get("cvss", {}).get("attack_vector") or "N/A",
+            pb.get("cvss", {}).get("attack_vector") or "N/A",
+        )
+    )
+    lines.append(
+        row(
+            "Privileges req.",
+            pa.get("cvss", {}).get("privileges_required") or "N/A",
+            pb.get("cvss", {}).get("privileges_required") or "N/A",
+        )
+    )
+    lines.append(
+        row(
+            "User interaction",
+            pa.get("cvss", {}).get("user_interaction") or "N/A",
+            pb.get("cvss", {}).get("user_interaction") or "N/A",
+        )
+    )
+    lines.append(
+        row("Priority score", str(int(comparison["priority_score_a"])), str(int(comparison["priority_score_b"])))
+    )
     lines.append(f"{sep}\n")
     lines.append(f"\n  RECOMMENDATION\n  {comparison['recommendation']}\n")
 

--- a/tests/test_compare_cves.py
+++ b/tests/test_compare_cves.py
@@ -36,15 +36,7 @@ MOCK_NVD_LOG4SHELL = {
     },
     "weaknesses": [{"description": [{"lang": "en", "value": "CWE-917"}]}],
     "configurations": [
-        {
-            "nodes": [
-                {
-                    "cpeMatch": [
-                        {"criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*", "vulnerable": True}
-                    ]
-                }
-            ]
-        }
+        {"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*", "vulnerable": True}]}]}
     ],
 }
 
@@ -69,15 +61,7 @@ MOCK_NVD_XZ = {
     },
     "weaknesses": [{"description": [{"lang": "en", "value": "CWE-506"}]}],
     "configurations": [
-        {
-            "nodes": [
-                {
-                    "cpeMatch": [
-                        {"criteria": "cpe:2.3:a:tukaani:xz_utils:*:*:*:*:*:*:*:*", "vulnerable": True}
-                    ]
-                }
-            ]
-        }
+        {"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:tukaani:xz_utils:*:*:*:*:*:*:*:*", "vulnerable": True}]}]}
     ],
 }
 

--- a/tests/test_compare_cves.py
+++ b/tests/test_compare_cves.py
@@ -1,0 +1,884 @@
+"""
+Tests for compare_cves tool and manus-use compare CLI subcommand.
+
+All tests are fully mocked — no real HTTP calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures / shared mock data
+# ──────────────────────────────────────────────────────────────────────────────
+
+MOCK_NVD_LOG4SHELL = {
+    "id": "CVE-2021-44228",
+    "published": "2021-12-10T10:15:09.143",
+    "descriptions": [{"lang": "en", "value": "Apache Log4j2 RCE vulnerability via JNDI"}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 10.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"lang": "en", "value": "CWE-917"}]}],
+    "configurations": [
+        {
+            "nodes": [
+                {
+                    "cpeMatch": [
+                        {"criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*", "vulnerable": True}
+                    ]
+                }
+            ]
+        }
+    ],
+}
+
+MOCK_NVD_XZ = {
+    "id": "CVE-2024-3094",
+    "published": "2024-03-29T17:15:21.940",
+    "descriptions": [{"lang": "en", "value": "XZ Utils backdoor inserted by malicious actor"}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 10.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"lang": "en", "value": "CWE-506"}]}],
+    "configurations": [
+        {
+            "nodes": [
+                {
+                    "cpeMatch": [
+                        {"criteria": "cpe:2.3:a:tukaani:xz_utils:*:*:*:*:*:*:*:*", "vulnerable": True}
+                    ]
+                }
+            ]
+        }
+    ],
+}
+
+MOCK_EPSS_LOG4SHELL = {"cve": "CVE-2021-44228", "epss": "0.97535", "percentile": "0.99999", "date": "2024-01-01"}
+MOCK_EPSS_XZ = {"cve": "CVE-2024-3094", "epss": "0.04234", "percentile": "0.87543", "date": "2024-01-01"}
+
+MOCK_KEV_CATALOG = {
+    "vulnerabilities": [
+        {
+            "cveID": "CVE-2021-44228",
+            "vendorProject": "Apache",
+            "product": "Log4j2",
+            "dateAdded": "2021-12-10",
+            "dueDate": "2021-12-24",
+            "requiredAction": "Apply updates per vendor guidance.",
+        }
+    ]
+}
+
+
+def _nvd_response(record: dict) -> MagicMock:
+    """Create a mock requests.Response for NVD data."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"vulnerabilities": [{"cve": record}]}
+    return resp
+
+
+def _epss_response(entry: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = {"data": [entry]}
+    return resp
+
+
+def _kev_response(catalog: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = catalog
+    return resp
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests for private helper functions
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestFetchNvd:
+    def test_returns_cve_record_on_success(self):
+        from manus_use.tools.compare_cves import _fetch_nvd
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            mock_get.return_value = _nvd_response(MOCK_NVD_LOG4SHELL)
+            result = _fetch_nvd("CVE-2021-44228")
+
+        assert result.get("id") == "CVE-2021-44228"
+
+    def test_returns_error_dict_when_no_vulnerabilities(self):
+        from manus_use.tools.compare_cves import _fetch_nvd
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"vulnerabilities": []}
+            mock_get.return_value = resp
+            result = _fetch_nvd("CVE-9999-9999")
+
+        assert "error" in result
+
+    def test_returns_error_dict_on_request_exception(self):
+        import requests
+
+        from manus_use.tools.compare_cves import _fetch_nvd
+
+        with patch("manus_use.tools.compare_cves.requests.get", side_effect=requests.RequestException("timeout")):
+            result = _fetch_nvd("CVE-2021-44228")
+
+        assert "error" in result
+        assert "timeout" in result["error"]
+
+
+class TestFetchEpss:
+    def test_returns_entry_on_success(self):
+        from manus_use.tools.compare_cves import _fetch_epss
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            mock_get.return_value = _epss_response(MOCK_EPSS_LOG4SHELL)
+            result = _fetch_epss("CVE-2021-44228")
+
+        assert result.get("epss") == "0.97535"
+
+    def test_returns_error_dict_when_no_data(self):
+        from manus_use.tools.compare_cves import _fetch_epss
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"data": []}
+            mock_get.return_value = resp
+            result = _fetch_epss("CVE-9999-9999")
+
+        assert "error" in result
+
+    def test_returns_error_on_request_exception(self):
+        import requests
+
+        from manus_use.tools.compare_cves import _fetch_epss
+
+        with patch("manus_use.tools.compare_cves.requests.get", side_effect=requests.RequestException("conn")):
+            result = _fetch_epss("CVE-2021-44228")
+
+        assert "error" in result
+
+
+class TestFetchKev:
+    def test_returns_in_kev_true_for_known_cve(self):
+        from manus_use.tools.compare_cves import _fetch_kev
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            mock_get.return_value = _kev_response(MOCK_KEV_CATALOG)
+            result = _fetch_kev("CVE-2021-44228")
+
+        assert result["in_kev"] is True
+        assert result["date_added"] == "2021-12-10"
+        assert result["vendor_project"] == "Apache"
+
+    def test_returns_in_kev_false_for_unknown_cve(self):
+        from manus_use.tools.compare_cves import _fetch_kev
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            mock_get.return_value = _kev_response(MOCK_KEV_CATALOG)
+            result = _fetch_kev("CVE-2024-3094")
+
+        assert result["in_kev"] is False
+        assert "date_added" not in result
+
+    def test_returns_in_kev_false_on_request_exception(self):
+        import requests
+
+        from manus_use.tools.compare_cves import _fetch_kev
+
+        with patch("manus_use.tools.compare_cves.requests.get", side_effect=requests.RequestException("net")):
+            result = _fetch_kev("CVE-2021-44228")
+
+        assert result["in_kev"] is False
+        assert "error" in result
+
+    def test_case_insensitive_matching(self):
+        from manus_use.tools.compare_cves import _fetch_kev
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            mock_get.return_value = _kev_response(MOCK_KEV_CATALOG)
+            result = _fetch_kev("cve-2021-44228")  # lower-case input
+
+        assert result["in_kev"] is True
+
+
+class TestExtractCvss:
+    def test_prefers_v31_over_v2(self):
+        from manus_use.tools.compare_cves import _extract_cvss
+
+        result = _extract_cvss(MOCK_NVD_LOG4SHELL)
+        assert result["version"] == "3.1"
+        assert result["score"] == 10.0
+        assert result["severity"] == "CRITICAL"
+        assert result["attack_vector"] == "NETWORK"
+
+    def test_falls_back_to_v2_when_no_v3(self):
+        from manus_use.tools.compare_cves import _extract_cvss
+
+        nvd = {
+            "metrics": {
+                "cvssMetricV2": [
+                    {
+                        "baseSeverity": "HIGH",
+                        "cvssData": {
+                            "baseScore": 9.3,
+                            "vectorString": "AV:N/AC:M/Au:N/C:C/I:C/A:C",
+                            "accessVector": "NETWORK",
+                        },
+                    }
+                ]
+            }
+        }
+        result = _extract_cvss(nvd)
+        assert result["version"] == "2.0"
+        assert result["score"] == 9.3
+
+    def test_returns_none_score_when_no_metrics(self):
+        from manus_use.tools.compare_cves import _extract_cvss
+
+        result = _extract_cvss({})
+        assert result["score"] is None
+        assert result["severity"] is None
+
+
+class TestExtractCwe:
+    def test_returns_cwe_ids(self):
+        from manus_use.tools.compare_cves import _extract_cwe
+
+        result = _extract_cwe(MOCK_NVD_LOG4SHELL)
+        assert "CWE-917" in result
+
+    def test_filters_out_placeholder_cwes(self):
+        from manus_use.tools.compare_cves import _extract_cwe
+
+        nvd = {
+            "weaknesses": [
+                {"description": [{"lang": "en", "value": "NVD-CWE-Other"}]},
+                {"description": [{"lang": "en", "value": "NVD-CWE-noinfo"}]},
+                {"description": [{"lang": "en", "value": "CWE-79"}]},
+            ]
+        }
+        result = _extract_cwe(nvd)
+        assert result == ["CWE-79"]
+
+    def test_returns_empty_list_when_no_weaknesses(self):
+        from manus_use.tools.compare_cves import _extract_cwe
+
+        assert _extract_cwe({}) == []
+
+
+class TestExtractAffected:
+    def test_returns_vendor_product(self):
+        from manus_use.tools.compare_cves import _extract_affected
+
+        result = _extract_affected(MOCK_NVD_LOG4SHELL)
+        assert "Apache" in result
+        # title-case may render as "Log4J" — check case-insensitively
+        assert "log4j" in result.lower()
+
+    def test_returns_unknown_when_no_config(self):
+        from manus_use.tools.compare_cves import _extract_affected
+
+        assert _extract_affected({}) == "Unknown"
+
+
+class TestExtractPublished:
+    def test_returns_date_portion(self):
+        from manus_use.tools.compare_cves import _extract_published
+
+        result = _extract_published(MOCK_NVD_LOG4SHELL)
+        assert result == "2021-12-10"
+
+    def test_returns_unknown_when_missing(self):
+        from manus_use.tools.compare_cves import _extract_published
+
+        assert _extract_published({}) == "Unknown"
+
+
+class TestExtractDescription:
+    def test_returns_english_description(self):
+        from manus_use.tools.compare_cves import _extract_description
+
+        result = _extract_description(MOCK_NVD_LOG4SHELL)
+        assert "Log4j2" in result
+
+    def test_truncates_long_descriptions(self):
+        from manus_use.tools.compare_cves import _extract_description
+
+        nvd = {"descriptions": [{"lang": "en", "value": "x" * 300}]}
+        result = _extract_description(nvd)
+        assert len(result) <= 201  # 200 chars + ellipsis
+        assert result.endswith("…")
+
+    def test_returns_empty_string_when_no_description(self):
+        from manus_use.tools.compare_cves import _extract_description
+
+        assert _extract_description({}) == ""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests for scoring logic
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestScoreCve:
+    def _make_profile(
+        self,
+        in_kev=False,
+        cvss_score=None,
+        epss=None,
+        attack_vector=None,
+        privileges_required=None,
+        user_interaction=None,
+    ):
+        return {
+            "kev": {"in_kev": in_kev},
+            "cvss": {
+                "score": cvss_score,
+                "attack_vector": attack_vector,
+                "privileges_required": privileges_required,
+                "user_interaction": user_interaction,
+            },
+            "epss": {"epss": epss},
+        }
+
+    def test_kev_adds_ten_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, reasons = _score_cve(self._make_profile(in_kev=True))
+        assert score >= 10
+        assert any("KEV" in r for r in reasons)
+
+    def test_critical_cvss_adds_eight_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, reasons = _score_cve(self._make_profile(cvss_score=9.8))
+        assert score >= 8
+        assert any("Critical" in r for r in reasons)
+
+    def test_high_cvss_adds_five_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(cvss_score=7.5))
+        assert score == 5
+
+    def test_medium_cvss_adds_two_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(cvss_score=5.0))
+        assert score == 2
+
+    def test_high_epss_adds_eight_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, reasons = _score_cve(self._make_profile(epss=0.85))
+        assert score >= 8
+        assert any("very high" in r for r in reasons)
+
+    def test_medium_epss_adds_five_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(epss=0.55))
+        assert score == 5
+
+    def test_low_elevated_epss_adds_two_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(epss=0.15))
+        assert score == 2
+
+    def test_network_av_adds_three_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, reasons = _score_cve(self._make_profile(attack_vector="NETWORK"))
+        assert score == 3
+        assert any("remotely exploitable" in r for r in reasons)
+
+    def test_none_pr_adds_two_points(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(privileges_required="NONE"))
+        assert score == 2
+
+    def test_none_ui_adds_one_point(self):
+        from manus_use.tools.compare_cves import _score_cve
+
+        score, _ = _score_cve(self._make_profile(user_interaction="NONE"))
+        assert score == 1
+
+    def test_full_score_log4shell_profile(self):
+        """Log4Shell: KEV + CVSS 10 + high EPSS + NETWORK + no priv + no UI"""
+        from manus_use.tools.compare_cves import _score_cve
+
+        profile = self._make_profile(
+            in_kev=True,
+            cvss_score=10.0,
+            epss=0.97,
+            attack_vector="NETWORK",
+            privileges_required="NONE",
+            user_interaction="NONE",
+        )
+        score, _ = _score_cve(profile)
+        # 10 + 8 + 8 + 3 + 2 + 1 = 32
+        assert score == 32
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests for _build_comparison
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestBuildComparison:
+    def _profile(self, cve_id, score_val):
+        """Build a minimal profile with a predictable score."""
+        return {
+            "cve_id": cve_id,
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "score": score_val,
+                "severity": "CRITICAL" if score_val >= 9 else "HIGH",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "version": "3.1",
+            },
+            "epss": {},
+            "cwe": [],
+            "affected": "Vendor / Product",
+            "published": "2024-01-01",
+            "description": "Test description",
+        }
+
+    def test_higher_cvss_wins(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        pa = self._profile("CVE-2021-44228", 10.0)
+        pb = self._profile("CVE-2024-3094", 7.5)
+        result = _build_comparison(pa, {"in_kev": False}, pb, {"in_kev": False})
+        assert result["higher_priority"] == "CVE-2021-44228"
+
+    def test_kev_membership_can_flip_priority(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        # pa: CVSS 9.0, no KEV; pb: CVSS 7.5 but in KEV
+        pa = self._profile("CVE-A", 9.0)
+        pb = self._profile("CVE-B", 7.5)
+        kev_b = {"in_kev": True, "date_added": "2024-01-01", "due_date": "2024-01-15"}
+        result = _build_comparison(pa, {"in_kev": False}, pb, kev_b)
+        # CVE-B: 10 (KEV) + 5 (High) + 3 (NETWORK) + 2 (PR=NONE) + 1 (UI=NONE) = 21
+        # CVE-A: 8 (Critical) + 3 + 2 + 1 = 14
+        assert result["higher_priority"] == "CVE-B"
+
+    def test_tie_produces_tie_result(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        pa = self._profile("CVE-A", 9.0)
+        pb = self._profile("CVE-B", 9.0)
+        result = _build_comparison(pa, {"in_kev": False}, pb, {"in_kev": False})
+        assert result["higher_priority"] == "tie"
+        assert result["confidence"] == "tie"
+
+    def test_recommendation_mentions_winner(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        pa = self._profile("CVE-2021-44228", 10.0)
+        pb = self._profile("CVE-2024-3094", 6.0)
+        result = _build_comparison(pa, {"in_kev": False}, pb, {"in_kev": False})
+        assert "CVE-2021-44228" in result["recommendation"]
+
+    def test_strong_confidence_when_margin_ge_10(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        pa = self._profile("CVE-A", 10.0)
+        pa_kev = {"in_kev": True, "date_added": "2024-01-01", "due_date": "2024-01-15"}
+        pb = self._profile("CVE-B", 4.0)
+        result = _build_comparison(pa, pa_kev, pb, {"in_kev": False})
+        assert result["confidence"] == "strong"
+
+    def test_priority_scores_included_in_result(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        pa = self._profile("CVE-A", 9.0)
+        pb = self._profile("CVE-B", 7.5)
+        result = _build_comparison(pa, {"in_kev": False}, pb, {"in_kev": False})
+        assert "priority_score_a" in result
+        assert "priority_score_b" in result
+        assert result["priority_score_a"] > result["priority_score_b"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests for _render_text
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestRenderText:
+    def _make_comparison(self):
+        from manus_use.tools.compare_cves import _build_comparison
+
+        profile_a = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "score": 10.0,
+                "severity": "CRITICAL",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "version": "3.1",
+            },
+            "epss": {"epss": "0.97535", "percentile": "0.99999"},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4j2",
+            "published": "2021-12-10",
+            "description": "Apache Log4j2 RCE",
+        }
+        profile_b = {
+            "cve_id": "CVE-2024-3094",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "score": 10.0,
+                "severity": "CRITICAL",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "version": "3.1",
+            },
+            "epss": {"epss": "0.04234", "percentile": "0.87543"},
+            "cwe": ["CWE-506"],
+            "affected": "Tukaani / Xz Utils",
+            "published": "2024-03-29",
+            "description": "XZ Utils backdoor",
+        }
+        kev_a = {"in_kev": True, "date_added": "2021-12-10", "due_date": "2021-12-24"}
+        return _build_comparison(profile_a, kev_a, profile_b, {"in_kev": False})
+
+    def test_contains_both_cve_ids(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        comp = self._make_comparison()
+        text = _render_text(comp)
+        assert "CVE-2021-44228" in text
+        assert "CVE-2024-3094" in text
+
+    def test_contains_cvss_row(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        text = _render_text(self._make_comparison())
+        assert "CVSS" in text
+
+    def test_contains_epss_row(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        text = _render_text(self._make_comparison())
+        assert "EPSS" in text
+
+    def test_contains_kev_row(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        text = _render_text(self._make_comparison())
+        assert "KEV" in text
+
+    def test_contains_recommendation(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        text = _render_text(self._make_comparison())
+        assert "RECOMMENDATION" in text
+
+    def test_kev_yes_shown_for_kev_member(self):
+        from manus_use.tools.compare_cves import _render_text
+
+        text = _render_text(self._make_comparison())
+        assert "YES" in text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Integration-style tests for the Strands tool entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCompareCvesToolEntryPoint:
+    def _make_tool_use(self, cve_id_a: str, cve_id_b: str) -> dict:
+        return {"toolUseId": "test-123", "input": {"cve_id_a": cve_id_a, "cve_id_b": cve_id_b}}
+
+    def _setup_mocks(self, mock_get):
+        """Configure mock_get to return appropriate responses depending on URL."""
+
+        def side_effect(url, **kwargs):
+            params = kwargs.get("params", {})
+            cve = params.get("cve", "").upper() if params else ""
+
+            if "nvd.nist.gov" in url:
+                cve_in_url = url.split("cveId=")[-1].upper() if "cveId=" in url else ""
+                if "CVE-2021-44228" in cve_in_url:
+                    return _nvd_response(MOCK_NVD_LOG4SHELL)
+                return _nvd_response(MOCK_NVD_XZ)
+            elif "api.first.org" in url:
+                if "CVE-2021-44228" in cve.upper():
+                    return _epss_response(MOCK_EPSS_LOG4SHELL)
+                return _epss_response(MOCK_EPSS_XZ)
+            elif "cisa.gov" in url:
+                return _kev_response(MOCK_KEV_CATALOG)
+            m = MagicMock()
+            m.raise_for_status = MagicMock()
+            m.json.return_value = {}
+            return m
+
+        mock_get.side_effect = side_effect
+
+    def test_returns_success_status(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._setup_mocks(mock_get)
+            result = compare_cves(self._make_tool_use("CVE-2021-44228", "CVE-2024-3094"))
+
+        assert result["status"] == "success"
+
+    def test_returns_text_content(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._setup_mocks(mock_get)
+            result = compare_cves(self._make_tool_use("CVE-2021-44228", "CVE-2024-3094"))
+
+        texts = [c["text"] for c in result["content"] if "text" in c]
+        assert texts
+        assert "CVE-2021-44228" in texts[0]
+
+    def test_returns_json_content(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._setup_mocks(mock_get)
+            result = compare_cves(self._make_tool_use("CVE-2021-44228", "CVE-2024-3094"))
+
+        jsons = [c["json"] for c in result["content"] if "json" in c]
+        assert jsons
+        comp = jsons[0]
+        assert "cve_a" in comp
+        assert "cve_b" in comp
+        assert "recommendation" in comp
+
+    def test_invalid_cve_id_returns_error(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        result = compare_cves(self._make_tool_use("not-a-cve", "CVE-2024-3094"))
+        assert result["status"] == "error"
+
+    def test_both_cve_ids_validated(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        result = compare_cves(self._make_tool_use("CVE-2021-44228", "bad-id"))
+        assert result["status"] == "error"
+
+    def test_higher_priority_field_present(self):
+        from manus_use.tools.compare_cves import compare_cves
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._setup_mocks(mock_get)
+            result = compare_cves(self._make_tool_use("CVE-2021-44228", "CVE-2024-3094"))
+
+        jsons = [c["json"] for c in result["content"] if "json" in c]
+        assert jsons[0]["higher_priority"] in ("CVE-2021-44228", "CVE-2024-3094", "tie")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI subcommand tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestCompareCLIParser:
+    def test_parser_accepts_two_cve_ids(self):
+        from manus_use.cli import _build_compare_parser
+
+        parser = _build_compare_parser()
+        args = parser.parse_args(["CVE-2021-44228", "CVE-2024-3094"])
+        assert args.cve_id_a == "CVE-2021-44228"
+        assert args.cve_id_b == "CVE-2024-3094"
+
+    def test_parser_defaults_output_to_text(self):
+        from manus_use.cli import _build_compare_parser
+
+        parser = _build_compare_parser()
+        args = parser.parse_args(["CVE-2021-44228", "CVE-2024-3094"])
+        assert args.output == "text"
+
+    def test_parser_accepts_json_output_flag(self):
+        from manus_use.cli import _build_compare_parser
+
+        parser = _build_compare_parser()
+        args = parser.parse_args(["CVE-2021-44228", "CVE-2024-3094", "--output", "json"])
+        assert args.output == "json"
+
+    def test_parser_rejects_invalid_output_format(self):
+        from manus_use.cli import _build_compare_parser
+
+        parser = _build_compare_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args(["CVE-A", "CVE-B", "--output", "xml"])
+
+    def test_help_exits_zero(self, capsys):
+        from manus_use.cli import _build_compare_parser
+
+        parser = _build_compare_parser()
+        with pytest.raises(SystemExit) as exc:
+            parser.parse_args(["--help"])
+        assert exc.value.code == 0
+
+
+class TestRunCompare:
+    def _mock_imports(self, mock_get):
+        """Patch requests to return deterministic mock data."""
+
+        def side_effect(url, **kwargs):
+            params = kwargs.get("params", {})
+            cve = params.get("cve", "").upper() if params else ""
+
+            if "nvd.nist.gov" in url:
+                cve_in_url = url.split("cveId=")[-1].upper() if "cveId=" in url else ""
+                if "CVE-2021-44228" in cve_in_url:
+                    return _nvd_response(MOCK_NVD_LOG4SHELL)
+                return _nvd_response(MOCK_NVD_XZ)
+            elif "api.first.org" in url:
+                if "CVE-2021-44228" in cve.upper():
+                    return _epss_response(MOCK_EPSS_LOG4SHELL)
+                return _epss_response(MOCK_EPSS_XZ)
+            elif "cisa.gov" in url:
+                return _kev_response(MOCK_KEV_CATALOG)
+            m = MagicMock()
+            m.raise_for_status = MagicMock()
+            m.json.return_value = {}
+            return m
+
+        mock_get.side_effect = side_effect
+
+    def test_text_output_exits_zero(self, capsys):
+        from manus_use.cli import _run_compare
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._mock_imports(mock_get)
+            code = _run_compare(["CVE-2021-44228", "CVE-2024-3094"])
+
+        assert code == 0
+
+    def test_text_output_contains_both_cves(self, capsys):
+        from manus_use.cli import _run_compare
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._mock_imports(mock_get)
+            _run_compare(["CVE-2021-44228", "CVE-2024-3094"])
+
+        captured = capsys.readouterr()
+        assert "CVE-2021-44228" in captured.out
+        assert "CVE-2024-3094" in captured.out
+
+    def test_json_output_is_valid_json(self, capsys):
+        from manus_use.cli import _run_compare
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._mock_imports(mock_get)
+            code = _run_compare(["CVE-2021-44228", "CVE-2024-3094", "--output", "json"])
+
+        assert code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "recommendation" in data
+
+    def test_json_output_contains_higher_priority_field(self, capsys):
+        from manus_use.cli import _run_compare
+
+        with patch("manus_use.tools.compare_cves.requests.get") as mock_get:
+            self._mock_imports(mock_get)
+            _run_compare(["CVE-2021-44228", "CVE-2024-3094", "--output", "json"])
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["higher_priority"] in ("CVE-2021-44228", "CVE-2024-3094", "tie")
+
+    def test_invalid_cve_id_a_exits_one(self, capsys):
+        from manus_use.cli import _run_compare
+
+        code = _run_compare(["invalid", "CVE-2024-3094"])
+        assert code == 1
+
+    def test_invalid_cve_id_b_exits_one(self, capsys):
+        from manus_use.cli import _run_compare
+
+        code = _run_compare(["CVE-2024-3094", "not-a-cve"])
+        assert code == 1
+
+    def test_error_message_written_to_stderr(self, capsys):
+        from manus_use.cli import _run_compare
+
+        _run_compare(["bad-input", "CVE-2024-3094"])
+        captured = capsys.readouterr()
+        assert "error" in captured.err.lower() or "Invalid" in captured.err
+
+
+class TestMainDispatchesCompare:
+    def test_compare_in_subcommands_set(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "compare" in _SUBCOMMANDS
+
+    def test_main_routes_compare_subcommand(self):
+
+        with patch("manus_use.cli._run_compare", return_value=0) as mock_run:
+            with patch("sys.argv", ["manus-use", "compare", "CVE-2021-44228", "CVE-2024-3094"]):
+                try:
+                    from manus_use.cli import main
+
+                    main()
+                except SystemExit as e:
+                    assert e.code == 0
+
+            mock_run.assert_called_once_with(["CVE-2021-44228", "CVE-2024-3094"])
+
+    def test_main_compare_passes_output_flag(self):
+
+        with patch("manus_use.cli._run_compare", return_value=0) as mock_run:
+            with patch("sys.argv", ["manus-use", "compare", "CVE-2021-44228", "CVE-2024-3094", "--output", "json"]):
+                try:
+                    from manus_use.cli import main
+
+                    main()
+                except SystemExit:
+                    pass
+
+            mock_run.assert_called_once_with(["CVE-2021-44228", "CVE-2024-3094", "--output", "json"])


### PR DESCRIPTION
## What & Why

`manus-use` had standalone tools for each dimension of CVE analysis — CVSS from `analyze`, EPSS scores from `epss-trend`, KEV status from the analysis pipeline — but no way to answer the most common triage question: **"Which of these two CVEs should I patch first?"**

This PR closes that gap with a new `compare_cves` Strands tool and `manus-use compare <CVE-A> <CVE-B>` CLI subcommand.

## Changes

**`src/manus_use/tools/compare_cves.py`** — new Strands tool:
- Fetches NVD, EPSS (FIRST.org), and CISA KEV data for both CVEs in parallel (4-worker thread pool)
- Extracts CVSS score/severity/vector (v3.1 → v3.0 → v2.0 preference order), CWE, affected vendor/product, published date, English description
- Assigns each CVE a composite priority score using a documented, auditable rubric:
  - KEV membership: +10 (confirmed active exploitation)
  - Critical CVSS (≥9.0): +8, High (7–8.9): +5, Medium (4–6.9): +2
  - EPSS ≥0.70: +8, 0.40–0.69: +5, 0.10–0.39: +2
  - Network attack vector: +3, no privileges required: +2, no user interaction: +1
- Emits a plain-English recommendation with confidence level (strong/moderate/weak/tie)
- Returns both a human-readable aligned table and a structured JSON payload

**`manus-use compare <CVE-A> <CVE-B>`** CLI subcommand with `--output {text,json}`, registered in `_SUBCOMMANDS` and `main()`.

**`README.md`**: new `manus-use compare` section with usage examples and options table.

## Tests

`tests/test_compare_cves.py` — 67 new tests, 100% mocked (no real HTTP):
- Unit tests for all private helpers
- Integration-style tests for the Strands tool entry point
- CLI parser, `_run_compare`, and `main()` dispatch tests

**Before:** 483 tests passing → **After:** 550 tests passing (+67)