### PR TITLE
feat(tools): silent patch detector — find_silent_patches tool + manus-use silent-patches subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,56 @@ History is stored at `~/.manus-use/history.jsonl`.
 
 ---
 
+### `manus-use silent-patches <owner/repo>` — Silent patch detector
+
+```bash
+# Scan the last 90 days of commits for silent security fixes
+manus-use silent-patches django/django
+
+# Narrow the date window
+manus-use silent-patches curl/curl --since 2024-01-01 --until 2024-06-01
+
+# Machine-readable output for scripting / SIEM ingestion
+manus-use silent-patches owner/repo --output json | jq '.candidates[] | select(.score >= 30)'
+
+# Fast mode: message keywords only (no diff fetch — much faster)
+manus-use silent-patches torvalds/linux --fast --max-commits 500
+```
+
+Scans a public GitHub repository's commit history for potential silent security
+fixes — commits that look like security patches (based on keywords in the commit
+message and/or diff) but have **no associated CVE or GHSA reference**.
+
+Silent patches are a major blind spot in CVE-based vulnerability management.
+Vendors sometimes quietly fix security bugs without filing a CVE — either
+deliberately (to limit exposure) or because the fix predates the CVE assignment.
+
+**How it works:**
+
+1. Fetches the commit list from the GitHub REST API (paginates up to `--max-commits`).
+2. Skips any commit whose message already contains `CVE-XXXX-YYYY` or `GHSA-…` (overt disclosures).
+3. Scores remaining commits on security keyword frequency in the commit message
+   (high-signal: `vulnerability`, `overflow`, `injection`, `auth bypass`, `RCE`;
+   lower-signal: `fix`, `sanitize`, `escape`, `validate`).
+4. For commits that pass the message threshold, fetches the unified diff and scores
+   it on security-sensitive code patterns (`html.escape`, `check_permission`,
+   `is_authenticated`, `parameterized`, `shell=False`, …).
+5. Infers the most likely bug class from the diff (`xss`, `sql_injection`,
+   `auth_bypass`, `buffer_overflow`, `deserialization`, …).
+6. Returns candidates sorted by suspicion score (0–100), descending.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--since YYYY-MM-DD` | 90 days ago | Start date for the scan window |
+| `--until YYYY-MM-DD` | today | End date for the scan window |
+| `--max-commits N` | `200` | Maximum commits to inspect (max 500) |
+| `--fast` | off | Skip diff scan; rely only on commit-message keywords |
+| `--output {text,json}` | `text` | Output format; `json` includes the full candidate list |
+
+---
+
 ## Configuration
 
 Create `~/.manus-use/config.toml` (or run `manus-use init`):
@@ -533,6 +583,10 @@ manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priori
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6
+
+# Scan a repo for silent security fixes (no CVE reference)
+manus-use silent-patches django/django
+manus-use silent-patches curl/curl --since 2024-01-01 --output json | jq '.candidates[] | select(.score >= 25)'
 ```
 
 > **Important:** These tools are designed for defensive security purposes only. Use them for legitimate security research, vulnerability management, and defence.

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -94,6 +94,11 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - A direct link to the commit on GitHub.
   If no commit is found (private repo or non-GitHub), note this and proceed.
 
+**Step 6b: Silent Patch Check (Optional)**
+- If the CVE's affected repository is a public GitHub repo (e.g. extracted from NVD references or GHSA), call `find_silent_patches` with that repo and a date range of ~90 days centred on the CVE disclosure date.
+- Report any high-score candidates (score ≥ 20) as potential related silent fixes — commits in the same codebase that look like security patches but carry no CVE reference.
+- This step is optional; skip it if the affected repository cannot be determined or if the CVE is not associated with a public GitHub project.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -184,6 +189,7 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_use.tools.find_silent_patches import find_silent_patches
             from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_patch_diff import get_patch_diff
@@ -240,6 +246,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.verify_exploit",
             get_epss_trend,
             get_patch_diff,
+            find_silent_patches,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1052,6 +1052,7 @@ _SUBCOMMANDS = {
     "epss-trend",
     "patch-diff",
     "compare",
+    "silent-patches",
 }
 
 
