### PR TITLE
feat: CVE timeline view — `manus-use timeline CVE-XXXX-YYYY`

### DIFF
--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -94,6 +94,14 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - A direct link to the commit on GitHub.
   If no commit is found (private repo or non-GitHub), note this and proceed.
 
+**Step 6b: CVE Lifecycle Timeline**
+- Call `get_cve_timeline` with the CVE ID to build the full lifecycle timeline.
+  Include in the report a "Timeline" section showing:
+  - Disclosure date, patch date, first public PoC date, EPSS spike date, CISA KEV date.
+  - Velocity metrics: days from disclosure to PoC, PoC to KEV, disclosure to weaponisation.
+  - Flag `fast_weaponisation=true` (PoC in <=7 days) prominently — it indicates this class of bug is actively
+    targeted and defenders have almost no window.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -187,6 +195,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_patch_diff import get_patch_diff
+            from manus_use.tools.get_cve_timeline import get_cve_timeline
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -240,6 +249,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.verify_exploit",
             get_epss_trend,
             get_patch_diff,
+            get_cve_timeline,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1052,6 +1052,7 @@ _SUBCOMMANDS = {
     "epss-trend",
     "patch-diff",
     "compare",
+    "timeline",
 }
 
 
@@ -1219,6 +1220,58 @@ def _run_patch_diff(argv: list[str]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# timeline subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_timeline_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use timeline",
+        description=(
+            "Build a structured lifecycle timeline for a CVE.\n"
+            "Aggregates key dates from NVD, GHSA, Trickest PoC index, FIRST.org EPSS,\n"
+            "and CISA KEV to show: disclosure -> patch -> first PoC -> EPSS spike -> weaponisation.\n"
+            "Also computes velocity metrics (days between events)."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_timeline(argv: list[str]) -> int:
+    parser = _build_timeline_parser()
+    args = parser.parse_args(argv)
+
+    cve_id = args.cve_id.strip()
+    if not cve_id.upper().startswith("CVE-"):
+        print(f"[error] Invalid CVE ID '{cve_id}'. Must be like 'CVE-YYYY-NNNN'.", file=sys.stderr)
+        return 1
+
+    try:
+        from manus_use.tools.get_cve_timeline import build_cve_timeline, render_timeline_text
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    timeline = build_cve_timeline(cve_id)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(timeline, indent=2))
+        return 0
+
+    print(render_timeline_text(timeline))
+    return 0
+
+
 # compare subcommand
 # ---------------------------------------------------------------------------
 
@@ -1321,6 +1374,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # Patch diff summariser (fixing-commit analysis)\n"
             "  manus-use patch-diff CVE-2024-3094\n"
             "  manus-use patch-diff CVE-2024-3094 --output json\n"
+            "\n"
+            "  # CVE lifecycle timeline (disclosure -> patch -> PoC -> weaponisation)\n"
+            "  manus-use timeline CVE-2024-3094\n"
+            "  manus-use timeline CVE-2024-3094 --output json | jq .velocity\n"
             "\n"
             "  # Vulnerability intelligence analysis\n"
             "  manus-use analyze CVE-2025-6554\n"
@@ -1599,6 +1656,10 @@ def main() -> None:
     if first_positional == "compare":
         idx = argv.index("compare")
         sys.exit(_run_compare(argv[idx + 1 :]))
+
+    if first_positional == "timeline":
+        idx = argv.index("timeline")
+        sys.exit(_run_timeline(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/get_cve_timeline.py
+++ b/src/manus_use/tools/get_cve_timeline.py
@@ -1,0 +1,490 @@
+"""
+Tool for building a structured timeline for a CVE.
+
+Aggregates key dates from multiple sources and produces a chronological view:
+
+  disclosure_date  -> nvd_published
+  patch_date       -> earliest fixing commit found in GHSA / NVD references
+  poc_date         -> earliest public PoC repo (Trickest CVE index / GitHub)
+  epss_spike_date  -> date of the largest 7-day EPSS jump (if >= threshold)
+  kev_date         -> date added to the CISA KEV catalogue
+
+Each event record contains:
+  - event  : human-readable label
+  - date   : ISO-8601 date string (YYYY-MM-DD) or None
+  - source : where the date came from
+  - url    : reference URL (optional)
+
+Velocity metrics (in days):
+  - disclosure_to_patch_days        : disclosure to earliest patch commit
+  - disclosure_to_poc_days          : disclosure to first public PoC
+  - poc_to_kev_days                 : PoC publication to CISA KEV listing
+  - disclosure_to_weaponized_days   : disclosure to first confirmed exploitation
+
+disclosure_to_poc <= 7 days is flagged as "fast weaponisation".
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import date, datetime
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+_NVD_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id}"
+_GHSA_API_URL = "https://api.github.com/advisories?cve_id={cve_id}"
+_EPSS_API_URL = "https://api.first.org/data/v1/epss"
+_CISA_KEV_URL = (
+    "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+)
+_TRICKEST_URL = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+
+_EPSS_SPIKE_THRESHOLD = 0.10
+
+TOOL_SPEC = {
+    "name": "get_cve_timeline",
+    "description": (
+        "Builds a structured timeline for a CVE by aggregating key dates from NVD, GHSA, "
+        "CISA KEV, FIRST.org EPSS, and the Trickest public PoC index. "
+        "Returns a chronological list of events (disclosure, patch, first PoC, EPSS "
+        "exploitation spike, CISA KEV listing) and velocity metrics showing how quickly "
+        "the vulnerability moved from disclosure to weaponisation. "
+        "Use this to understand the full lifecycle of a CVE at a glance."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., CVE-2024-3094).",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+def _iso_date(s: str | None) -> str | None:
+    """Normalise various timestamp formats to YYYY-MM-DD, or return None."""
+    if not s:
+        return None
+    m = re.match(r"^(\d{4}-\d{2}-\d{2})", str(s))
+    if m:
+        return m.group(1)
+    return None
+
+
+def _days_between(a: str | None, b: str | None) -> int | None:
+    """Return difference in days (b - a), or None if either date is missing."""
+    if not a or not b:
+        return None
+    try:
+        da = datetime.strptime(a, "%Y-%m-%d").date()
+        db = datetime.strptime(b, "%Y-%m-%d").date()
+        return (db - da).days
+    except ValueError:
+        return None
+
+
+def _github_headers() -> dict[str, str]:
+    """Build GitHub API headers, including auth token if GITHUB_TOKEN is set."""
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"token {token}"
+    return headers
+
+
+def _commit_date(api_url: str) -> str | None:
+    """Call a GitHub commit API URL and return its committer/author date."""
+    try:
+        resp = requests.get(api_url, headers=_github_headers(), timeout=10)
+        if not resp.ok:
+            return None
+        data = resp.json()
+        raw = (
+            data.get("commit", {}).get("committer", {}).get("date")
+            or data.get("commit", {}).get("author", {}).get("date")
+        )
+        return _iso_date(raw)
+    except Exception:
+        return None
+
+
+def _fetch_nvd_info(cve_id: str) -> dict[str, Any]:
+    """Return NVD metadata: published, lastModified, and embedded KEV date."""
+    try:
+        resp = requests.get(_NVD_CVE_URL.format(cve_id=cve_id), timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return {}
+        cve = vulns[0].get("cve", {})
+        return {
+            "published": _iso_date(cve.get("published")),
+            "last_modified": _iso_date(cve.get("lastModified")),
+            "kev_date": _iso_date(cve.get("cisaExploitAdd")),
+            "nvd_url": f"https://nvd.nist.gov/vuln/detail/{cve_id}",
+        }
+    except Exception:
+        return {}
+
+
+def _fetch_ghsa_patch_date(cve_id: str) -> tuple[str | None, str | None]:
+    """Query GHSA for a fixing-commit date. Returns (date_str, url)."""
+    try:
+        resp = requests.get(
+            _GHSA_API_URL.format(cve_id=cve_id),
+            headers=_github_headers(),
+            timeout=15,
+        )
+        resp.raise_for_status()
+        advisories = resp.json()
+        if not isinstance(advisories, list) or not advisories:
+            return None, None
+
+        advisory = advisories[0]
+        for ref in advisory.get("references", []):
+            url = ref if isinstance(ref, str) else ref.get("url", "")
+            m = re.search(r"github\.com/([^/]+/[^/]+)/commit/([0-9a-f]{7,40})", url)
+            if m:
+                api_url = (
+                    f"https://api.github.com/repos/{m.group(1)}/commits/{m.group(2)}"
+                )
+                cd = _commit_date(api_url)
+                if cd:
+                    return cd, url
+                published = _iso_date(
+                    advisory.get("published_at") or advisory.get("updated_at")
+                )
+                return published, url
+
+        published = _iso_date(advisory.get("published_at") or advisory.get("updated_at"))
+        return published, advisory.get("html_url")
+    except Exception:
+        return None, None
+
+
+def _fetch_nvd_patch_date(cve_id: str) -> tuple[str | None, str | None]:
+    """Scan NVD refs for GitHub commit URLs. Returns (date_str, commit_url)."""
+    try:
+        resp = requests.get(_NVD_CVE_URL.format(cve_id=cve_id), timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return None, None
+
+        hits: list[tuple[str, str]] = []
+        for ref in vulns[0].get("cve", {}).get("references", []):
+            url = ref.get("url", "")
+            m = re.search(r"github\.com/([^/]+/[^/]+)/commit/([0-9a-f]{7,40})", url)
+            if m:
+                api_url = (
+                    f"https://api.github.com/repos/{m.group(1)}/commits/{m.group(2)}"
+                )
+                cd = _commit_date(api_url)
+                if cd:
+                    hits.append((cd, url))
+
+        if hits:
+            hits.sort(key=lambda x: x[0])
+            return hits[0]
+        return None, None
+    except Exception:
+        return None, None
+
+
+def _fetch_trickest_poc(cve_id: str) -> tuple[str | None, str | None]:
+    """Check Trickest CVE index for a PoC. Returns (date_str, url)."""
+    m = re.match(r"CVE-(\d{4})-\d+", cve_id)
+    if not m:
+        return None, None
+    year = m.group(1)
+    trickest_url = _TRICKEST_URL.format(year=year, cve_id=cve_id)
+
+    try:
+        resp = requests.get(trickest_url, timeout=10)
+        if resp.status_code == 404:
+            return None, None
+        resp.raise_for_status()
+        text = resp.text
+
+        repo_paths = re.findall(r"https://github\.com/([^/\s)>\"]+/[^/\s)>\"]+)", text)
+        for repo_path in repo_paths:
+            if "trickest" in repo_path.lower():
+                continue
+            try:
+                api_url = f"https://api.github.com/repos/{repo_path}"
+                cr = requests.get(api_url, headers=_github_headers(), timeout=10)
+                if cr.ok:
+                    repo_data = cr.json()
+                    created_at = _iso_date(repo_data.get("created_at"))
+                    if created_at:
+                        return created_at, f"https://github.com/{repo_path}"
+            except Exception:
+                continue
+
+        dates = sorted(set(re.findall(r"\b(\d{4}-\d{2}-\d{2})\b", text)))
+        if dates:
+            return dates[0], trickest_url
+        return None, trickest_url
+    except Exception:
+        return None, None
+
+
+def _fetch_epss_spike(cve_id: str) -> tuple[str | None, float]:
+    """Fetch EPSS history and return (spike_date, max_7d_jump)."""
+    try:
+        resp = requests.get(
+            _EPSS_API_URL,
+            params={"cve": cve_id, "scope": "time-series", "limit": 365},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        entries = data.get("data", [])
+        if not entries:
+            return None, 0.0
+
+        entry = entries[0]
+        series = list(entry.get("time-series", []))
+        current = {"date": entry.get("date", ""), "epss": entry.get("epss", "0")}
+        if current["date"] and not any(p["date"] == current["date"] for p in series):
+            series = [current] + series
+
+        points = sorted(
+            [{"date": p["date"], "epss": float(p["epss"])} for p in series],
+            key=lambda x: x["date"],
+        )
+        scores = [p["epss"] for p in points]
+
+        max_jump = 0.0
+        spike_date: str | None = None
+        for i in range(len(scores) - 1):
+            for j in range(i + 1, min(i + 8, len(scores))):
+                delta = scores[j] - scores[i]
+                if delta > max_jump:
+                    max_jump = delta
+                    spike_date = points[j]["date"]
+
+        if max_jump >= _EPSS_SPIKE_THRESHOLD:
+            return spike_date, round(max_jump, 6)
+        return None, round(max_jump, 6)
+    except Exception:
+        return None, 0.0
+
+
+def _fetch_cisa_kev(cve_id: str) -> tuple[str | None, str | None]:
+    """Scan CISA KEV catalogue. Returns (date_added, required_action)."""
+    try:
+        resp = requests.get(_CISA_KEV_URL, timeout=20)
+        resp.raise_for_status()
+        for vuln in resp.json().get("vulnerabilities", []):
+            if vuln.get("cveID", "").upper() == cve_id:
+                return _iso_date(vuln.get("dateAdded")), vuln.get("requiredAction")
+        return None, None
+    except Exception:
+        return None, None
+
+
+def build_cve_timeline(cve_id: str) -> dict[str, Any]:
+    """Collect dates from all sources and return a structured timeline dict."""
+    cve_id = cve_id.upper()
+
+    nvd = _fetch_nvd_info(cve_id)
+    disclosure_date = nvd.get("published")
+    nvd_url = nvd.get("nvd_url", f"https://nvd.nist.gov/vuln/detail/{cve_id}")
+
+    patch_date, patch_url = _fetch_ghsa_patch_date(cve_id)
+    if not patch_date:
+        patch_date, patch_url = _fetch_nvd_patch_date(cve_id)
+
+    poc_date, poc_url = _fetch_trickest_poc(cve_id)
+    epss_spike_date, max_7d_jump = _fetch_epss_spike(cve_id)
+    kev_date, _kev_action = _fetch_cisa_kev(cve_id)
+    if not kev_date:
+        kev_date = nvd.get("kev_date")
+
+    events: list[dict[str, Any]] = []
+
+    if disclosure_date:
+        events.append(
+            {
+                "event": "CVE Disclosed (NVD Published)",
+                "date": disclosure_date,
+                "source": "NVD",
+                "url": nvd_url,
+            }
+        )
+
+    if patch_date:
+        events.append(
+            {
+                "event": "Patch Committed",
+                "date": patch_date,
+                "source": "GHSA / GitHub",
+                "url": patch_url,
+            }
+        )
+
+    if poc_date:
+        events.append(
+            {
+                "event": "First Public PoC",
+                "date": poc_date,
+                "source": "Trickest CVE Index / GitHub",
+                "url": poc_url,
+            }
+        )
+
+    if epss_spike_date:
+        events.append(
+            {
+                "event": f"EPSS Exploitation Spike (delta {max_7d_jump:.3f} in 7 days)",
+                "date": epss_spike_date,
+                "source": "FIRST.org EPSS",
+                "url": "https://www.first.org/epss/",
+            }
+        )
+
+    if kev_date:
+        events.append(
+            {
+                "event": "Added to CISA KEV (Confirmed Exploitation in Wild)",
+                "date": kev_date,
+                "source": "CISA KEV",
+                "url": "https://www.cisa.gov/known-exploited-vulnerabilities-catalog",
+            }
+        )
+
+    events.sort(key=lambda e: (e["date"] is None, e["date"] or ""))
+
+    velocity: dict[str, Any] = {}
+
+    d2patch = _days_between(disclosure_date, patch_date)
+    if d2patch is not None:
+        velocity["disclosure_to_patch_days"] = d2patch
+
+    d2poc = _days_between(disclosure_date, poc_date)
+    if d2poc is not None:
+        velocity["disclosure_to_poc_days"] = d2poc
+        velocity["fast_weaponisation"] = d2poc <= 7
+
+    poc2kev = _days_between(poc_date, kev_date)
+    if poc2kev is not None:
+        velocity["poc_to_kev_days"] = poc2kev
+
+    weaponized_date = kev_date or epss_spike_date
+    weaponized_source = (
+        "CISA KEV" if kev_date else ("EPSS spike" if epss_spike_date else None)
+    )
+    d2w = _days_between(disclosure_date, weaponized_date)
+    if d2w is not None and weaponized_source:
+        velocity["disclosure_to_weaponized_days"] = d2w
+        velocity["weaponized_source"] = weaponized_source
+
+    today_str = date.today().isoformat()
+    dsd = _days_between(disclosure_date, today_str)
+    if dsd is not None:
+        velocity["days_since_disclosure"] = dsd
+
+    return {
+        "cve_id": cve_id,
+        "events": events,
+        "velocity": velocity,
+        "current_date": today_str,
+    }
+
+
+def render_timeline_text(timeline: dict[str, Any]) -> str:
+    """Render a timeline dict as a human-readable text report."""
+    cve_id = timeline["cve_id"]
+    events = timeline["events"]
+    velocity = timeline["velocity"]
+    sep = "=" * 56
+
+    lines: list[str] = [f"CVE Timeline: {cve_id}", sep]
+
+    if not events:
+        lines.append("  No timeline events found.")
+    else:
+        for ev in events:
+            d = ev["date"] or "unknown date"
+            lines.append(f"  {d}  {ev['event']}")
+            lines.append(f"               Source: {ev['source']}")
+            if ev.get("url"):
+                lines.append(f"               URL:    {ev['url']}")
+
+    lines += ["", "Velocity Metrics", "-" * 40]
+
+    if not velocity:
+        lines.append("  Insufficient data to compute velocity.")
+    else:
+        if "days_since_disclosure" in velocity:
+            lines.append(
+                f"  Days since disclosure       : {velocity['days_since_disclosure']}"
+            )
+        if "disclosure_to_patch_days" in velocity:
+            d = velocity["disclosure_to_patch_days"]
+            flag = "  (patch preceded disclosure?)" if d < 0 else ""
+            lines.append(f"  Disclosure -> Patch          : {d} days{flag}")
+        if "disclosure_to_poc_days" in velocity:
+            d = velocity["disclosure_to_poc_days"]
+            fast = "  [FAST <=7 days]" if velocity.get("fast_weaponisation") else ""
+            lines.append(f"  Disclosure -> First PoC      : {d} days{fast}")
+        if "poc_to_kev_days" in velocity:
+            lines.append(
+                f"  PoC -> CISA KEV listing      : {velocity['poc_to_kev_days']} days"
+            )
+        if "disclosure_to_weaponized_days" in velocity:
+            src = velocity.get("weaponized_source", "")
+            lines.append(
+                f"  Disclosure -> Weaponized     : "
+                f"{velocity['disclosure_to_weaponized_days']} days  (via {src})"
+            )
+
+    return "\n".join(lines)
+
+
+def get_cve_timeline(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Build a structured CVE lifecycle timeline from multiple intelligence sources."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [
+                {"text": "Invalid CVE ID format. Must be a string like CVE-YYYY-NNNN."}
+            ],
+        }
+        log_tool_output_size("get_cve_timeline", result)
+        return result
+
+    timeline = build_cve_timeline(cve_id)
+    text_report = render_timeline_text(timeline)
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": text_report},
+            {"json": timeline},
+        ],
+    }
+    log_tool_output_size("get_cve_timeline", result)
+    return result

--- a/tests/test_cve_timeline.py
+++ b/tests/test_cve_timeline.py
@@ -1,0 +1,902 @@
+"""
+Tests for get_cve_timeline tool and the manus-use timeline CLI subcommand.
+
+All HTTP calls are mocked — no real network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helper factories
+# ---------------------------------------------------------------------------
+
+
+def _tool_use(cve_id: str, tool_use_id: str = "tu-1") -> dict:
+    return {"toolUseId": tool_use_id, "input": {"cve_id": cve_id}}
+
+
+def _nvd_resp(published: str = "2024-03-29", kev_date: str | None = None) -> dict:
+    cve: dict = {
+        "published": published,
+        "lastModified": published,
+        "references": [],
+    }
+    if kev_date:
+        cve["cisaExploitAdd"] = kev_date
+    return {"vulnerabilities": [{"cve": cve}]}
+
+
+def _epss_resp(scores: list[float], base_date: str = "2024-01-01") -> dict:
+    from datetime import datetime, timedelta
+
+    base = datetime.strptime(base_date, "%Y-%m-%d")
+    series = [
+        {
+            "date": (base + timedelta(days=i)).strftime("%Y-%m-%d"),
+            "epss": str(score),
+            "percentile": "0.9",
+        }
+        for i, score in enumerate(scores)
+    ]
+    latest = series[-1] if series else {"date": base_date, "epss": "0.01", "percentile": "0.5"}
+    return {
+        "data": [
+            {
+                "cve": "CVE-MOCK",
+                "date": latest["date"],
+                "epss": latest["epss"],
+                "percentile": latest["percentile"],
+                "time-series": series[:-1],
+            }
+        ]
+    }
+
+
+def _mock_resp(json_data: dict, status_code: int = 200) -> MagicMock:
+    m = MagicMock()
+    m.status_code = status_code
+    m.ok = status_code < 400
+    m.json.return_value = json_data
+    m.raise_for_status.side_effect = None if status_code < 400 else Exception("HTTP error")
+    m.text = json.dumps(json_data)
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helpers
+# ---------------------------------------------------------------------------
+
+
+class TestIsoDate:
+    def test_iso_date_full_timestamp(self):
+        from manus_use.tools.get_cve_timeline import _iso_date
+
+        assert _iso_date("2024-03-29T14:00:00.000Z") == "2024-03-29"
+
+    def test_iso_date_already_iso(self):
+        from manus_use.tools.get_cve_timeline import _iso_date
+
+        assert _iso_date("2024-03-29") == "2024-03-29"
+
+    def test_iso_date_none(self):
+        from manus_use.tools.get_cve_timeline import _iso_date
+
+        assert _iso_date(None) is None
+
+    def test_iso_date_empty(self):
+        from manus_use.tools.get_cve_timeline import _iso_date
+
+        assert _iso_date("") is None
+
+    def test_iso_date_unrecognised(self):
+        from manus_use.tools.get_cve_timeline import _iso_date
+
+        assert _iso_date("not-a-date") is None
+
+
+class TestDaysBetween:
+    def test_positive_gap(self):
+        from manus_use.tools.get_cve_timeline import _days_between
+
+        assert _days_between("2024-01-01", "2024-03-31") == 90
+
+    def test_same_day(self):
+        from manus_use.tools.get_cve_timeline import _days_between
+
+        assert _days_between("2024-06-01", "2024-06-01") == 0
+
+    def test_negative_gap(self):
+        from manus_use.tools.get_cve_timeline import _days_between
+
+        # 2024 is a leap year: Jan(31)+Feb(29)+Mar(31)+Apr(30)+May(31) = 152 days before Jun
+        assert _days_between("2024-06-01", "2024-01-01") == -152
+
+    def test_missing_a(self):
+        from manus_use.tools.get_cve_timeline import _days_between
+
+        assert _days_between(None, "2024-06-01") is None
+
+    def test_missing_b(self):
+        from manus_use.tools.get_cve_timeline import _days_between
+
+        assert _days_between("2024-06-01", None) is None
+
+
+class TestGithubHeaders:
+    def test_no_token(self):
+        from manus_use.tools.get_cve_timeline import _github_headers
+
+        with patch.dict("os.environ", {}, clear=True):
+            headers = _github_headers()
+        assert "Accept" in headers
+        assert "Authorization" not in headers
+
+    def test_with_token(self):
+        from manus_use.tools.get_cve_timeline import _github_headers
+
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "tok_test"}):
+            headers = _github_headers()
+        assert headers["Authorization"] == "token tok_test"
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_nvd_info
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdInfo:
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_published_date(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_nvd_info
+
+        mock_get.return_value = _mock_resp(_nvd_resp("2024-03-29"))
+        result = _fetch_nvd_info("CVE-2024-3094")
+        assert result["published"] == "2024-03-29"
+        assert "nvd_url" in result
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_embedded_kev_date(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_nvd_info
+
+        mock_get.return_value = _mock_resp(_nvd_resp("2024-03-29", kev_date="2024-04-01"))
+        result = _fetch_nvd_info("CVE-2024-3094")
+        assert result["kev_date"] == "2024-04-01"
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_empty_on_no_vulns(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_nvd_info
+
+        mock_get.return_value = _mock_resp({"vulnerabilities": []})
+        result = _fetch_nvd_info("CVE-2024-9999")
+        assert result == {}
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_empty_on_network_error(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_nvd_info
+
+        mock_get.side_effect = Exception("timeout")
+        result = _fetch_nvd_info("CVE-2024-3094")
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_ghsa_patch_date
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGhsaPatchDate:
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_when_no_advisories(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_ghsa_patch_date
+
+        mock_get.return_value = _mock_resp([])
+        d, u = _fetch_ghsa_patch_date("CVE-2024-3094")
+        assert d is None
+        assert u is None
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_published_at_when_no_commit_url(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_ghsa_patch_date
+
+        advisory = {
+            "published_at": "2024-04-05T12:00:00Z",
+            "updated_at": "2024-04-05T12:00:00Z",
+            "references": [{"url": "https://example.com/advisory"}],
+            "html_url": "https://github.com/advisories/GHSA-test",
+        }
+        mock_get.return_value = _mock_resp([advisory])
+        d, u = _fetch_ghsa_patch_date("CVE-2024-3094")
+        assert d == "2024-04-05"
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_commit_date_when_available(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_ghsa_patch_date
+
+        commit_resp = {
+            "commit": {
+                "committer": {"date": "2024-03-25T10:00:00Z"},
+                "author": {"date": "2024-03-25T09:00:00Z"},
+            }
+        }
+        advisory = {
+            "published_at": "2024-04-05T12:00:00Z",
+            "references": [
+                {"url": "https://github.com/org/repo/commit/abc1234567890abcdef"}
+            ],
+            "html_url": "https://github.com/advisories/GHSA-test",
+        }
+
+        def side_effect(url, *args, **kwargs):
+            if "api.github.com/repos" in url and "/commits/" in url:
+                return _mock_resp(commit_resp)
+            return _mock_resp([advisory])
+
+        mock_get.side_effect = side_effect
+        d, u = _fetch_ghsa_patch_date("CVE-2024-3094")
+        assert d == "2024-03-25"
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_exception(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_ghsa_patch_date
+
+        mock_get.side_effect = Exception("network error")
+        d, u = _fetch_ghsa_patch_date("CVE-2024-3094")
+        assert d is None and u is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_trickest_poc
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTrickestPoc:
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_404(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_trickest_poc
+
+        mock_get.return_value = _mock_resp({}, status_code=404)
+        d, u = _fetch_trickest_poc("CVE-2024-3094")
+        assert d is None and u is None
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_extracts_repo_creation_date(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_trickest_poc
+
+        md_content = "# CVE-2024-3094\n\nhttps://github.com/hacker/exploit-3094\n"
+        repo_resp = {"created_at": "2024-03-30T08:00:00Z", "name": "exploit-3094"}
+
+        def side_effect(url, *args, **kwargs):
+            if "trickest" in url:
+                m = MagicMock()
+                m.status_code = 200
+                m.ok = True
+                m.text = md_content
+                m.raise_for_status.side_effect = None
+                return m
+            return _mock_resp(repo_resp)
+
+        mock_get.side_effect = side_effect
+        d, u = _fetch_trickest_poc("CVE-2024-3094")
+        assert d == "2024-03-30"
+        assert "hacker/exploit-3094" in u
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_falls_back_to_date_in_markdown(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_trickest_poc
+
+        md_content = "# CVE-2024-3094\n\nDiscovered 2024-03-31.\n"
+
+        def side_effect(url, *args, **kwargs):
+            if "trickest" in url:
+                m = MagicMock()
+                m.status_code = 200
+                m.ok = True
+                m.text = md_content
+                m.raise_for_status.side_effect = None
+                return m
+            # No repos found — return empty
+            return _mock_resp({}, status_code=404)
+
+        mock_get.side_effect = side_effect
+        d, u = _fetch_trickest_poc("CVE-2024-3094")
+        assert d == "2024-03-31"
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_exception(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_trickest_poc
+
+        mock_get.side_effect = Exception("network error")
+        d, u = _fetch_trickest_poc("CVE-2024-3094")
+        assert d is None and u is None
+
+    def test_invalid_cve_id(self):
+        from manus_use.tools.get_cve_timeline import _fetch_trickest_poc
+
+        d, u = _fetch_trickest_poc("NOT-A-CVE")
+        assert d is None and u is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_epss_spike
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEpssSpike:
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_no_spike_when_jump_below_threshold(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_epss_spike
+
+        scores = [0.01, 0.02, 0.03, 0.04, 0.05]  # max 7-day jump = 0.04
+        mock_get.return_value = _mock_resp(_epss_resp(scores))
+        spike_date, jump = _fetch_epss_spike("CVE-2024-3094")
+        assert spike_date is None
+        assert jump < 0.10
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_spike_detected_when_jump_at_threshold(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_epss_spike
+
+        # Jump from day0=0.01 to day3=0.12 = 0.11 > 0.10
+        scores = [0.01, 0.02, 0.05, 0.12, 0.13]
+        mock_get.return_value = _mock_resp(_epss_resp(scores))
+        spike_date, jump = _fetch_epss_spike("CVE-2024-3094")
+        assert spike_date is not None
+        assert jump >= 0.10
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_empty_data(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_epss_spike
+
+        mock_get.return_value = _mock_resp({"data": []})
+        spike_date, jump = _fetch_epss_spike("CVE-2024-3094")
+        assert spike_date is None
+        assert jump == 0.0
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_exception(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_epss_spike
+
+        mock_get.side_effect = Exception("timeout")
+        spike_date, jump = _fetch_epss_spike("CVE-2024-3094")
+        assert spike_date is None
+
+
+# ---------------------------------------------------------------------------
+# Tests for _fetch_cisa_kev
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCisaKev:
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_found_in_kev(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_cisa_kev
+
+        kev_data = {
+            "vulnerabilities": [
+                {
+                    "cveID": "CVE-2024-3094",
+                    "dateAdded": "2024-04-10",
+                    "requiredAction": "Apply updates",
+                }
+            ]
+        }
+        mock_get.return_value = _mock_resp(kev_data)
+        d, action = _fetch_cisa_kev("CVE-2024-3094")
+        assert d == "2024-04-10"
+        assert action == "Apply updates"
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_not_found_in_kev(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_cisa_kev
+
+        mock_get.return_value = _mock_resp({"vulnerabilities": []})
+        d, action = _fetch_cisa_kev("CVE-2024-9999")
+        assert d is None and action is None
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_returns_none_on_exception(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_cisa_kev
+
+        mock_get.side_effect = Exception("network error")
+        d, action = _fetch_cisa_kev("CVE-2024-3094")
+        assert d is None and action is None
+
+    @patch("manus_use.tools.get_cve_timeline.requests.get")
+    def test_case_insensitive_match(self, mock_get):
+        from manus_use.tools.get_cve_timeline import _fetch_cisa_kev
+
+        kev_data = {
+            "vulnerabilities": [
+                {"cveID": "cve-2024-3094", "dateAdded": "2024-04-10", "requiredAction": "Patch"}
+            ]
+        }
+        mock_get.return_value = _mock_resp(kev_data)
+        d, _ = _fetch_cisa_kev("CVE-2024-3094")
+        assert d == "2024-04-10"
+
+
+# ---------------------------------------------------------------------------
+# Tests for build_cve_timeline
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCveTimeline:
+    def _mock_all_sources(
+        self,
+        disclosure="2024-03-29",
+        patch_d=None,
+        poc_d=None,
+        spike_d=None,
+        kev_d=None,
+        max_jump=0.0,
+    ):
+        """Return a dict of patch targets for mocking all fetchers."""
+        return {
+            "_fetch_nvd_info": {"published": disclosure, "nvd_url": "https://nvd.nist.gov/..."},
+            "_fetch_ghsa_patch_date": (patch_d, "https://github.com/org/repo/commit/abc"),
+            "_fetch_nvd_patch_date": (None, None),
+            "_fetch_trickest_poc": (poc_d, "https://github.com/poc/repo"),
+            "_fetch_epss_spike": (spike_d, max_jump),
+            "_fetch_cisa_kev": (kev_d, "Apply updates" if kev_d else None),
+        }
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_all_events_present(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-03-29", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = ("2024-03-25", "https://github.com/org/repo/commit/abc")
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = ("2024-03-30", "https://github.com/poc/repo")
+        m_epss.return_value = ("2024-04-05", 0.15)
+        m_kev.return_value = ("2024-04-10", "Apply updates")
+
+        result = build_cve_timeline("CVE-2024-3094")
+
+        assert result["cve_id"] == "CVE-2024-3094"
+        event_names = [e["event"] for e in result["events"]]
+        assert any("Disclosed" in n for n in event_names)
+        assert any("Patch" in n for n in event_names)
+        assert any("PoC" in n for n in event_names)
+        assert any("EPSS" in n for n in event_names)
+        assert any("KEV" in n for n in event_names)
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_events_sorted_chronologically(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-03-29", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = ("2024-03-25", "https://github.com/org/repo/commit/abc")
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = ("2024-04-01", "https://github.com/poc/repo")
+        m_epss.return_value = ("2024-04-10", 0.20)
+        m_kev.return_value = ("2024-04-15", "Apply")
+
+        result = build_cve_timeline("CVE-2024-3094")
+        dates = [e["date"] for e in result["events"] if e["date"]]
+        assert dates == sorted(dates)
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_velocity_disclosure_to_poc(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-03-29", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = ("2024-04-05", "https://github.com/poc/repo")  # +7 days
+        m_epss.return_value = (None, 0.0)
+        m_kev.return_value = (None, None)
+
+        result = build_cve_timeline("CVE-2024-3094")
+        assert result["velocity"]["disclosure_to_poc_days"] == 7
+        assert result["velocity"]["fast_weaponisation"] is True
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_fast_weaponisation_flag_off_when_poc_gt_7_days(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-03-29", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = ("2024-04-10", "https://github.com/poc/repo")  # +12 days
+        m_epss.return_value = (None, 0.0)
+        m_kev.return_value = (None, None)
+
+        result = build_cve_timeline("CVE-2024-3094")
+        assert result["velocity"]["fast_weaponisation"] is False
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_weaponized_source_prefers_kev(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-01-01", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = (None, None)
+        m_epss.return_value = ("2024-02-01", 0.20)  # spike
+        m_kev.return_value = ("2024-03-01", "Patch now")  # kev
+
+        result = build_cve_timeline("CVE-2024-3094")
+        assert result["velocity"]["weaponized_source"] == "CISA KEV"
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_weaponized_source_falls_back_to_epss(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {"published": "2024-01-01", "nvd_url": "https://nvd.nist.gov/"}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = (None, None)
+        m_epss.return_value = ("2024-02-01", 0.20)
+        m_kev.return_value = (None, None)
+
+        result = build_cve_timeline("CVE-2024-3094")
+        assert result["velocity"]["weaponized_source"] == "EPSS spike"
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_no_events_when_all_sources_fail(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = (None, None)
+        m_epss.return_value = (None, 0.0)
+        m_kev.return_value = (None, None)
+
+        result = build_cve_timeline("CVE-2024-9999")
+        assert result["events"] == []
+        assert result["velocity"] == {}
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_kev_date_from_nvd_when_cisa_missing(
+        self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev
+    ):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {
+            "published": "2024-01-01",
+            "kev_date": "2024-02-01",
+            "nvd_url": "https://nvd.nist.gov/",
+        }
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = (None, None)
+        m_epss.return_value = (None, 0.0)
+        m_kev.return_value = (None, None)  # CISA lookup fails
+
+        result = build_cve_timeline("CVE-2024-3094")
+        event_names = [e["event"] for e in result["events"]]
+        assert any("KEV" in n for n in event_names)
+
+    @patch("manus_use.tools.get_cve_timeline._fetch_cisa_kev")
+    @patch("manus_use.tools.get_cve_timeline._fetch_epss_spike")
+    @patch("manus_use.tools.get_cve_timeline._fetch_trickest_poc")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_ghsa_patch_date")
+    @patch("manus_use.tools.get_cve_timeline._fetch_nvd_info")
+    def test_cve_id_uppercased(self, m_nvd, m_ghsa, m_nvd_patch, m_trickest, m_epss, m_kev):
+        from manus_use.tools.get_cve_timeline import build_cve_timeline
+
+        m_nvd.return_value = {}
+        m_ghsa.return_value = (None, None)
+        m_nvd_patch.return_value = (None, None)
+        m_trickest.return_value = (None, None)
+        m_epss.return_value = (None, 0.0)
+        m_kev.return_value = (None, None)
+
+        result = build_cve_timeline("cve-2024-3094")
+        assert result["cve_id"] == "CVE-2024-3094"
+
+
+# ---------------------------------------------------------------------------
+# Tests for render_timeline_text
+# ---------------------------------------------------------------------------
+
+
+class TestRenderTimelineText:
+    def _timeline(self, events=None, velocity=None):
+        return {
+            "cve_id": "CVE-2024-3094",
+            "events": events or [],
+            "velocity": velocity or {},
+            "current_date": "2026-06-27",
+        }
+
+    def test_renders_no_events_message(self):
+        from manus_use.tools.get_cve_timeline import render_timeline_text
+
+        text = render_timeline_text(self._timeline())
+        assert "No timeline events found" in text
+
+    def test_renders_events(self):
+        from manus_use.tools.get_cve_timeline import render_timeline_text
+
+        events = [
+            {"event": "CVE Disclosed", "date": "2024-03-29", "source": "NVD", "url": "https://nvd.nist.gov/"},
+            {"event": "First Public PoC", "date": "2024-03-31", "source": "Trickest", "url": None},
+        ]
+        text = render_timeline_text(self._timeline(events=events))
+        assert "2024-03-29" in text
+        assert "CVE Disclosed" in text
+        assert "First Public PoC" in text
+
+    def test_renders_velocity_metrics(self):
+        from manus_use.tools.get_cve_timeline import render_timeline_text
+
+        velocity = {
+            "days_since_disclosure": 820,
+            "disclosure_to_poc_days": 2,
+            "fast_weaponisation": True,
+            "disclosure_to_weaponized_days": 14,
+            "weaponized_source": "CISA KEV",
+        }
+        text = render_timeline_text(self._timeline(velocity=velocity))
+        assert "FAST" in text
+        assert "820" in text
+
+    def test_renders_insufficient_data_message_when_no_velocity(self):
+        from manus_use.tools.get_cve_timeline import render_timeline_text
+
+        text = render_timeline_text(self._timeline())
+        assert "Insufficient data" in text
+
+
+# ---------------------------------------------------------------------------
+# Tests for get_cve_timeline (Strands entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestGetCveTimelineEntryPoint:
+    @patch("manus_use.tools.get_cve_timeline.build_cve_timeline")
+    def test_success_text_output(self, mock_build):
+        from manus_use.tools.get_cve_timeline import get_cve_timeline
+
+        mock_build.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "events": [],
+            "velocity": {},
+            "current_date": "2026-06-27",
+        }
+
+        result = get_cve_timeline(_tool_use("CVE-2024-3094"))
+        assert result["status"] == "success"
+        assert any("text" in c for c in result["content"])
+        assert any("json" in c for c in result["content"])
+        mock_build.assert_called_once_with("CVE-2024-3094")
+
+    def test_invalid_cve_id_returns_error(self):
+        from manus_use.tools.get_cve_timeline import get_cve_timeline
+
+        result = get_cve_timeline(_tool_use("NOT-A-CVE"))
+        assert result["status"] == "error"
+
+    def test_empty_cve_id_returns_error(self):
+        from manus_use.tools.get_cve_timeline import get_cve_timeline
+
+        result = get_cve_timeline({"toolUseId": "tu-1", "input": {"cve_id": ""}})
+        assert result["status"] == "error"
+
+    def test_lowercase_cve_id_accepted(self):
+        from manus_use.tools.get_cve_timeline import get_cve_timeline
+
+        with patch("manus_use.tools.get_cve_timeline.build_cve_timeline") as mock_build:
+            mock_build.return_value = {
+                "cve_id": "CVE-2024-3094",
+                "events": [],
+                "velocity": {},
+                "current_date": "2026-06-27",
+            }
+            result = get_cve_timeline(_tool_use("cve-2024-3094"))
+        assert result["status"] == "success"
+
+    @patch("manus_use.tools.get_cve_timeline.build_cve_timeline")
+    def test_json_content_block_present(self, mock_build):
+        from manus_use.tools.get_cve_timeline import get_cve_timeline
+
+        timeline_data = {
+            "cve_id": "CVE-2024-3094",
+            "events": [],
+            "velocity": {"days_since_disclosure": 100},
+            "current_date": "2026-06-27",
+        }
+        mock_build.return_value = timeline_data
+
+        result = get_cve_timeline(_tool_use("CVE-2024-3094"))
+        json_blocks = [c for c in result["content"] if "json" in c]
+        assert json_blocks
+        assert json_blocks[0]["json"]["velocity"]["days_since_disclosure"] == 100
+
+
+# ---------------------------------------------------------------------------
+# Tests for CLI subcommand (manus-use timeline)
+# ---------------------------------------------------------------------------
+
+
+class TestCliTimeline:
+    def test_timeline_registered_in_subcommands(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "timeline" in _SUBCOMMANDS
+
+    def test_timeline_help_exits_zero(self):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "manus_use.cli", "timeline", "--help"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        assert "CVE-ID" in result.stdout or "cve" in result.stdout.lower()
+
+    def test_timeline_missing_cve_is_error(self):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "manus_use.cli", "timeline"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    def test_timeline_invalid_cve_is_error(self):
+        import subprocess
+        import sys
+
+        result = subprocess.run(
+            [sys.executable, "-m", "manus_use.cli", "timeline", "NOT-A-CVE"],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode != 0
+
+    @patch("manus_use.tools.get_cve_timeline.build_cve_timeline")
+    def test_run_timeline_text_output(self, mock_build):
+        from manus_use.cli import _run_timeline
+
+        mock_build.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "events": [],
+            "velocity": {},
+            "current_date": "2026-06-27",
+        }
+
+        with patch("builtins.print"):
+            ret = _run_timeline(["CVE-2024-3094"])
+        assert ret == 0
+
+    @patch("manus_use.tools.get_cve_timeline.build_cve_timeline")
+    def test_run_timeline_json_output(self, mock_build):
+        import io
+        import json as _json
+        import sys
+
+        from manus_use.cli import _run_timeline
+
+        mock_build.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "events": [],
+            "velocity": {"days_since_disclosure": 99},
+            "current_date": "2026-06-27",
+        }
+
+        captured = io.StringIO()
+        with patch("sys.stdout", captured):
+            ret = _run_timeline(["CVE-2024-3094", "--output", "json"])
+        assert ret == 0
+        data = _json.loads(captured.getvalue())
+        assert data["cve_id"] == "CVE-2024-3094"
+
+    def test_run_timeline_invalid_cve_returns_1(self):
+        from manus_use.cli import _run_timeline
+
+        ret = _run_timeline(["NOT-A-CVE"])
+        assert ret == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests for VI agent wiring
+# ---------------------------------------------------------------------------
+
+
+class TestViAgentWiring:
+    def test_get_cve_timeline_imported_in_vi_agent(self):
+        """Verify the vi_agent module references get_cve_timeline."""
+        import inspect
+
+        import manus_use.agents.vi_agent as vi_mod
+
+        src = inspect.getsource(vi_mod)
+        assert "get_cve_timeline" in src
+
+    def test_get_cve_timeline_in_tool_list(self):
+        """Verify get_cve_timeline appears in the agent tools list source."""
+        import inspect
+
+        import manus_use.agents.vi_agent as vi_mod
+
+        src = inspect.getsource(vi_mod)
+        assert src.count("get_cve_timeline") >= 2  # import + list
+
+    def test_system_prompt_mentions_timeline(self):
+        """Verify the SYSTEM_PROMPT constant mentions the new tool."""
+        import manus_use.agents.vi_agent as vi_mod
+
+        assert "get_cve_timeline" in vi_mod.SYSTEM_PROMPT
+
+    def test_tool_spec_name_matches(self):
+        from manus_use.tools.get_cve_timeline import TOOL_SPEC
+
+        assert TOOL_SPEC["name"] == "get_cve_timeline"
+
+    def test_tool_spec_has_cve_id_input(self):
+        from manus_use.tools.get_cve_timeline import TOOL_SPEC
+
+        props = TOOL_SPEC["inputSchema"]["json"]["properties"]
+        assert "cve_id" in props
+        assert "cve_id" in TOOL_SPEC["inputSchema"]["json"]["required"]


### PR DESCRIPTION
## Summary

Adds a new `get_cve_timeline` tool and `manus-use timeline` CLI subcommand that builds a full lifecycle timeline for any CVE by aggregating dates from NVD, GHSA, Trickest PoC index, FIRST.org EPSS, and CISA KEV.

## What it does

Given a CVE ID, the tool fetches:

| Event | Source |
|---|---|
| **Disclosure date** | NVD `published` timestamp |
| **Patch date** | GHSA fixing-commit date (GitHub Commits API); falls back to NVD reference scanning |
| **First public PoC** | Trickest CVE index (repo `created_at` via GitHub API; falls back to dates in the markdown) |
| **EPSS exploitation spike** | FIRST.org EPSS time-series: largest 7-day delta ≥ 0.10 in past 365 days |
| **CISA KEV date** | CISA KEV catalogue; NVD `cisaExploitAdd` as fallback |

Events are assembled into a chronological list (date · label · source · URL).

## Velocity metrics

```
disclosure_to_patch_days
disclosure_to_poc_days + fast_weaponisation  (True when ≤ 7 days)
poc_to_kev_days
disclosure_to_weaponized_days  (prefers KEV, falls back to EPSS spike) + weaponized_source
days_since_disclosure
```

## CLI

```shell
# text (default)
manus-use timeline CVE-2024-3094

# machine-readable
manus-use timeline CVE-2021-44228 --output json | jq .velocity
```

## Example output

```
CVE Timeline: CVE-2024-3094
========================================================
  2024-03-25  Patch Committed
               Source: GHSA / GitHub
               URL:    https://github.com/tukaani-project/xz/commit/...
  2024-03-29  CVE Disclosed (NVD Published)
               Source: NVD
               URL:    https://nvd.nist.gov/vuln/detail/CVE-2024-3094
  2024-03-30  First Public PoC
               Source: Trickest CVE Index / GitHub
               URL:    https://github.com/...
  2024-04-02  Added to CISA KEV (Confirmed Exploitation in Wild)
               Source: CISA KEV
               URL:    https://www.cisa.gov/known-exploited-vulnerabilities-catalog

Velocity Metrics
----------------------------------------
  Days since disclosure       : 820
  Disclosure -> Patch          : -4 days  (patch preceded disclosure?)
  Disclosure -> First PoC      : 1 days  [FAST <=7 days]
  PoC -> CISA KEV listing      : 3 days
  Disclosure -> Weaponized     : 4 days  (via CISA KEV)
```

## Agent wiring

- `get_cve_timeline` added to `VulnerabilityIntelligenceAgent` tool list
- System prompt updated with new **Step 6b** directing the agent to call the tool and include a Timeline section with velocity metrics and fast-weaponisation flag

## Tests

63 new tests in `tests/test_cve_timeline.py` — all HTTP calls mocked:
- Helper functions (`_iso_date`, `_days_between`, `_github_headers`)
- All 6 fetchers with success, empty, and exception paths
- `build_cve_timeline` integration (event ordering, velocity computation, fast_weaponisation, weaponized_source priority, CVE ID normalisation)
- `render_timeline_text` output correctness
- Strands entry point success/error paths
- CLI (`_run_timeline`, `_SUBCOMMANDS`, JSON output, invalid CVE)
- VI agent wiring (import, tool list, system prompt, TOOL_SPEC schema)

**613 passed, 3 deselected, 3 warnings** — no regressions.