@@ -1219,6 +1220,97 @@ def _run_patch_diff(argv: list[str]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# silent-patches subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_silent_patches_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use silent-patches",
+        description=(
+            "Scan a GitHub repository's commit history for potential silent security\n"
+            "fixes — commits that look like security patches (based on keywords in\n"
+            "the commit message or diff) but have no associated CVE/GHSA reference.\n"
+            "\n"
+            "Useful for finding vulnerabilities that were quietly fixed without a CVE,\n"
+            "or that the vendor chose not to disclose publicly."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "repo",
+        metavar="OWNER/REPO",
+        help="GitHub repository to scan, e.g. 'django/django' or 'curl/curl'",
+    )
+    p.add_argument(
+        "--since",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Scan commits after this date (default: 90 days ago)",
+    )
+    p.add_argument(
+        "--until",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Scan commits before this date (default: today)",
+    )
+    p.add_argument(
+        "--max-commits",
+        type=int,
+        default=200,
+        metavar="N",
+        help="Maximum number of commits to inspect (default: 200, max: 500)",
+    )
+    p.add_argument(
+        "--fast",
+        action="store_true",
+        default=False,
+        help="Skip diff scan; rely only on commit-message keywords (faster, less precise)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_silent_patches(argv: list[str]) -> int:
+    parser = _build_silent_patches_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_use.tools.find_silent_patches import (
+            find_silent_patches_impl,
+            render_silent_patches_text,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    result = find_silent_patches_impl(
+        repo=args.repo,
+        since=args.since,
+        until=args.until,
+        max_commits=args.max_commits,
+        fast=args.fast,
+    )
+
+    if "error" in result:
+        print(f"[error] {result['error']}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(result, indent=2))
+        return 0
+
+    print(render_silent_patches_text(result))
+    return 0
+
+
 # compare subcommand
 # ---------------------------------------------------------------------------
 
@@ -1334,6 +1426,11 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # CVE remediation guidance\n"
             "  manus-use remediate CVE-2024-3094\n"
             "  manus-use remediate CVE-2024-3094 --output json\n"
+            "  \n"
+            "  # Silent patch detection\n"
+            "  manus-use silent-patches django/django\n"
+            "  manus-use silent-patches curl/curl --since 2024-01-01 --output json\n"
+            "  manus-use silent-patches owner/repo --fast --max-commits 100\n"
         ),
     )
     parser.add_argument(
@@ -1599,6 +1696,10 @@ def main() -> None:
     if first_positional == "compare":
         idx = argv.index("compare")
         sys.exit(_run_compare(argv[idx + 1 :]))
+
+    if first_positional == "silent-patches":
+        idx = argv.index("silent-patches")
+        sys.exit(_run_silent_patches(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/find_silent_patches.py
+++ b/src/manus_use/tools/find_silent_patches.py
@@ -1,0 +1,551 @@
+"""
+Tool for detecting potential silent security patches in a GitHub repository.
+
+A "silent patch" is a commit that:
+  - Modifies code in a way that looks like a security fix (keywords in the
+    commit message or diff: fix, sanitize, validate, escape, overflow, injection,
+    auth, permission, …)
+  - Has **no associated CVE ID** (no "CVE-XXXX-YYYY" in the message or in the
+    linked PR/issue body)
+
+Silent patches are a major blind spot in standard CVE-based vulnerability
+management workflows.  Vendors sometimes quietly fix security bugs without
+filing a CVE — either deliberately (to limit exposure) or because the fix
+predates the CVE assignment.  Finding them requires inspecting commit history
+directly.
+
+Usage
+-----
+  manus-use silent-patches owner/repo
+  manus-use silent-patches owner/repo --since 2024-01-01 --output json
+
+The tool fetches the commit list from GitHub's REST API (no auth required for
+public repos; set GITHUB_TOKEN env var to raise rate limits) and classifies
+each commit using a two-stage heuristic:
+
+  Stage 1 — message scan   : security keywords in the commit subject / body
+  Stage 2 — diff scan      : security keywords in the unified diff (optional,
+                              enabled unless --fast / fast=True is passed)
+
+Results are scored (0-100) and returned in descending order.
+
+Only public GitHub repositories are supported.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Strands tool spec
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "find_silent_patches",
+    "description": (
+        "Scans a GitHub repository's commit history for potential silent security fixes — "
+        "commits that look like security patches (based on keywords in the commit message "
+        "or diff) but have no associated CVE ID. "
+        "Returns a list of candidate commits ranked by a suspicion score, together with "
+        "the matched security keywords, the bug class inferred from the diff, and a direct "
+        "link to the commit on GitHub. "
+        "Useful for finding vulnerabilities that were quietly fixed before a CVE was assigned, "
+        "or that the vendor chose not to disclose publicly."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "repo": {
+                    "type": "string",
+                    "description": (
+                        "GitHub repository in 'owner/repo' format "
+                        "(e.g., 'django/django' or 'curl/curl')."
+                    ),
+                },
+                "since": {
+                    "type": "string",
+                    "description": (
+                        "ISO 8601 date string (YYYY-MM-DD). "
+                        "Only commits after this date are scanned. "
+                        "Defaults to 90 days ago."
+                    ),
+                },
+                "until": {
+                    "type": "string",
+                    "description": (
+                        "ISO 8601 date string (YYYY-MM-DD). "
+                        "Only commits before this date are scanned. "
+                        "Defaults to today."
+                    ),
+                },
+                "max_commits": {
+                    "type": "integer",
+                    "description": (
+                        "Maximum number of commits to inspect. "
+                        "Defaults to 200. Maximum 500."
+                    ),
+                },
+                "fast": {
+                    "type": "boolean",
+                    "description": (
+                        "When true, skip the diff-content scan and rely only on commit "
+                        "message keywords. Much faster but less accurate. Defaults to false."
+                    ),
+                },
+            },
+            "required": ["repo"],
+        }
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Keyword tables
+# ---------------------------------------------------------------------------
+
+# Commit-message keywords that suggest a security fix.
+# Each tuple: (keyword_pattern, weight)
+_MSG_KEYWORDS: list[tuple[str, int]] = [
+    # High-signal terms
+    (r"\bsecurity\b", 20),
+    (r"\bvulnerabilit", 20),
+    (r"\bexploit\b", 20),
+    (r"\bcve-\d{4}-\d+", 25),          # would be CVE — included to *exclude* later
+    (r"\bghsa-", 20),                   # GitHub Security Advisory
+    (r"\badvisory\b", 15),
+    # Medium-signal
+    (r"\bsanitize\b", 12),
+    (r"\bsanitise\b", 12),
+    (r"\bescape\b", 10),
+    (r"\binjection\b", 15),
+    (r"\boverflow\b", 15),
+    (r"\buse[- ]after[- ]free\b", 20),
+    (r"\bbuffer\b", 8),
+    (r"\bauth(?:entication|oriz)?\b", 10),
+    (r"\bpermission\b", 8),
+    (r"\bprivilege\b", 10),
+    (r"\baccess[- ]control\b", 12),
+    (r"\bbypass\b", 12),
+    (r"\bdenial[- ]of[- ]service\b", 15),
+    (r"\bd(?:o|e)s\b", 8),
+    (r"\brace[- ]condition\b", 12),
+    (r"\bpath[- ]traversal\b", 15),
+    (r"\bdirectory[- ]traversal\b", 15),
+    (r"\bsql[- ]inject", 15),
+    (r"\bxss\b", 15),
+    (r"\bcross[- ]site\b", 12),
+    (r"\bcsrf\b", 15),
+    (r"\bssrf\b", 15),
+    (r"\bremote[- ]code[- ]exec", 20),
+    (r"\brce\b", 18),
+    (r"\bnull[- ](?:pointer|deref)", 12),
+    (r"\bheap\b", 8),
+    (r"\bmemory[- ](?:corrupt|leak|safety)", 15),
+    (r"\binteger[- ]overflow\b", 15),
+    (r"\bformat[- ]string\b", 15),
+    (r"\btype[- ]confusion\b", 15),
+    (r"\bunintended\b", 6),
+    (r"\bfix\b", 5),                    # generic but common in security patches
+    (r"\bpatch\b", 5),
+    (r"\bmitigat", 8),
+    (r"\bharden", 8),
+    (r"\bprotect\b", 5),
+    (r"\bvalidat", 7),
+    (r"\bsecure\b", 8),
+    (r"\bimproper\b", 8),
+    (r"\bcritical\b", 10),
+    (r"\bmalicious\b", 12),
+    (r"\battack\b", 10),
+]
+
+# Diff-level keywords that suggest security-sensitive changes
+_DIFF_KEYWORDS: list[tuple[str, int]] = [
+    (r"\bsanitize\b", 10),
+    (r"\bsanitise\b", 10),
+    (r"\bhtml\.escape\b", 10),
+    (r"\bescape\(", 8),
+    (r"\bvalidate\b", 8),
+    (r"\bcheck_permission\b", 12),
+    (r"\bis_authenticated\b", 12),
+    (r"\bhas_permission\b", 12),
+    (r"\bpermission_required\b", 12),
+    (r"\bauth(?:oriz|entic)", 10),
+    (r"\boverflow\b", 12),
+    (r"\bfree\(", 10),
+    (r"\bkfree\(", 10),
+    (r"\bnull[- ]check\b", 8),
+    (r"\bassert\b", 5),
+    (r"\braise\b.*[Ee]rror", 5),
+    (r"\bif not\b", 4),
+    (r"\bif\b.*is None", 5),
+    (r"\bsql\b", 8),
+    (r"\bexecute\(", 8),
+    (r"\bprepare\(", 8),
+    (r"\bparameterized\b", 10),
+    (r"\bsubprocess\b", 8),
+    (r"shell=False", 10),
+    (r"\bos\.path\.realpath\b", 8),
+    (r"\bos\.path\.abspath\b", 6),
+    (r"\bpickle\b", 10),
+    (r"\byaml\.safe_load\b", 10),
+    (r"\bhmac\b", 10),
+    (r"\bconstant_time_compare\b", 12),
+    (r"\bsecrets\b", 8),
+    (r"\bcryptography\b", 8),
+    (r"\bssl_verify\b", 8),
+    (r"\bcert(?:ificate)?\b", 6),
+    (r"\bcsp\b", 8),
+    (r"\bx-content-type\b", 8),
+    (r"\bx-frame-options\b", 8),
+    (r"\bstrict-transport\b", 8),
+]
+
+# Bug classes inferred from diff content
+_BUG_CLASSES: list[tuple[str, list[str]]] = [
+    ("sql_injection", [r"\bsql\b", r"\bexecute\(", r"\bparameterized\b", r"\bprepare\("]),
+    ("command_injection", [r"\bsubprocess\b", r"shell=False", r"\bshlex\b"]),
+    ("path_traversal", [r"realpath", r"abspath", r"\.\./", r"\.\.\\\\"]),
+    ("buffer_overflow", [r"\boverflow\b", r"\bmemcpy\b", r"\bstrcpy\b"]),
+    ("use_after_free", [r"\bfree\(", r"\bkfree\(", r"use.after.free"]),
+    ("null_dereference", [r"null.check", r"is None", r"!= null"]),
+    ("auth_bypass", [r"\bauth", r"\bpermission", r"\sis_authenticated\b", r"\bhas_permission\b"]),
+    ("xss", [r"\bescape\b", r"html\.escape", r"\bsanitize\b", r"\bsanitise\b"]),
+    ("deserialization", [r"\bpickle\b", r"yaml\.safe_load", r"\bunmarshal\b"]),
+    ("cryptographic", [r"\bhmac\b", r"\bconstant_time_compare\b", r"\bcryptography\b"]),
+    ("input_validation", [r"\bvalidate\b", r"\bassert\b", r"\braises?\b.*[Ee]rror"]),
+    ("csrf_ssrf", [r"\bcsrf\b", r"\bssrf\b", r"\brequest_forgery\b"]),
+    ("information_disclosure", [r"\bsecrets\b", r"\bcert\b", r"\bssl_verify\b"]),
+    ("header_injection", [r"\bx-content-type\b", r"\bx-frame-options\b", r"\bcsp\b"]),
+]
+
+_CVE_RE = re.compile(r"\bCVE-\d{4}-\d+\b", re.IGNORECASE)
+_GHSA_RE = re.compile(r"\bGHSA-[A-Z0-9]{4}-[A-Z0-9]{4}-[A-Z0-9]{4}\b", re.IGNORECASE)
+
+# ---------------------------------------------------------------------------
+# GitHub helpers
+# ---------------------------------------------------------------------------
+
+
+def _github_headers() -> dict[str, str]:
+    """Return request headers for GitHub API, including auth token if present."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_json(url: str, headers: dict[str, str] | None = None, timeout: int = 15) -> Any:
+    resp = requests.get(url, headers=headers or {}, timeout=timeout)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _default_since() -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=90)
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _parse_date(date_str: str) -> str:
+    """Accept YYYY-MM-DD or full ISO-8601 and normalise to GitHub format."""
+    date_str = date_str.strip()
+    if len(date_str) == 10:
+        return f"{date_str}T00:00:00Z"
+    return date_str
+
+
+# ---------------------------------------------------------------------------
+# Commit scoring
+# ---------------------------------------------------------------------------
+
+
+def _score_message(message: str) -> tuple[int, list[str]]:
+    """Return (score, matched_keywords) for a commit message."""
+    lower = message.lower()
+    score = 0
+    matched: list[str] = []
+    for pattern, weight in _MSG_KEYWORDS:
+        if re.search(pattern, lower):
+            matched.append(pattern.strip(r"\b"))
+            score += weight
+    return score, matched
+
+
+def _score_diff(diff_text: str) -> tuple[int, list[str]]:
+    """Return (score, matched_keywords) based on diff content."""
+    lower = diff_text.lower()
+    score = 0
+    matched: list[str] = []
+    for pattern, weight in _DIFF_KEYWORDS:
+        if re.search(pattern, lower):
+            clean = re.sub(r"^\\b|\\b$|\\\\\(.*$", "", pattern)
+            matched.append(clean)
+            score += weight
+    return score, matched
+
+
+def _infer_bug_class(diff_text: str) -> str | None:
+    """Return the most-likely bug class from the diff, or None."""
+    lower = diff_text.lower()
+    best_class: str | None = None
+    best_hits = 0
+    for bug_class, patterns in _BUG_CLASSES:
+        hits = sum(1 for p in patterns if re.search(p, lower))
+        if hits > best_hits:
+            best_hits = hits
+            best_class = bug_class
+    return best_class if best_hits >= 2 else None
+
+
+def _has_cve_reference(text: str) -> bool:
+    return bool(_CVE_RE.search(text) or _GHSA_RE.search(text))
+
+
+# ---------------------------------------------------------------------------
+# GitHub API calls
+# ---------------------------------------------------------------------------
+
+
+def _list_commits(
+    repo: str,
+    since: str,
+    until: str,
+    max_commits: int,
+    headers: dict[str, str],
+) -> list[dict[str, Any]]:
+    """Paginate the GitHub commit list API and return up to max_commits items."""
+    commits: list[dict[str, Any]] = []
+    page = 1
+    per_page = min(100, max_commits)
+    while len(commits) < max_commits:
+        url = (
+            f"https://api.github.com/repos/{repo}/commits"
+            f"?since={since}&until={until}&per_page={per_page}&page={page}"
+        )
+        try:
+            data = _fetch_json(url, headers=headers)
+        except requests.HTTPError as exc:
+            if exc.response is not None and exc.response.status_code == 404:
+                raise ValueError(f"Repository '{repo}' not found on GitHub.") from exc
+            raise
+        if not data:
+            break
+        commits.extend(data)
+        if len(data) < per_page:
+            break
+        page += 1
+    return commits[:max_commits]
+
+
+def _fetch_commit_diff(repo: str, sha: str, headers: dict[str, str]) -> str:
+    """Fetch the unified diff for a single commit."""
+    diff_headers = dict(headers)
+    diff_headers["Accept"] = "application/vnd.github.diff"
+    url = f"https://api.github.com/repos/{repo}/commits/{sha}"
+    try:
+        resp = requests.get(url, headers=diff_headers, timeout=20)
+        resp.raise_for_status()
+        return resp.text
+    except Exception:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def find_silent_patches_impl(
+    repo: str,
+    since: str | None = None,
+    until: str | None = None,
+    max_commits: int = 200,
+    fast: bool = False,
+) -> dict[str, Any]:
+    """
+    Scan *repo* for commits that look like silent security fixes.
+
+    Returns a dict with:
+      - repo: str
+      - since / until: str
+      - total_scanned: int
+      - candidates: list[dict]  — sorted by score descending
+      - summary: str
+    """
+    repo = re.sub(r"^https?://github\.com/", "", repo.strip()).strip("/")
+    if "/" not in repo:
+        return {"error": f"Invalid repo format '{repo}'. Expected 'owner/repo'."}
+
+    max_commits = min(max(1, max_commits), 500)
+
+    since_str = _parse_date(since) if since else _default_since()
+    until_str = _parse_date(until) if until else datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    headers = _github_headers()
+
+    try:
+        commits = _list_commits(repo, since_str, until_str, max_commits, headers)
+    except ValueError as exc:
+        return {"error": str(exc)}
+    except requests.HTTPError as exc:
+        return {"error": f"GitHub API error: {exc}"}
+    except requests.RequestException as exc:
+        return {"error": f"Network error: {exc}"}
+
+    candidates: list[dict[str, Any]] = []
+
+    for commit_obj in commits:
+        sha = commit_obj.get("sha", "")[:12]
+        full_sha = commit_obj.get("sha", "")
+        commit_data = commit_obj.get("commit", {})
+        message = commit_data.get("message", "")
+        author_info = commit_data.get("author", {})
+        date_str = author_info.get("date", "")
+        author_name = author_info.get("name", "unknown")
+        url = commit_obj.get("html_url", f"https://github.com/{repo}/commit/{full_sha}")
+
+        # Skip if the commit message itself contains a CVE/GHSA reference
+        # (these are overt disclosures, not silent patches)
+        if _has_cve_reference(message):
+            continue
+
+        msg_score, msg_keywords = _score_message(message)
+        if msg_score < 5:
+            # Not interesting based on message alone; skip diff scan
+            continue
+
+        diff_score = 0
+        diff_keywords: list[str] = []
+        bug_class: str | None = None
+
+        if not fast:
+            diff_text = _fetch_commit_diff(repo, full_sha, headers)
+            if diff_text:
+                diff_score, diff_keywords = _score_diff(diff_text)
+                bug_class = _infer_bug_class(diff_text)
+
+        total_score = min(100, msg_score + diff_score)
+
+        if total_score >= 10:
+            all_keywords = list(dict.fromkeys(msg_keywords + diff_keywords))  # dedup, preserve order
+            candidates.append(
+                {
+                    "sha": sha,
+                    "date": date_str[:10] if date_str else "",
+                    "author": author_name,
+                    "message": message.split("\n")[0][:120],
+                    "score": total_score,
+                    "msg_score": msg_score,
+                    "diff_score": diff_score,
+                    "keywords": all_keywords[:10],
+                    "bug_class": bug_class,
+                    "url": url,
+                }
+            )
+
+    # Sort by score descending
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+
+    summary_parts = [
+        f"Scanned {len(commits)} commits in {repo} ({since_str[:10]} → {until_str[:10]}).",
+        f"Found {len(candidates)} potential silent security patch(es) (no CVE reference).",
+    ]
+    if candidates:
+        top = candidates[0]
+        summary_parts.append(
+            f"Highest-suspicion commit: {top['sha']} (score {top['score']}) — '{top['message'][:60]}'"
+        )
+
+    return {
+        "repo": repo,
+        "since": since_str[:10],
+        "until": until_str[:10],
+        "total_scanned": len(commits),
+        "candidates": candidates,
+        "summary": " ".join(summary_parts),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+def render_silent_patches_text(result: dict[str, Any]) -> str:
+    """Render the find_silent_patches result as a human-readable report."""
+    if "error" in result:
+        return f"Error: {result['error']}"
+
+    lines: list[str] = []
+    lines.append(f"Silent Patch Scan: {result['repo']}")
+    lines.append("=" * 60)
+    lines.append(f"  Period  : {result['since']} → {result['until']}")
+    lines.append(f"  Scanned : {result['total_scanned']} commits")
+    lines.append(f"  Found   : {len(result['candidates'])} candidate(s) with no CVE reference")
+    lines.append("")
+
+    candidates = result.get("candidates", [])
+    if not candidates:
+        lines.append("  No suspicious commits found in this period.")
+        return "\n".join(lines)
+
+    lines.append("Candidates (sorted by suspicion score)")
+    lines.append("-" * 60)
+
+    for i, c in enumerate(candidates, 1):
+        lines.append(f"  [{i}] {c['sha']}  score={c['score']:3d}  {c['date']}  by {c['author']}")
+        lines.append(f"       {c['message']}")
+        if c.get("bug_class"):
+            lines.append(f"       Bug class : {c['bug_class']}")
+        if c.get("keywords"):
+            lines.append(f"       Keywords  : {', '.join(c['keywords'])}")
+        lines.append(f"       URL       : {c['url']}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands entry point
+# ---------------------------------------------------------------------------
+
+
+def find_silent_patches(tool: ToolUse, **kwargs: Any) -> ToolResult:  # noqa: ARG001
+    """Strands tool entry point for finding silent security patches in a GitHub repo."""
+    inp = tool.get("input", {})
+    repo = inp.get("repo", "")
+    since = inp.get("since")
+    until = inp.get("until")
+    max_commits = int(inp.get("max_commits", 200))
+    fast = bool(inp.get("fast", False))
+
+    if not repo:
+        return {
+            "toolUseId": tool["toolUseId"],
+            "status": "error",
+            "content": [{"text": "Missing required parameter: repo"}],
+        }
+
+    result = find_silent_patches_impl(
+        repo=repo,
+        since=since,
+        until=until,
+        max_commits=max_commits,
+        fast=fast,
+    )
+
+    log_tool_output_size("find_silent_patches", result)
+
+    return {
+        "toolUseId": tool["toolUseId"],
+        "status": "success",
+        "content": [{"text": str(result)}],
+    }

--- a/tests/test_silent_patches.py
+++ b/tests/test_silent_patches.py
@@ -1,0 +1,856 @@
+"""
+Tests for the silent patch detector (find_silent_patches tool + CLI subcommand).
+
+All HTTP calls are mocked — no real network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers & fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_commit(
+    sha: str = "abc1234567890",
+    message: str = "fix: normal bug",
+    date: str = "2024-03-15T12:00:00Z",
+    author: str = "Alice",
+) -> dict:
+    return {
+        "sha": sha,
+        "html_url": f"https://github.com/owner/repo/commit/{sha}",
+        "commit": {
+            "message": message,
+            "author": {"date": date, "name": author},
+        },
+    }
+
+
+def _make_tool_use(repo: str, **kwargs) -> dict:
+    inp = {"repo": repo}
+    inp.update(kwargs)
+    return {"toolUseId": "tu-001", "input": inp}
+
+
+# ---------------------------------------------------------------------------
+# Module-level import sanity
+# ---------------------------------------------------------------------------
+
+
+def test_find_silent_patches_module_imports():
+    from manus_use.tools.find_silent_patches import find_silent_patches  # noqa: F401
+
+    assert callable(find_silent_patches)
+
+
+def test_tool_spec_structure():
+    from manus_use.tools.find_silent_patches import TOOL_SPEC
+
+    assert TOOL_SPEC["name"] == "find_silent_patches"
+    assert "repo" in TOOL_SPEC["inputSchema"]["json"]["properties"]
+    assert TOOL_SPEC["inputSchema"]["json"]["required"] == ["repo"]
+
+
+def test_tool_spec_description_mentions_silent_patch():
+    from manus_use.tools.find_silent_patches import TOOL_SPEC
+
+    assert "silent" in TOOL_SPEC["description"].lower()
+    assert "cve" in TOOL_SPEC["description"].lower()
+
+
+# ---------------------------------------------------------------------------
+# _github_headers
+# ---------------------------------------------------------------------------
+
+
+def test_github_headers_no_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    from manus_use.tools.find_silent_patches import _github_headers
+
+    h = _github_headers()
+    assert "Authorization" not in h
+    assert h["Accept"] == "application/vnd.github.v3+json"
+
+
+def test_github_headers_with_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "ghp_test123")
+    from manus_use.tools.find_silent_patches import _github_headers
+
+    h = _github_headers()
+    assert h["Authorization"] == "Bearer ghp_test123"
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+
+def test_parse_date_short():
+    from manus_use.tools.find_silent_patches import _parse_date
+
+    assert _parse_date("2024-03-01") == "2024-03-01T00:00:00Z"
+
+
+def test_parse_date_full_iso():
+    from manus_use.tools.find_silent_patches import _parse_date
+
+    full = "2024-03-01T15:30:00Z"
+    assert _parse_date(full) == full
+
+
+def test_parse_date_strips_whitespace():
+    from manus_use.tools.find_silent_patches import _parse_date
+
+    assert _parse_date("  2024-06-01  ") == "2024-06-01T00:00:00Z"
+
+
+# ---------------------------------------------------------------------------
+# _default_since
+# ---------------------------------------------------------------------------
+
+
+def test_default_since_is_90_days_ago():
+    from datetime import datetime, timezone
+
+    from manus_use.tools.find_silent_patches import _default_since
+
+    result = _default_since()
+    dt = datetime.fromisoformat(result.replace("Z", "+00:00"))
+    delta = datetime.now(timezone.utc) - dt
+    # Should be approximately 90 days (allow 1 day tolerance for test speed)
+    assert 89 <= delta.days <= 91
+
+
+# ---------------------------------------------------------------------------
+# _score_message
+# ---------------------------------------------------------------------------
+
+
+def test_score_message_security_keyword():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("fix: security vulnerability in auth module")
+    assert score >= 20
+    assert len(kws) >= 1
+
+
+def test_score_message_no_keywords():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("chore: update dependencies")
+    # Might still score zero or very low
+    assert score <= 5
+    assert isinstance(kws, list)
+
+
+def test_score_message_cve_reference():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    # CVE keyword should match (we use it to exclude later)
+    score, kws = _score_message("fix CVE-2024-1234: path traversal")
+    assert score >= 15
+
+
+def test_score_message_injection_keyword():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("fix: prevent SQL injection in login form")
+    assert score >= 10
+
+
+def test_score_message_buffer_overflow():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("fix buffer overflow in packet parser")
+    assert score >= 10
+
+
+def test_score_message_bypass():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("fix authentication bypass in API handler")
+    assert score >= 10
+
+
+def test_score_message_rce():
+    from manus_use.tools.find_silent_patches import _score_message
+
+    score, kws = _score_message("fix RCE via template injection")
+    assert score >= 18
+
+
+# ---------------------------------------------------------------------------
+# _score_diff
+# ---------------------------------------------------------------------------
+
+
+def test_score_diff_sanitize():
+    from manus_use.tools.find_silent_patches import _score_diff
+
+    score, kws = _score_diff("+    output = html.escape(user_input)")
+    assert score >= 8
+
+
+def test_score_diff_empty():
+    from manus_use.tools.find_silent_patches import _score_diff
+
+    score, kws = _score_diff("")
+    assert score == 0
+    assert kws == []
+
+
+def test_score_diff_sql_parameterized():
+    from manus_use.tools.find_silent_patches import _score_diff
+
+    diff = "+    cursor.execute(query, (param,))\n+    # Use parameterized query"
+    score, kws = _score_diff(diff)
+    assert score >= 8
+
+
+def test_score_diff_auth_check():
+    from manus_use.tools.find_silent_patches import _score_diff
+
+    diff = "+    if not is_authenticated(request.user):\n+        raise PermissionError"
+    score, kws = _score_diff(diff)
+    assert score >= 10
+
+
+# ---------------------------------------------------------------------------
+# _infer_bug_class
+# ---------------------------------------------------------------------------
+
+
+def test_infer_bug_class_auth():
+    from manus_use.tools.find_silent_patches import _infer_bug_class
+
+    diff = "check_permission(user)\nis_authenticated\nhas_permission"
+    result = _infer_bug_class(diff)
+    assert result == "auth_bypass"
+
+
+def test_infer_bug_class_sql():
+    from manus_use.tools.find_silent_patches import _infer_bug_class
+
+    diff = "cursor.execute(query)\nparameterized\nuse sql prepare"
+    result = _infer_bug_class(diff)
+    assert result == "sql_injection"
+
+
+def test_infer_bug_class_xss():
+    from manus_use.tools.find_silent_patches import _infer_bug_class
+
+    diff = "html.escape(input)\nsanitize(data)\nescape(text)"
+    result = _infer_bug_class(diff)
+    assert result == "xss"
+
+
+def test_infer_bug_class_none_for_generic():
+    from manus_use.tools.find_silent_patches import _infer_bug_class
+
+    diff = "fix typo in README\nadd blank line"
+    result = _infer_bug_class(diff)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _has_cve_reference
+# ---------------------------------------------------------------------------
+
+
+def test_has_cve_reference_true():
+    from manus_use.tools.find_silent_patches import _has_cve_reference
+
+    assert _has_cve_reference("Fixes CVE-2024-3094 in xz-utils") is True
+
+
+def test_has_cve_reference_ghsa():
+    from manus_use.tools.find_silent_patches import _has_cve_reference
+
+    assert _has_cve_reference("GHSA-abcd-1234-efgh") is True
+
+
+def test_has_cve_reference_none():
+    from manus_use.tools.find_silent_patches import _has_cve_reference
+
+    assert _has_cve_reference("fix auth bypass in login") is False
+
+
+def test_has_cve_reference_case_insensitive():
+    from manus_use.tools.find_silent_patches import _has_cve_reference
+
+    assert _has_cve_reference("cve-2021-44228 log4j") is True
+
+
+# ---------------------------------------------------------------------------
+# _list_commits
+# ---------------------------------------------------------------------------
+
+
+def test_list_commits_success():
+    from manus_use.tools.find_silent_patches import _list_commits
+
+    commits = [_make_commit(sha=f"abc{i:010d}") for i in range(5)]
+
+    with patch("manus_use.tools.find_silent_patches._fetch_json", return_value=commits):
+        result = _list_commits("owner/repo", "2024-01-01T00:00:00Z", "2024-03-01T00:00:00Z", 100, {})
+    assert len(result) == 5
+
+
+def test_list_commits_respects_max():
+    from manus_use.tools.find_silent_patches import _list_commits
+
+    commits = [_make_commit(sha=f"abc{i:010d}") for i in range(50)]
+
+    with patch("manus_use.tools.find_silent_patches._fetch_json", return_value=commits):
+        result = _list_commits("owner/repo", "2024-01-01T00:00:00Z", "2024-03-01T00:00:00Z", 10, {})
+    assert len(result) == 10
+
+
+def test_list_commits_404_raises_value_error():
+    import requests
+
+    from manus_use.tools.find_silent_patches import _list_commits
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    exc = requests.HTTPError(response=mock_resp)
+
+    with patch("manus_use.tools.find_silent_patches._fetch_json", side_effect=exc):
+        with pytest.raises(ValueError, match="not found"):
+            _list_commits("bad/repo", "2024-01-01T00:00:00Z", "2024-03-01T00:00:00Z", 100, {})
+
+
+def test_list_commits_pagination_stops_on_empty():
+    from manus_use.tools.find_silent_patches import _list_commits
+
+    # First call returns 3 items (< per_page of min(100,5)), so should stop
+    commits = [_make_commit(sha=f"abc{i:010d}") for i in range(3)]
+
+    with patch("manus_use.tools.find_silent_patches._fetch_json", return_value=commits) as mock_fetch:
+        result = _list_commits("owner/repo", "2024-01-01T00:00:00Z", "2024-03-01T00:00:00Z", 5, {})
+    assert len(result) == 3
+    assert mock_fetch.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _fetch_commit_diff
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_commit_diff_success():
+    from manus_use.tools.find_silent_patches import _fetch_commit_diff
+
+    mock_resp = MagicMock()
+    mock_resp.text = "+    sanitize(input)\n-    pass"
+    mock_resp.raise_for_status = MagicMock()
+
+    with patch("manus_use.tools.find_silent_patches.requests.get", return_value=mock_resp):
+        result = _fetch_commit_diff("owner/repo", "abc123", {})
+    assert "sanitize" in result
+
+
+def test_fetch_commit_diff_failure_returns_empty():
+    from manus_use.tools.find_silent_patches import _fetch_commit_diff
+
+    with patch(
+        "manus_use.tools.find_silent_patches.requests.get",
+        side_effect=Exception("network error"),
+    ):
+        result = _fetch_commit_diff("owner/repo", "abc123", {})
+    assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# find_silent_patches_impl — integration
+# ---------------------------------------------------------------------------
+
+
+def _mock_commits_for_impl():
+    """Return a mix: one suspicious (no CVE), one with CVE (should be filtered out), one generic."""
+    return [
+        _make_commit(
+            sha="security1234567",
+            message="fix: sanitize user input to prevent XSS",
+        ),
+        _make_commit(
+            sha="cve_commit12345",
+            message="fix CVE-2024-9999: buffer overflow in parser",
+        ),
+        _make_commit(
+            sha="generic1234567",
+            message="chore: bump version to 2.0.1",
+        ),
+        _make_commit(
+            sha="auth_bypass1234",
+            message="security: fix authentication bypass in login endpoint",
+        ),
+    ]
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_filters_cve_commits(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = _mock_commits_for_impl()
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+
+    # CVE commit should be excluded from candidates
+    shas = [c["sha"] for c in result["candidates"]]
+    assert not any("cve_commit" in s for s in shas)
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_includes_suspicious_commits(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = _mock_commits_for_impl()
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+
+    # At minimum, the sanitize/XSS commit should score high enough to appear
+    assert len(result["candidates"]) >= 1
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_sorted_by_score_descending(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = _mock_commits_for_impl()
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+
+    scores = [c["score"] for c in result["candidates"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_total_scanned_matches_commit_count(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    commits = _mock_commits_for_impl()
+    mock_list.return_value = commits
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+    assert result["total_scanned"] == len(commits)
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_returns_repo_and_date_range(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = []
+
+    result = find_silent_patches_impl(repo="owner/repo", since="2024-01-01", until="2024-03-01", fast=True)
+    assert result["repo"] == "owner/repo"
+    assert result["since"] == "2024-01-01"
+    assert result["until"] == "2024-03-01"
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_strips_github_url_prefix(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = []
+
+    result = find_silent_patches_impl(repo="https://github.com/owner/repo", fast=True)
+    assert result["repo"] == "owner/repo"
+
+
+def test_impl_invalid_repo_format():
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    result = find_silent_patches_impl(repo="notavalidrepo")
+    assert "error" in result
+    assert "Invalid repo format" in result["error"]
+
+
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_404_repo(mock_list):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.side_effect = ValueError("Repository 'bad/repo' not found on GitHub.")
+
+    result = find_silent_patches_impl(repo="bad/repo")
+    assert "error" in result
+    assert "not found" in result["error"].lower()
+
+
+@patch(
+    "manus_use.tools.find_silent_patches._fetch_commit_diff",
+    return_value="+    html.escape(data)\n+    sanitize(user)\n+    is_authenticated(req)",
+)
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_diff_scan_increases_score(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = [
+        _make_commit(sha="fix12345678901", message="fix: sanitize output"),
+    ]
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=False)
+    # Diff score should add to message score
+    assert result["candidates"][0]["diff_score"] > 0
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_fast_mode_skips_diff(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = [
+        _make_commit(sha="fix12345678901", message="fix: sanitize output"),
+    ]
+
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+    mock_diff.assert_not_called()
+    if result["candidates"]:
+        assert result["candidates"][0]["diff_score"] == 0
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_max_commits_capped_at_500(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = []
+
+    find_silent_patches_impl(repo="owner/repo", max_commits=9999, fast=True)
+    # Check that the call used a max of 500
+    # max_commits is the 3rd positional arg to _list_commits
+    assert mock_list.call_args[0][3] == 500
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_impl_summary_string_populated(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches_impl
+
+    mock_list.return_value = _mock_commits_for_impl()
+    result = find_silent_patches_impl(repo="owner/repo", fast=True)
+    assert isinstance(result["summary"], str)
+    assert len(result["summary"]) > 10
+
+
+# ---------------------------------------------------------------------------
+# render_silent_patches_text
+# ---------------------------------------------------------------------------
+
+
+def test_render_text_with_candidates():
+    from manus_use.tools.find_silent_patches import render_silent_patches_text
+
+    result = {
+        "repo": "owner/repo",
+        "since": "2024-01-01",
+        "until": "2024-03-01",
+        "total_scanned": 50,
+        "candidates": [
+            {
+                "sha": "abc1234",
+                "date": "2024-02-10",
+                "author": "Alice",
+                "message": "fix: sanitize user input",
+                "score": 45,
+                "msg_score": 20,
+                "diff_score": 25,
+                "keywords": ["sanitize", "xss"],
+                "bug_class": "xss",
+                "url": "https://github.com/owner/repo/commit/abc1234",
+            }
+        ],
+        "summary": "Scanned 50 commits. Found 1 candidate.",
+    }
+    text = render_silent_patches_text(result)
+    assert "owner/repo" in text
+    assert "abc1234" in text
+    assert "xss" in text
+    assert "sanitize" in text
+    assert "45" in text
+
+
+def test_render_text_no_candidates():
+    from manus_use.tools.find_silent_patches import render_silent_patches_text
+
+    result = {
+        "repo": "clean/repo",
+        "since": "2024-01-01",
+        "until": "2024-03-01",
+        "total_scanned": 30,
+        "candidates": [],
+        "summary": "No candidates found.",
+    }
+    text = render_silent_patches_text(result)
+    assert "No suspicious commits" in text
+
+
+def test_render_text_error():
+    from manus_use.tools.find_silent_patches import render_silent_patches_text
+
+    text = render_silent_patches_text({"error": "Repository 'bad/repo' not found on GitHub."})
+    assert "Error:" in text
+    assert "not found" in text.lower()
+
+
+def test_render_text_shows_period():
+    from manus_use.tools.find_silent_patches import render_silent_patches_text
+
+    result = {
+        "repo": "owner/repo",
+        "since": "2024-01-01",
+        "until": "2024-06-01",
+        "total_scanned": 10,
+        "candidates": [],
+        "summary": "",
+    }
+    text = render_silent_patches_text(result)
+    assert "2024-01-01" in text
+    assert "2024-06-01" in text
+
+
+# ---------------------------------------------------------------------------
+# Strands entry point (find_silent_patches function)
+# ---------------------------------------------------------------------------
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits", return_value=[])
+def test_strands_entrypoint_success(mock_list, mock_diff):
+    from manus_use.tools.find_silent_patches import find_silent_patches
+
+    tool = _make_tool_use("owner/repo", since="2024-01-01", fast=True)
+    result = find_silent_patches(tool)
+    assert result["status"] == "success"
+    assert "content" in result
+    assert result["toolUseId"] == "tu-001"
+
+
+def test_strands_entrypoint_missing_repo():
+    from manus_use.tools.find_silent_patches import find_silent_patches
+
+    tool = {"toolUseId": "tu-002", "input": {}}
+    result = find_silent_patches(tool)
+    assert result["status"] == "error"
+    assert "Missing required parameter" in result["content"][0]["text"]
+
+
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_strands_entrypoint_404(mock_list):
+    from manus_use.tools.find_silent_patches import find_silent_patches
+
+    mock_list.side_effect = ValueError("Repository 'bad/repo' not found on GitHub.")
+    tool = _make_tool_use("bad/repo")
+    result = find_silent_patches(tool)
+    # The impl returns {"error": ...} which the entrypoint wraps as success content
+    assert result["status"] == "success"
+    content_text = result["content"][0]["text"]
+    assert "error" in content_text.lower() or "not found" in content_text.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI — _build_silent_patches_parser
+# ---------------------------------------------------------------------------
+
+
+def test_cli_parser_defaults():
+    from manus_use.cli import _build_silent_patches_parser
+
+    p = _build_silent_patches_parser()
+    args = p.parse_args(["owner/repo"])
+    assert args.repo == "owner/repo"
+    assert args.since is None
+    assert args.until is None
+    assert args.max_commits == 200
+    assert args.fast is False
+    assert args.output == "text"
+
+
+def test_cli_parser_all_flags():
+    from manus_use.cli import _build_silent_patches_parser
+
+    p = _build_silent_patches_parser()
+    args = p.parse_args([
+        "django/django",
+        "--since", "2024-01-01",
+        "--until", "2024-06-01",
+        "--max-commits", "100",
+        "--fast",
+        "--output", "json",
+    ])
+    assert args.repo == "django/django"
+    assert args.since == "2024-01-01"
+    assert args.until == "2024-06-01"
+    assert args.max_commits == 100
+    assert args.fast is True
+    assert args.output == "json"
+
+
+def test_cli_parser_help_exits_zero():
+    from manus_use.cli import _build_silent_patches_parser
+
+    p = _build_silent_patches_parser()
+    with pytest.raises(SystemExit) as exc:
+        p.parse_args(["--help"])
+    assert exc.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# CLI — _run_silent_patches
+# ---------------------------------------------------------------------------
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits", return_value=[])
+def test_run_silent_patches_text_output_exits_zero(mock_list, mock_diff, capsys):
+    from manus_use.cli import _run_silent_patches
+
+    rc = _run_silent_patches(["owner/repo", "--fast"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "owner/repo" in out
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits", return_value=[])
+def test_run_silent_patches_json_output(mock_list, mock_diff, capsys):
+    from manus_use.cli import _run_silent_patches
+
+    rc = _run_silent_patches(["owner/repo", "--output", "json", "--fast"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert "candidates" in data
+    assert data["repo"] == "owner/repo"
+
+
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_run_silent_patches_invalid_repo(mock_list, capsys):
+    from manus_use.cli import _run_silent_patches
+
+    # No "/" in repo name → impl returns error
+    rc = _run_silent_patches(["notarepo", "--fast"])
+    assert rc == 1
+
+
+@patch("manus_use.tools.find_silent_patches._fetch_commit_diff", return_value="")
+@patch("manus_use.tools.find_silent_patches._list_commits")
+def test_run_silent_patches_with_candidates(mock_list, mock_diff, capsys):
+    from manus_use.cli import _run_silent_patches
+
+    mock_list.return_value = [
+        _make_commit(sha="sec1234567890x", message="fix: sanitize XSS input in user profile"),
+    ]
+
+    rc = _run_silent_patches(["owner/repo", "--fast"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # Should mention the candidate
+    assert "sec12345" in out or "sanitize" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI — subcommand registration
+# ---------------------------------------------------------------------------
+
+
+def test_silent_patches_in_subcommands_set():
+    from manus_use.cli import _SUBCOMMANDS
+
+    assert "silent-patches" in _SUBCOMMANDS
+
+
+def test_silent_patches_dispatch_in_main(monkeypatch):
+    """Test that main() dispatches to _run_silent_patches when 'silent-patches' is first positional."""
+    from unittest.mock import patch
+
+    with patch("manus_use.cli._run_silent_patches", return_value=0) as mock_run:
+        with patch("sys.argv", ["manus-use", "silent-patches", "django/django", "--fast"]):
+            try:
+                from manus_use.cli import main
+
+                main()
+            except SystemExit as exc:
+                assert exc.code == 0
+
+        mock_run.assert_called_once_with(["django/django", "--fast"])
+
+
+# ---------------------------------------------------------------------------
+# VI agent wiring
+# ---------------------------------------------------------------------------
+
+
+def test_vi_agent_imports_find_silent_patches():
+    """Verify VulnerabilityIntelligenceAgent module references find_silent_patches."""
+    import importlib
+
+    spec = importlib.util.find_spec("manus_use.agents.vi_agent")
+    assert spec is not None
+    source = spec.loader.get_source("manus_use.agents.vi_agent")
+    assert "find_silent_patches" in source
+
+
+def test_vi_agent_system_prompt_mentions_silent_patch():
+    import importlib
+
+    spec = importlib.util.find_spec("manus_use.agents.vi_agent")
+    source = spec.loader.get_source("manus_use.agents.vi_agent")
+    assert "silent" in source.lower() or "Silent Patch" in source
+
+
+def test_vi_agent_tool_list_includes_find_silent_patches(monkeypatch):
+    """VulnerabilityIntelligenceAgent.__init__ should add find_silent_patches to tools."""
+    # We mock the heavy deps so we don't need real strands/strands_tools installed
+    import types
+
+    fake_strands = types.ModuleType("strands")
+    fake_strands.Agent = MagicMock()
+    fake_strands_tools = types.ModuleType("strands_tools")
+    fake_strands_tools.current_time = MagicMock()
+
+    monkeypatch.setitem(sys.modules, "strands", fake_strands)
+    monkeypatch.setitem(sys.modules, "strands_tools", fake_strands_tools)
+
+    # Ensure the module source mentions find_silent_patches in the import block
+    import importlib
+
+    spec = importlib.util.find_spec("manus_use.agents.vi_agent")
+    source = spec.loader.get_source("manus_use.agents.vi_agent")
+    assert "from manus_use.tools.find_silent_patches import find_silent_patches" in source
+
+
+# ---------------------------------------------------------------------------
+# README / docs coverage
+# ---------------------------------------------------------------------------
+
+
+def test_readme_mentions_silent_patches():
+    """README.md should document the silent-patches subcommand."""
+    readme = __import__("pathlib").Path(__file__).parent.parent / "README.md"
+    text = readme.read_text()
+    assert "silent-patches" in text
+
+
+def test_readme_silent_patches_example_has_owner_repo():
+    """README silent-patches example should include a plausible repo argument."""
+    readme = __import__("pathlib").Path(__file__).parent.parent / "README.md"
+    text = readme.read_text()
+    # Should show at least one owner/repo example
+    import re
+
+    section_match = re.search(r"silent-patches.*?(?=###|$)", text, re.DOTALL)
+    assert section_match is not None
+    assert "/" in section_match.group()


### PR DESCRIPTION
## What & Why

Silent patches are a major blind spot in standard CVE-based vulnerability management. Vendors sometimes quietly fix security bugs without filing a CVE — either deliberately (to limit exposure) or because the fix predates CVE assignment. Finding them requires directly inspecting commit history.

This PR adds `manus-use silent-patches <owner/repo>` — a first-class CLI subcommand and Strands tool that scans a public GitHub repository's commit history for commits that look like security patches but carry **no CVE or GHSA reference**.

## Changes

- **`src/manus_use/tools/find_silent_patches.py`** — two-stage scoring heuristic (message keywords → diff keywords), 14-class bug classification, CVE/GHSA filtering, GitHub paginated commit API, `GITHUB_TOKEN` support, Strands `TOOL_SPEC` + entry point, text renderer
- **`manus-use silent-patches` CLI subcommand** — `--since`, `--until`, `--max-commits`, `--fast`, `--output {text,json}`
- **VI agent wiring** — `find_silent_patches` added to `VulnerabilityIntelligenceAgent` tool list; optional Step 6b in system prompt
- **`README.md`** — new CLI reference section with flags table and examples

## Tests

67 new tests in `tests/test_silent_patches.py` — all HTTP calls mocked, zero real network I/O. Covers helpers, scoring, bug classification, CVE filter, GitHub API wrappers, impl edge cases, renderer, Strands entry point, CLI parser + runner, main() dispatch, VI agent wiring, README coverage.

**617 total tests pass, 3 deselected (integration), 0 failed.**