### PR TITLE
feat(tools): exploit complexity scorer — score_exploit_complexity tool + manus-use exploit-complexity subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,42 @@ cross-referencing three data sources.
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Output format; `json` includes the full comparison |
 
+### `manus-use exploit-complexity <CVE-ID>` — Exploit complexity scorer
+
+```bash
+# Score how hard it is for an attacker to exploit a CVE (1=trivial, 5=very hard)
+manus-use exploit-complexity CVE-2024-3094
+
+# Machine-readable output
+manus-use exploit-complexity CVE-2024-3094 --output json | jq .complexity_score
+```
+
+Analyses the CVE's NVD CVSS vector and, when available, the PoC source code from
+the [Trickest CVE index](https://github.com/trickest/cve) to score the practical
+effort required to exploit the vulnerability across five dimensions:
+
+| Dimension | What it measures |
+|-----------|------------------|
+| Lines of code | How much exploit code an attacker needs to write / adapt |
+| Authentication required | Credentials, tokens, or privilege level needed |
+| Network hops | How many services the exploit must reach |
+| OS/platform dependencies | Platform-specific syscalls, kernel structs, gadgets |
+| Exploit chain length | Number of discrete attack stages |
+
+Each dimension is scored 1–5 (1 = easy for the attacker). The weighted overall
+`complexity_score` (1–5) is accompanied by a human-readable label
+(*trivial / low / moderate / high / very_high*) and an `attacker_friendly`
+boolean (True when score ≤ 2.5).
+
+Use this alongside `epss-trend` and `compare` to answer: *"this CVE is CVSS 9.8
+— but is it actually easy to exploit right now?"*
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format; `json` includes per-dimension scores and metadata |
+
 ### `manus-use discover` — CVE discovery
 
 ```bash
@@ -530,6 +566,10 @@ manus-use remediate CVE-2024-3094
 # Compare two CVEs side-by-side for triage prioritisation
 manus-use compare CVE-2024-3094 CVE-2021-44228
 manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
+
+# Score how hard it is for an attacker to exploit a CVE (1=trivial, 5=very hard)
+manus-use exploit-complexity CVE-2024-3094
+manus-use exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -94,6 +94,14 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - A direct link to the commit on GitHub.
   If no commit is found (private repo or non-GitHub), note this and proceed.
 
+**Step 6b: Exploit Complexity Scoring**
+- Call `score_exploit_complexity` with the CVE ID. Include in the report:
+  - The overall complexity score (1–5) and label (trivial / low / moderate / high / very_high).
+  - The `attacker_friendly` flag — if True, flag prominently that this CVE is easy to weaponise.
+  - Per-dimension breakdown: lines of code, authentication required, network hops, OS/platform dependencies, exploit chain length.
+  - Whether the score was derived from PoC code analysis or NVD CVSS vector only.
+  This score contextualises raw CVSS severity: a CVSS 9.8 with complexity_score=1.5 is far more urgent than the same CVSS with complexity_score=4.5.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -189,6 +197,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_patch_diff import get_patch_diff
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
+            from manus_use.tools.score_exploit_complexity import score_exploit_complexity
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -240,6 +249,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.verify_exploit",
             get_epss_trend,
             get_patch_diff,
+            score_exploit_complexity,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1052,6 +1052,7 @@ _SUBCOMMANDS = {
     "epss-trend",
     "patch-diff",
     "compare",
+    "exploit-complexity",
 }
 
 
@@ -1289,6 +1290,54 @@ def _run_compare(argv: list[str]) -> int:
 
     # Text output
     print(_render_text(comparison))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# exploit-complexity subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_exploit_complexity_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="manus-use exploit-complexity",
+        description="Score the practical complexity of exploiting a CVE (1=trivial, 5=very hard).",
+    )
+    parser.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier (e.g. CVE-2024-3094)")
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return parser
+
+
+def _run_exploit_complexity(argv: list[str]) -> int:
+    parser = _build_exploit_complexity_parser()
+    args = parser.parse_args(argv)
+
+    cve_id: str = args.cve_id.strip()
+    import re as _re
+
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id, _re.IGNORECASE):
+        parser.error(f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN")
+
+    try:
+        from manus_use.tools.score_exploit_complexity import _render_text, _run_scoring
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: failed to import score_exploit_complexity: {exc}", file=__import__('sys').stderr)
+        return 1
+
+    result = _run_scoring(cve_id)
+
+    if args.output == "json":
+        import json as _json
+
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    print(_render_text(result))
     return 0
 
 
@@ -1599,6 +1648,10 @@ def main() -> None:
     if first_positional == "compare":
         idx = argv.index("compare")
         sys.exit(_run_compare(argv[idx + 1 :]))
+
+    if first_positional == "exploit-complexity":
+        idx = argv.index("exploit-complexity")
+        sys.exit(_run_exploit_complexity(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/score_exploit_complexity.py
+++ b/src/manus_use/tools/score_exploit_complexity.py
@@ -1,0 +1,586 @@
+"""
+Tool: score_exploit_complexity
+
+Analyses a CVE's PoC code and NVD metadata to produce a structured exploit
+complexity score — a measure of how hard it is for an attacker to *use* the
+vulnerability in practice.
+
+Inputs (all derived automatically from the CVE ID):
+
+1. **NVD CVSS vector** — Attack Vector, Privileges Required, User Interaction,
+   Scope, Authentication fields give a baseline complexity signal.
+2. **PoC source code** — fetched from Trickest CVE index or NVD references.
+   Scored across five dimensions:
+   - *Lines of code* — longer exploits are harder to develop / adapt.
+   - *Required authentication* — credential-setup or login steps.
+   - *Network hops* — how many remote hosts / services the exploit must reach.
+   - *OS/platform dependencies* — platform-specific syscalls, kernel structs,
+     hard-coded paths, library names.
+   - *Exploit chain length* — how many discrete stages the attack requires
+     (e.g. SSRF → credential leak → lateral movement).
+
+Output dimensions are each scored 1–5 (1 = simple / attacker-friendly,
+5 = complex / hard to weaponise). An overall ``complexity_score`` (1–5,
+float) is the weighted average.  A companion ``attacker_friendly`` boolean
+is ``True`` when the overall score ≤ 2.5.
+
+All HTTP calls are mockable — no side effects in unit tests.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["score_exploit_complexity"]
+
+# ---------------------------------------------------------------------------
+# Scoring constants
+# ---------------------------------------------------------------------------
+
+# Weight applied to each sub-dimension in the final weighted average.
+# Must sum to 1.0.
+_WEIGHTS: dict[str, float] = {
+    "lines_of_code": 0.15,
+    "auth_required": 0.25,
+    "network_hops": 0.20,
+    "os_dependencies": 0.15,
+    "chain_length": 0.25,
+}
+
+# NVD Attack Vector → network-hops base score
+_AV_SCORE: dict[str, int] = {
+    "NETWORK": 1,   # reachable from the internet — easy
+    "ADJACENT": 2,  # same network segment
+    "LOCAL": 4,     # must be on the machine
+    "PHYSICAL": 5,  # physical access required
+}
+
+# NVD Privileges Required → auth base score
+_PR_SCORE: dict[str, int] = {
+    "NONE": 1,
+    "LOW": 2,
+    "HIGH": 4,
+}
+
+# NVD User Interaction → chain-length modifier
+_UI_SCORE: dict[str, int] = {
+    "NONE": 0,
+    "REQUIRED": 1,
+}
+
+# ---------------------------------------------------------------------------
+# PoC fetch helpers
+# ---------------------------------------------------------------------------
+
+_TRICKEST_RAW = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+_CVE_RE = re.compile(r"CVE-(\d{4})-\d+", re.IGNORECASE)
+_URL_RE = re.compile(r"https?://\S+")
+_GITHUB_RAW_RE = re.compile(
+    r"https?://(?:raw\.githubusercontent\.com|github\.com)/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+",
+    re.IGNORECASE,
+)
+
+
+def _github_headers() -> dict[str, str]:
+    headers: dict[str, str] = {"Accept": "application/vnd.github.v3+json"}
+    token = os.environ.get("GITHUB_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _fetch_trickest_markdown(cve_id: str) -> str | None:
+    """Return the raw trickest markdown for *cve_id*, or None on failure."""
+    m = _CVE_RE.match(cve_id)
+    if not m:
+        return None
+    year = m.group(1)
+    url = _TRICKEST_RAW.format(year=year, cve_id=cve_id.upper())
+    try:
+        resp = requests.get(url, timeout=15)
+        if resp.status_code == 200:
+            return resp.text
+    except requests.RequestException:
+        pass
+    return None
+
+
+
+def _extract_poc_urls_from_trickest(markdown: str) -> list[str]:
+    """Return all http(s) URLs found in the trickest markdown."""
+    return _URL_RE.findall(markdown)
+
+
+def _fetch_nvd_references(cve_id: str) -> list[str]:
+    """Return the list of reference URLs from NVD for *cve_id*."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return []
+        cve_data = vulns[0].get("cve", {})
+        return [r.get("url", "") for r in cve_data.get("references", []) if r.get("url")]
+    except requests.RequestException:
+        return []
+
+
+def _is_poc_candidate(url: str) -> bool:
+    """Heuristic: is this URL likely to contain PoC source code?"""
+    lowered = url.lower()
+    return any(
+        kw in lowered
+        for kw in (
+            "github.com",
+            "raw.githubusercontent.com",
+            "exploit-db",
+            "packetstormsecurity",
+            "gist.github",
+            "pastebin",
+            "gitlab.com",
+        )
+    )
+
+
+def _fetch_poc_code(url: str) -> str | None:
+    """Attempt to fetch PoC source code from *url*.
+
+    - GitHub blob URLs are converted to raw URLs.
+    - Content is truncated to 50 kB to avoid processing huge files.
+    """
+    # Convert github.com blob → raw.githubusercontent.com
+    raw_url = re.sub(
+        r"https://github\.com/([^/]+)/([^/]+)/blob/",
+        r"https://raw.githubusercontent.com/\1/\2/",
+        url,
+    )
+    try:
+        resp = requests.get(raw_url, timeout=20, headers={"User-Agent": "manus-use/1.0"})
+        if resp.status_code == 200:
+            return resp.text[:51_200]
+    except requests.RequestException:
+        pass
+    return None
+
+
+def _fetch_nvd_cvss_vector(cve_id: str) -> dict[str, Any]:
+    """Return a dict with CVSS v3 vector fields for *cve_id*, or empty dict."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return {}
+        cve_data = vulns[0].get("cve", {})
+        metrics = cve_data.get("metrics", {})
+        # Prefer v3.1, fall back to v3.0, then v2
+        for key in ("cvssMetricV31", "cvssMetricV30"):
+            entries = metrics.get(key, [])
+            if entries:
+                cv = entries[0].get("cvssData", {})
+                return {
+                    "attackVector": cv.get("attackVector", ""),
+                    "privilegesRequired": cv.get("privilegesRequired", ""),
+                    "userInteraction": cv.get("userInteraction", ""),
+                    "scope": cv.get("scope", ""),
+                    "baseScore": cv.get("baseScore"),
+                }
+        return {}
+    except requests.RequestException:
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Code analysis helpers
+# ---------------------------------------------------------------------------
+
+# Patterns that suggest the exploit requires authentication / credentials
+_AUTH_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\bpassword\b",
+        r"\bcredential",
+        r"\bauth_?token\b",
+        r"\bapi_?key\b",
+        r"\bbasicauth\b",
+        r"\blogin\b",
+        r"\bsession_?id\b",
+        r"\bcookie\b",
+        r"\bjwt\b",
+        r"\bbearer\b",
+        r"\bssh_key\b",
+        r"\bprivate_key\b",
+        r"\bsudo\b",
+    ]
+]
+
+# Patterns that imply additional network hops / service calls
+_NETWORK_HOP_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\bsocket\b",
+        r"\bconnect\(",
+        r"\brequests?\.(get|post|put|delete|patch)",
+        r"\burllib\b",
+        r"\bhttp\.client\b",
+        r"\bsmtp\b",
+        r"\bftp\b",
+        r"\bldap\b",
+        r"\bssrf\b",
+        r"\breverse.shell\b",
+        r"\bncat\b|\bnc\b",
+        r"\bstage[_\s]?\d",
+        r"\bpivot\b",
+        r"\blateral.movement\b",
+        r"\bport.forward",
+        r"\btunnel\b",
+    ]
+]
+
+# Patterns that suggest OS/platform-specific dependencies
+_OS_DEP_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\bctypes\b",
+        r"\bstruct\.pack\b",
+        r"\bkallsyms\b",
+        r"\bksymtab\b",
+        r"\b/proc/",
+        r"\b/sys/",
+        r"\bkernel_version\b",
+        r"\bplatform\.(system|machine|architecture)",
+        r"#include\s+<",
+        r"\bwinapi\b",
+        r"\bwin32\b",
+        r"\bGetProcAddress\b",
+        r"\bVirtualAlloc\b",
+        r"\bRtlAdjustPrivilege\b",
+        r"\blibc\b",
+        r"\bglibc\b",
+        r"\bshellcode\b",
+        r"\brop.chain\b",
+        r"\bgadget\b",
+    ]
+]
+
+# Patterns that hint at multi-stage chaining
+_CHAIN_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\bstage\b",
+        r"\bchain\b",
+        r"\bpivot\b",
+        r"\bsecond.stage\b",
+        r"\blateral\b",
+        r"\bpersistence\b",
+        r"\bprivilege.esc",
+        r"\bsandbox.escape\b",
+        r"\bbypass.*auth",
+        r"\bauth.*bypass",
+        r"\bsession.*fixation",
+        r"\bcall-back\b|\bcallback\b",
+        r"\bdropper\b",
+        r"\bloader\b",
+        r"\bstager\b",
+    ]
+]
+
+
+def _count_matches(code: str, patterns: list[re.Pattern[str]]) -> int:
+    """Return the number of *distinct* patterns that match *code*."""
+    return sum(1 for p in patterns if p.search(code))
+
+
+def _score_lines_of_code(code: str) -> int:
+    """Score 1–5 based on (non-blank, non-comment) lines of exploit code."""
+    lines = [
+        ln
+        for ln in code.splitlines()
+        if ln.strip() and not ln.strip().startswith(("#", "//", "/*", "*", "--"))
+    ]
+    n = len(lines)
+    if n < 30:
+        return 1
+    if n < 100:
+        return 2
+    if n < 300:
+        return 3
+    if n < 700:
+        return 4
+    return 5
+
+
+def _score_auth_required(code: str, pr_from_nvd: str) -> int:
+    """Score 1–5: how much authentication setup does the exploit require?"""
+    # Start from NVD Privileges Required
+    base = _PR_SCORE.get(pr_from_nvd.upper(), 1)
+    hits = _count_matches(code, _AUTH_PATTERNS)
+    # Each distinct auth pattern adds a bit of complexity
+    penalty = min(hits, 3)
+    return min(5, base + penalty)
+
+
+def _score_network_hops(code: str, av_from_nvd: str) -> int:
+    """Score 1–5: number of remote services the exploit must contact."""
+    base = _AV_SCORE.get(av_from_nvd.upper(), 2)
+    hits = _count_matches(code, _NETWORK_HOP_PATTERNS)
+    penalty = min(hits // 2, 2)
+    return min(5, base + penalty)
+
+
+def _score_os_dependencies(code: str) -> int:
+    """Score 1–5: how OS/platform-specific is the exploit?"""
+    hits = _count_matches(code, _OS_DEP_PATTERNS)
+    if hits == 0:
+        return 1
+    if hits <= 2:
+        return 2
+    if hits <= 4:
+        return 3
+    if hits <= 7:
+        return 4
+    return 5
+
+
+def _score_chain_length(code: str, ui_modifier: int) -> int:
+    """Score 1–5: how many discrete exploit stages are involved?"""
+    hits = _count_matches(code, _CHAIN_PATTERNS)
+    base = 1 + min(hits, 3) + ui_modifier
+    return min(5, base)
+
+
+# ---------------------------------------------------------------------------
+# NVD-only fallback (no PoC available)
+# ---------------------------------------------------------------------------
+
+
+def _nvd_only_complexity(cvss: dict[str, Any]) -> dict[str, Any]:
+    """Return dimension scores derived purely from the CVSS vector."""
+    av = cvss.get("attackVector", "NETWORK")
+    pr = cvss.get("privilegesRequired", "NONE")
+    ui = cvss.get("userInteraction", "NONE")
+
+    loc_score = 1  # unknown without PoC → assume simple
+    auth_score = _PR_SCORE.get(pr.upper(), 1)
+    net_score = _AV_SCORE.get(av.upper(), 2)
+    os_score = 1
+    chain_score = 1 + _UI_SCORE.get(ui.upper(), 0)
+
+    return {
+        "lines_of_code": loc_score,
+        "auth_required": auth_score,
+        "network_hops": net_score,
+        "os_dependencies": os_score,
+        "chain_length": chain_score,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Core scoring pipeline
+# ---------------------------------------------------------------------------
+
+
+def _compute_overall(dimensions: dict[str, int]) -> float:
+    total = sum(_WEIGHTS[k] * dimensions[k] for k in _WEIGHTS)
+    return round(total, 2)
+
+
+def _label(score: float) -> str:
+    if score <= 1.5:
+        return "trivial"
+    if score <= 2.5:
+        return "low"
+    if score <= 3.5:
+        return "moderate"
+    if score <= 4.5:
+        return "high"
+    return "very_high"
+
+
+def _dimension_label(score: int) -> str:
+    return ["", "trivial", "low", "moderate", "high", "very_high"][score]
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    """Return a human-readable text report."""
+    cve = result["cve_id"]
+    lines = [
+        f"Exploit Complexity Score: {cve}",
+        "=" * 56,
+        f"  Overall score   : {result['complexity_score']:.2f} / 5  ({result['complexity_label']})",
+        f"  Attacker-friendly: {'YES — low barrier to exploitation' if result['attacker_friendly'] else 'NO — significant effort required'}",
+        "",
+        "Dimension breakdown (1 = easy for attacker, 5 = hard)",
+        "-" * 56,
+    ]
+    dim_names = {
+        "lines_of_code": "PoC size (lines of code)",
+        "auth_required": "Authentication required",
+        "network_hops": "Network hops / reach",
+        "os_dependencies": "OS / platform dependencies",
+        "chain_length": "Exploit chain length",
+    }
+    dims = result["dimensions"]
+    for key, label in dim_names.items():
+        score = dims[key]
+        dlabel = _dimension_label(score)
+        lines.append(f"  {label:<32}: {score}/5  ({dlabel})")
+    lines += [
+        "",
+        "Data sources",
+        "-" * 56,
+        f"  NVD CVSS vector : {'available' if result['cvss_available'] else 'not available'}",
+        f"  PoC code found  : {'yes (' + str(result['poc_lines']) + ' lines)' if result['poc_found'] else 'no — NVD vector only'}",
+    ]
+    if result.get("poc_url"):
+        lines.append(f"  PoC URL         : {result['poc_url']}")
+    lines += ["", "Methodology note:", "  Scores combine NVD CVSS vector fields with static analysis of PoC"]
+    lines += ["  source code. Scores without PoC data are estimates only."]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "score_exploit_complexity",
+    "description": (
+        "Scores the practical complexity of exploiting a CVE on a 1–5 scale "
+        "(1 = trivial for an attacker, 5 = very hard to weaponise). "
+        "Analyses NVD CVSS vector fields (attack vector, privileges required, user interaction) "
+        "and, when available, the PoC source code from the Trickest CVE index. "
+        "Returns per-dimension scores (lines of code, authentication required, network hops, "
+        "OS/platform dependencies, exploit chain length) plus a weighted overall score and "
+        "an attacker_friendly boolean (True when score ≤ 2.5). "
+        "Use this to go beyond raw CVSS severity and understand *how hard* an attacker would "
+        "actually find it to exploit the vulnerability in practice."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier to score (e.g., 'CVE-2024-3094').",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "description": "Output format: 'text' (default) or 'json'.",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+def _run_scoring(cve_id: str) -> dict[str, Any]:
+    """Execute the full complexity-scoring pipeline for *cve_id*.
+
+    Returns a result dict that can be serialised to JSON or rendered as text.
+    """
+    cve_id = cve_id.upper().strip()
+
+    # ── 1. Fetch NVD CVSS vector ─────────────────────────────────────────────
+    cvss = _fetch_nvd_cvss_vector(cve_id)
+    cvss_available = bool(cvss)
+    av = cvss.get("attackVector", "NETWORK")
+    pr = cvss.get("privilegesRequired", "NONE")
+    ui = cvss.get("userInteraction", "NONE")
+    ui_modifier = _UI_SCORE.get(ui.upper(), 0)
+
+    # ── 2. Find a PoC ────────────────────────────────────────────────────────
+    poc_code: str | None = None
+    poc_url: str | None = None
+
+    # 2a. Try trickest/cve index
+    trickest_md = _fetch_trickest_markdown(cve_id)
+    if trickest_md:
+        candidate_urls = _extract_poc_urls_from_trickest(trickest_md)
+        for candidate in candidate_urls:
+            if _is_poc_candidate(candidate):
+                code = _fetch_poc_code(candidate)
+                if code and len(code.strip()) > 50:
+                    poc_code = code
+                    poc_url = candidate
+                    break
+
+    # 2b. Fall back to NVD references
+    if not poc_code:
+        nvd_refs = _fetch_nvd_references(cve_id)
+        for ref_url in nvd_refs:
+            if _is_poc_candidate(ref_url):
+                code = _fetch_poc_code(ref_url)
+                if code and len(code.strip()) > 50:
+                    poc_code = code
+                    poc_url = ref_url
+                    break
+
+    # ── 3. Score dimensions ──────────────────────────────────────────────────
+    if poc_code:
+        dimensions = {
+            "lines_of_code": _score_lines_of_code(poc_code),
+            "auth_required": _score_auth_required(poc_code, pr),
+            "network_hops": _score_network_hops(poc_code, av),
+            "os_dependencies": _score_os_dependencies(poc_code),
+            "chain_length": _score_chain_length(poc_code, ui_modifier),
+        }
+        poc_found = True
+        poc_lines = len([ln for ln in poc_code.splitlines() if ln.strip()])
+    else:
+        dimensions = _nvd_only_complexity(cvss)
+        poc_found = False
+        poc_lines = 0
+
+    overall = _compute_overall(dimensions)
+
+    return {
+        "cve_id": cve_id,
+        "complexity_score": overall,
+        "complexity_label": _label(overall),
+        "attacker_friendly": overall <= 2.5,
+        "dimensions": dimensions,
+        "cvss_available": cvss_available,
+        "poc_found": poc_found,
+        "poc_lines": poc_lines,
+        "poc_url": poc_url,
+        "cvss_base_score": cvss.get("baseScore"),
+        "attack_vector": av,
+        "privileges_required": pr,
+        "user_interaction": ui,
+    }
+
+
+@tool
+def score_exploit_complexity(cve_id: str, output: str = "text") -> str:
+    """Score the practical complexity of exploiting a CVE on a 1–5 scale.
+
+    Args:
+        cve_id: CVE identifier (e.g. 'CVE-2024-3094').
+        output: 'text' (default) or 'json'.
+
+    Returns:
+        Formatted report string.
+    """
+    if not isinstance(cve_id, str) or not re.match(r"CVE-\d{4}-\d+", cve_id, re.IGNORECASE):
+        return "Error: cve_id must be a valid CVE identifier like 'CVE-2024-3094'."
+
+    result = _run_scoring(cve_id)
+
+    if output == "json":
+        import json as _json
+
+        return _json.dumps(result, indent=2)
+
+    return _render_text(result)

--- a/tests/test_exploit_complexity.py
+++ b/tests/test_exploit_complexity.py
@@ -1,0 +1,1071 @@
+"""
+Tests for src/manus_use/tools/score_exploit_complexity.py
+
+All external HTTP calls are mocked — no real network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module under test
+# ---------------------------------------------------------------------------
+from manus_use.tools.score_exploit_complexity import (
+    _AUTH_PATTERNS,
+    _compute_overall,
+    _count_matches,
+    _dimension_label,
+    _extract_poc_urls_from_trickest,
+    _fetch_nvd_cvss_vector,
+    _fetch_nvd_references,
+    _fetch_poc_code,
+    _fetch_trickest_markdown,
+    _github_headers,
+    _is_poc_candidate,
+    _label,
+    _nvd_only_complexity,
+    _render_text,
+    _run_scoring,
+    _score_auth_required,
+    _score_chain_length,
+    _score_lines_of_code,
+    _score_network_hops,
+    _score_os_dependencies,
+    score_exploit_complexity,
+)
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _make_nvd_response(
+    av: str = "NETWORK",
+    pr: str = "NONE",
+    ui: str = "NONE",
+    base_score: float = 9.8,
+    scope: str = "UNCHANGED",
+) -> dict[str, Any]:
+    return {
+        "resultsPerPage": 1,
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2024-1234",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "cvssData": {
+                                    "attackVector": av,
+                                    "privilegesRequired": pr,
+                                    "userInteraction": ui,
+                                    "scope": scope,
+                                    "baseScore": base_score,
+                                }
+                            }
+                        ]
+                    },
+                    "references": [
+                        {"url": "https://github.com/org/repo/commit/abc123"},
+                        {"url": "https://example.com/advisory"},
+                    ],
+                }
+            }
+        ],
+    }
+
+
+# ===========================================================================
+# _github_headers
+# ===========================================================================
+
+
+def test_github_headers_no_token(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    headers = _github_headers()
+    assert "Accept" in headers
+    assert "Authorization" not in headers
+
+
+def test_github_headers_with_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "test_token_123")
+    headers = _github_headers()
+    assert headers["Authorization"] == "Bearer test_token_123"
+
+
+# ===========================================================================
+# _fetch_trickest_markdown
+# ===========================================================================
+
+
+def test_fetch_trickest_markdown_success():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = "# PoC for CVE-2024-1234\nhttps://github.com/user/poc"
+    with patch("requests.get", return_value=mock_resp):
+        result = _fetch_trickest_markdown("CVE-2024-1234")
+    assert result is not None
+    assert "CVE-2024-1234" in result
+
+
+def test_fetch_trickest_markdown_not_found():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    with patch("requests.get", return_value=mock_resp):
+        result = _fetch_trickest_markdown("CVE-2024-9999")
+    assert result is None
+
+
+def test_fetch_trickest_markdown_invalid_cve():
+    result = _fetch_trickest_markdown("NOT-A-CVE")
+    assert result is None
+
+
+def test_fetch_trickest_markdown_request_exception():
+    import requests
+
+    with patch("requests.get", side_effect=requests.RequestException("timeout")):
+        result = _fetch_trickest_markdown("CVE-2024-1234")
+    assert result is None
+
+
+# ===========================================================================
+# _extract_poc_urls_from_trickest
+# ===========================================================================
+
+
+def test_extract_poc_urls_from_trickest():
+    md = "some text https://github.com/user/repo and http://example.com/poc more text"
+    urls = _extract_poc_urls_from_trickest(md)
+    assert "https://github.com/user/repo" in urls
+    assert "http://example.com/poc" in urls
+
+
+def test_extract_poc_urls_empty():
+    assert _extract_poc_urls_from_trickest("no urls here") == []
+
+
+# ===========================================================================
+# _is_poc_candidate
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        ("https://github.com/user/poc-repo", True),
+        ("https://raw.githubusercontent.com/org/repo/main/exploit.py", True),
+        ("https://www.exploit-db.com/exploits/12345", True),
+        ("https://packetstormsecurity.com/files/123/exploit.tgz", True),
+        ("https://gist.github.com/user/abc123", True),
+        ("https://pastebin.com/abc123", True),
+        ("https://gitlab.com/user/repo", True),
+        ("https://nvd.nist.gov/vuln/detail/CVE-2024-1234", False),
+        ("https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-1234", False),
+        ("https://example.com/advisory", False),
+    ],
+)
+def test_is_poc_candidate(url, expected):
+    assert _is_poc_candidate(url) == expected
+
+
+# ===========================================================================
+# _fetch_poc_code
+# ===========================================================================
+
+
+def test_fetch_poc_code_success():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = "import socket\n# exploit code here\n" * 10
+    with patch("requests.get", return_value=mock_resp):
+        result = _fetch_poc_code("https://github.com/user/repo/blob/main/exploit.py")
+    assert result is not None
+    assert "socket" in result
+
+
+def test_fetch_poc_code_converts_github_blob_to_raw():
+    """github.com/…/blob/… should be converted to raw.githubusercontent.com"""
+    captured_urls: list[str] = []
+
+    def fake_get(url, **kwargs):
+        captured_urls.append(url)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.text = "code"
+        return mock_resp
+
+    with patch("requests.get", side_effect=fake_get):
+        _fetch_poc_code("https://github.com/org/repo/blob/main/exploit.py")
+
+    assert captured_urls[0].startswith("https://raw.githubusercontent.com/")
+    assert "/blob/" not in captured_urls[0]
+
+
+def test_fetch_poc_code_non_200():
+    mock_resp = MagicMock()
+    mock_resp.status_code = 404
+    with patch("requests.get", return_value=mock_resp):
+        result = _fetch_poc_code("https://github.com/user/repo/blob/main/missing.py")
+    assert result is None
+
+
+def test_fetch_poc_code_exception():
+    import requests
+
+    with patch("requests.get", side_effect=requests.RequestException("timeout")):
+        result = _fetch_poc_code("https://github.com/user/repo")
+    assert result is None
+
+
+def test_fetch_poc_code_truncated():
+    """Content longer than 50 kB should be truncated."""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.text = "x" * 100_000
+    with patch("requests.get", return_value=mock_resp):
+        result = _fetch_poc_code("https://github.com/user/repo")
+    assert result is not None
+    assert len(result) <= 51_200
+
+
+# ===========================================================================
+# _fetch_nvd_cvss_vector
+# ===========================================================================
+
+
+def test_fetch_nvd_cvss_vector_success():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = _make_nvd_response(av="LOCAL", pr="HIGH")
+        mock_get.return_value.raise_for_status = MagicMock()
+        result = _fetch_nvd_cvss_vector("CVE-2024-1234")
+    assert result["attackVector"] == "LOCAL"
+    assert result["privilegesRequired"] == "HIGH"
+    assert result["baseScore"] == 9.8
+
+
+def test_fetch_nvd_cvss_vector_no_vulnerabilities():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value.raise_for_status = MagicMock()
+        result = _fetch_nvd_cvss_vector("CVE-2024-9999")
+    assert result == {}
+
+
+def test_fetch_nvd_cvss_vector_exception():
+    import requests
+
+    with patch("requests.get", side_effect=requests.RequestException("timeout")):
+        result = _fetch_nvd_cvss_vector("CVE-2024-1234")
+    assert result == {}
+
+
+def test_fetch_nvd_cvss_vector_falls_back_to_v30():
+    """Prefers v3.1; if absent, uses v3.0"""
+    nvd_data = {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "metrics": {
+                        "cvssMetricV30": [
+                            {
+                                "cvssData": {
+                                    "attackVector": "ADJACENT",
+                                    "privilegesRequired": "LOW",
+                                    "userInteraction": "REQUIRED",
+                                    "scope": "CHANGED",
+                                    "baseScore": 7.5,
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    }
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = nvd_data
+        mock_get.return_value.raise_for_status = MagicMock()
+        result = _fetch_nvd_cvss_vector("CVE-2024-1234")
+    assert result["attackVector"] == "ADJACENT"
+    assert result["baseScore"] == 7.5
+
+
+# ===========================================================================
+# _fetch_nvd_references
+# ===========================================================================
+
+
+def test_fetch_nvd_references_success():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = _make_nvd_response()
+        mock_get.return_value.raise_for_status = MagicMock()
+        refs = _fetch_nvd_references("CVE-2024-1234")
+    assert "https://github.com/org/repo/commit/abc123" in refs
+    assert "https://example.com/advisory" in refs
+
+
+def test_fetch_nvd_references_empty():
+    with patch("requests.get") as mock_get:
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value.raise_for_status = MagicMock()
+        refs = _fetch_nvd_references("CVE-2024-9999")
+    assert refs == []
+
+
+def test_fetch_nvd_references_exception():
+    import requests
+
+    with patch("requests.get", side_effect=requests.RequestException("timeout")):
+        refs = _fetch_nvd_references("CVE-2024-1234")
+    assert refs == []
+
+
+# ===========================================================================
+# Scoring helper unit tests
+# ===========================================================================
+
+
+class TestCountMatches:
+    def test_no_matches(self):
+        assert _count_matches("hello world", _AUTH_PATTERNS) == 0
+
+    def test_single_match(self):
+        code = "password = 'secret'"
+        count = _count_matches(code, _AUTH_PATTERNS)
+        assert count >= 1
+
+    def test_multiple_distinct_patterns(self):
+        code = "password = 'x'\napi_key = 'y'\ncookie = 'z'"
+        count = _count_matches(code, _AUTH_PATTERNS)
+        assert count >= 3
+
+
+class TestScoreLinesOfCode:
+    def test_tiny_script(self):
+        code = "\n".join(["line"] * 10)
+        assert _score_lines_of_code(code) == 1
+
+    def test_small_script(self):
+        code = "\n".join(["line"] * 50)
+        assert _score_lines_of_code(code) == 2
+
+    def test_medium_script(self):
+        code = "\n".join(["line"] * 150)
+        assert _score_lines_of_code(code) == 3
+
+    def test_large_script(self):
+        code = "\n".join(["line"] * 400)
+        assert _score_lines_of_code(code) == 4
+
+    def test_huge_script(self):
+        code = "\n".join(["line"] * 800)
+        assert _score_lines_of_code(code) == 5
+
+    def test_blank_and_comment_lines_not_counted(self):
+        code = "\n".join(["# comment"] * 10 + [""] * 10 + ["code"] * 5)
+        assert _score_lines_of_code(code) == 1
+
+
+class TestScoreAuthRequired:
+    def test_no_auth_network_nopriv(self):
+        code = "import socket\nsocket.connect(('target', 80))"
+        score = _score_auth_required(code, "NONE")
+        assert score == 1  # base=1, no auth patterns hit
+
+    def test_high_privilege_from_nvd(self):
+        code = "connect(target)"
+        score = _score_auth_required(code, "HIGH")
+        assert score >= 4
+
+    def test_auth_patterns_in_code_raise_score(self):
+        code = "password = args.password\napi_key = config.key\ncookie = resp.cookies"
+        score = _score_auth_required(code, "NONE")
+        assert score > 1
+
+    def test_max_capped_at_5(self):
+        code = "\n".join(
+            [
+                "password = 'x'",
+                "api_key = 'y'",
+                "auth_token = 'z'",
+                "session_id = 'a'",
+                "cookie = 'b'",
+                "jwt = 'c'",
+            ]
+        )
+        score = _score_auth_required(code, "HIGH")
+        assert score <= 5
+
+
+class TestScoreNetworkHops:
+    def test_physical_access_local(self):
+        code = "open('/dev/sda')"
+        score = _score_network_hops(code, "PHYSICAL")
+        assert score >= 4
+
+    def test_network_av_no_hops(self):
+        code = "print('hello')"
+        score = _score_network_hops(code, "NETWORK")
+        assert score == 1
+
+    def test_multiple_network_calls(self):
+        code = (
+            "requests.get(stage1_url)\n"
+            "requests.post(pivot_url)\n"
+            "socket.connect(c2)\n"
+            "reverse_shell(target)\n"
+        )
+        score = _score_network_hops(code, "NETWORK")
+        assert score > 1
+
+    def test_max_capped_at_5(self):
+        code = "\n".join(["requests.get(url)"] * 10 + ["socket.connect(x)"] * 10)
+        score = _score_network_hops(code, "PHYSICAL")
+        assert score <= 5
+
+
+class TestScoreOsDependencies:
+    def test_pure_python_no_os_deps(self):
+        code = "import json\ndata = json.loads(payload)"
+        assert _score_os_dependencies(code) == 1
+
+    def test_ctypes_and_struct(self):
+        code = "import ctypes\nstruct.pack('<I', addr)"
+        score = _score_os_dependencies(code)
+        assert score >= 2
+
+    def test_shellcode_and_rop(self):
+        code = "shellcode = b'\\x90\\x90'\nrop_chain = [gadget1, gadget2]\n"
+        score = _score_os_dependencies(code)
+        assert score >= 2
+
+    def test_max_capped_at_5(self):
+        code = (
+            "ctypes.cdll\nstruct.pack\nkallsyms_lookup\n"
+            "/proc/kallsyms\nGetProcAddress\nVirtualAlloc\nshellcode\nrop_chain\ngadget\n"
+        )
+        score = _score_os_dependencies(code)
+        assert score <= 5
+
+
+class TestScoreChainLength:
+    def test_simple_no_chain(self):
+        code = "socket.connect(target)\nsend(payload)"
+        score = _score_chain_length(code, ui_modifier=0)
+        assert score >= 1
+
+    def test_multi_stage_with_user_interaction(self):
+        code = (
+            "# stage 1: SSRF\n"
+            "# stage 2: credential leak\n"
+            "# lateral movement\n"
+            "# privilege escalation\n"
+            "# persistence\n"
+        )
+        score = _score_chain_length(code, ui_modifier=1)
+        assert score >= 3
+
+    def test_max_capped_at_5(self):
+        code = "\n".join(
+            [
+                "stage 1",
+                "stage 2",
+                "chain exploit",
+                "lateral movement",
+                "privilege escalation",
+                "persistence",
+                "sandbox escape",
+            ]
+        )
+        score = _score_chain_length(code, ui_modifier=1)
+        assert score <= 5
+
+
+class TestNvdOnlyComplexity:
+    def test_network_nopriv_noui(self):
+        cvss = {"attackVector": "NETWORK", "privilegesRequired": "NONE", "userInteraction": "NONE"}
+        dims = _nvd_only_complexity(cvss)
+        assert dims["auth_required"] == 1
+        assert dims["network_hops"] == 1
+        assert dims["chain_length"] == 1
+        assert dims["lines_of_code"] == 1
+        assert dims["os_dependencies"] == 1
+
+    def test_local_high_priv(self):
+        cvss = {"attackVector": "LOCAL", "privilegesRequired": "HIGH", "userInteraction": "REQUIRED"}
+        dims = _nvd_only_complexity(cvss)
+        assert dims["auth_required"] == 4
+        assert dims["network_hops"] == 4
+        assert dims["chain_length"] == 2  # ui modifier = 1
+
+    def test_physical_access(self):
+        cvss = {"attackVector": "PHYSICAL", "privilegesRequired": "NONE", "userInteraction": "NONE"}
+        dims = _nvd_only_complexity(cvss)
+        assert dims["network_hops"] == 5
+
+
+class TestComputeOverall:
+    def test_all_ones(self):
+        dims = {k: 1 for k in ("lines_of_code", "auth_required", "network_hops", "os_dependencies", "chain_length")}
+        score = _compute_overall(dims)
+        assert score == 1.0
+
+    def test_all_fives(self):
+        dims = {k: 5 for k in ("lines_of_code", "auth_required", "network_hops", "os_dependencies", "chain_length")}
+        score = _compute_overall(dims)
+        assert score == 5.0
+
+    def test_mixed(self):
+        dims = {
+            "lines_of_code": 2,
+            "auth_required": 3,
+            "network_hops": 1,
+            "os_dependencies": 4,
+            "chain_length": 2,
+        }
+        score = _compute_overall(dims)
+        assert 1.0 <= score <= 5.0
+
+
+class TestLabelFunctions:
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (1.0, "trivial"),
+            (1.5, "trivial"),
+            (1.6, "low"),
+            (2.5, "low"),
+            (2.6, "moderate"),
+            (3.5, "moderate"),
+            (3.6, "high"),
+            (4.5, "high"),
+            (4.6, "very_high"),
+            (5.0, "very_high"),
+        ],
+    )
+    def test_label(self, score, expected):
+        assert _label(score) == expected
+
+    @pytest.mark.parametrize(
+        "score,expected",
+        [
+            (1, "trivial"),
+            (2, "low"),
+            (3, "moderate"),
+            (4, "high"),
+            (5, "very_high"),
+        ],
+    )
+    def test_dimension_label(self, score, expected):
+        assert _dimension_label(score) == expected
+
+
+# ===========================================================================
+# _render_text
+# ===========================================================================
+
+
+def _make_result(
+    poc_found: bool = True,
+    score: float = 2.0,
+    label: str = "low",
+    poc_url: str | None = "https://github.com/user/poc",
+    poc_lines: int = 42,
+) -> dict:
+    return {
+        "cve_id": "CVE-2024-1234",
+        "complexity_score": score,
+        "complexity_label": label,
+        "attacker_friendly": score <= 2.5,
+        "dimensions": {
+            "lines_of_code": 2,
+            "auth_required": 1,
+            "network_hops": 2,
+            "os_dependencies": 1,
+            "chain_length": 2,
+        },
+        "cvss_available": True,
+        "poc_found": poc_found,
+        "poc_lines": poc_lines,
+        "poc_url": poc_url,
+        "cvss_base_score": 9.8,
+        "attack_vector": "NETWORK",
+        "privileges_required": "NONE",
+        "user_interaction": "NONE",
+    }
+
+
+def test_render_text_contains_cve():
+    result = _make_result()
+    text = _render_text(result)
+    assert "CVE-2024-1234" in text
+
+
+def test_render_text_attacker_friendly():
+    result = _make_result(score=2.0, label="low")
+    text = _render_text(result)
+    assert "YES" in text
+
+
+def test_render_text_not_attacker_friendly():
+    result = _make_result(score=3.5, label="moderate")
+    text = _render_text(result)
+    assert "NO" in text
+
+
+def test_render_text_includes_poc_lines():
+    result = _make_result(poc_found=True, poc_lines=99)
+    text = _render_text(result)
+    assert "99" in text
+
+
+def test_render_text_no_poc():
+    result = _make_result(poc_found=False, poc_lines=0, poc_url=None)
+    text = _render_text(result)
+    assert "NVD vector only" in text.lower() or "nvd" in text.lower()
+
+
+def test_render_text_includes_poc_url():
+    result = _make_result(poc_url="https://github.com/org/poc-repo")
+    text = _render_text(result)
+    assert "https://github.com/org/poc-repo" in text
+
+
+def test_render_text_all_dimensions_present():
+    result = _make_result()
+    text = _render_text(result)
+    assert "Lines of code" in text or "lines of code" in text.lower()
+    assert "Authentication" in text or "auth" in text.lower()
+    assert "Network" in text or "network" in text.lower()
+    assert "OS" in text or "platform" in text.lower()
+    assert "chain" in text.lower()
+
+
+# ===========================================================================
+# _run_scoring integration (fully mocked)
+# ===========================================================================
+
+
+def _mock_trickest_200(cve_id: str) -> str:
+    return f"# PoC for {cve_id}\nhttps://github.com/user/poc/blob/main/exploit.py\n"
+
+
+_SIMPLE_POC_CODE = (
+    "import socket\n"
+    "import requests\n"
+    "\n"
+    "target = '192.168.1.1'\n"
+    "payload = b'A' * 64\n"
+    "s = socket.socket()\n"
+    "s.connect((target, 9999))\n"
+    "s.send(payload)\n"
+    "print('done')\n"
+)
+
+
+def test_run_scoring_with_poc():
+    """Full pipeline: NVD CVSS + trickest PoC found."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_poc_code") as mock_poc,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "NETWORK",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "baseScore": 9.8,
+        }
+        mock_trick.return_value = _mock_trickest_200("CVE-2024-1234")
+        mock_poc.return_value = _SIMPLE_POC_CODE
+
+        result = _run_scoring("CVE-2024-1234")
+
+    assert result["cve_id"] == "CVE-2024-1234"
+    assert result["poc_found"] is True
+    assert result["poc_lines"] > 0
+    assert 1.0 <= result["complexity_score"] <= 5.0
+    assert result["complexity_label"] in ("trivial", "low", "moderate", "high", "very_high")
+    assert isinstance(result["attacker_friendly"], bool)
+    assert result["cvss_available"] is True
+
+
+def test_run_scoring_no_poc_falls_back_to_nvd():
+    """When trickest returns nothing and NVD refs have no PoC, use NVD-only scoring."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "NETWORK",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "baseScore": 9.8,
+        }
+        mock_trick.return_value = None
+        mock_refs.return_value = ["https://nvd.nist.gov/vuln/detail/CVE-2024-1234"]
+
+        result = _run_scoring("CVE-2024-1234")
+
+    assert result["poc_found"] is False
+    assert result["poc_lines"] == 0
+    assert result["poc_url"] is None
+    assert 1.0 <= result["complexity_score"] <= 5.0
+
+
+def test_run_scoring_no_nvd_data():
+    """When NVD is unavailable, scoring still returns a result."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {}
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+
+        result = _run_scoring("CVE-2024-1234")
+
+    assert result["cvss_available"] is False
+    assert result["poc_found"] is False
+    assert 1.0 <= result["complexity_score"] <= 5.0
+
+
+def test_run_scoring_cve_id_uppercased():
+    """CVE ID must be uppercased regardless of input."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {}
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+
+        result = _run_scoring("cve-2024-1234")
+
+    assert result["cve_id"] == "CVE-2024-1234"
+
+
+def test_run_scoring_nvd_fallback_after_trickest():
+    """When trickest has no PoC URLs that are candidates, fall back to NVD refs."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_poc_code") as mock_poc,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {"attackVector": "NETWORK", "privilegesRequired": "NONE", "userInteraction": "NONE"}
+        # Trickest markdown with only a non-candidate URL
+        mock_trick.return_value = "# PoC\nhttps://nvd.nist.gov/vuln/detail/CVE-2024-1234\n"
+        # NVD ref has a candidate
+        mock_refs.return_value = ["https://github.com/user/repo/blob/main/exploit.py"]
+        mock_poc.return_value = _SIMPLE_POC_CODE
+
+        result = _run_scoring("CVE-2024-1234")
+
+    assert result["poc_found"] is True
+
+
+def test_run_scoring_attacker_friendly_low_complexity():
+    """Network-reachable, no-priv, simple PoC → attacker_friendly=True."""
+    simple_poc = "\n".join([f"line_{i}" for i in range(20)])
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_poc_code") as mock_poc,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "NETWORK",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "baseScore": 9.8,
+        }
+        mock_trick.return_value = "https://github.com/user/poc/blob/main/x.py\n"
+        mock_poc.return_value = simple_poc
+
+        result = _run_scoring("CVE-2024-1234")
+
+    # Low complexity → attacker_friendly should be True
+    assert result["attacker_friendly"] == (result["complexity_score"] <= 2.5)
+
+
+def test_run_scoring_high_complexity_physical_highpriv():
+    """Physical access + high privileges + no PoC → high complexity."""
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "PHYSICAL",
+            "privilegesRequired": "HIGH",
+            "userInteraction": "REQUIRED",
+            "baseScore": 4.2,
+        }
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+
+        result = _run_scoring("CVE-2024-1234")
+
+    assert result["complexity_score"] > 2.5
+    assert result["attacker_friendly"] is False
+
+
+# ===========================================================================
+# Strands @tool entry point
+# ===========================================================================
+
+
+def test_score_exploit_complexity_text_output():
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "NETWORK",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "baseScore": 9.8,
+        }
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+        output = score_exploit_complexity("CVE-2024-1234", output="text")
+
+    assert "CVE-2024-1234" in output
+    assert "Exploit Complexity" in output
+
+
+def test_score_exploit_complexity_json_output():
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {
+            "attackVector": "NETWORK",
+            "privilegesRequired": "NONE",
+            "userInteraction": "NONE",
+            "baseScore": 9.8,
+        }
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+        output = score_exploit_complexity("CVE-2024-1234", output="json")
+
+    parsed = json.loads(output)
+    assert parsed["cve_id"] == "CVE-2024-1234"
+    assert "complexity_score" in parsed
+    assert "dimensions" in parsed
+    assert "attacker_friendly" in parsed
+
+
+def test_score_exploit_complexity_invalid_cve():
+    output = score_exploit_complexity("NOT-A-CVE")
+    assert "Error" in output
+
+
+def test_score_exploit_complexity_default_output_is_text():
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {}
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+        # output not specified → defaults to "text"
+        output = score_exploit_complexity("CVE-2024-1234")
+
+    assert "CVE-2024-1234" in output
+    # Should NOT be JSON
+    with pytest.raises((json.JSONDecodeError, ValueError)):
+        json.loads(output)
+
+
+# ===========================================================================
+# CLI tests
+# ===========================================================================
+
+
+def test_cli_exploit_complexity_help_exits_zero():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "manus_use.cli", "exploit-complexity", "--help"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0
+    assert "exploit-complexity" in result.stdout.lower() or "score" in result.stdout.lower()
+
+
+def test_cli_exploit_complexity_invalid_cve_exits_nonzero():
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "manus_use.cli", "exploit-complexity", "NOT-A-CVE"],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+
+
+def test_cli_exploit_complexity_registered_in_subcommands():
+    from manus_use.cli import _SUBCOMMANDS
+
+    assert "exploit-complexity" in _SUBCOMMANDS
+
+
+def test_build_exploit_complexity_parser():
+    from manus_use.cli import _build_exploit_complexity_parser
+
+    parser = _build_exploit_complexity_parser()
+    args = parser.parse_args(["CVE-2024-3094"])
+    assert args.cve_id == "CVE-2024-3094"
+    assert args.output == "text"
+
+
+def test_build_exploit_complexity_parser_json_output():
+    from manus_use.cli import _build_exploit_complexity_parser
+
+    parser = _build_exploit_complexity_parser()
+    args = parser.parse_args(["CVE-2024-3094", "--output", "json"])
+    assert args.output == "json"
+
+
+def test_run_exploit_complexity_text(monkeypatch):
+    from manus_use.cli import _run_exploit_complexity
+
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {}
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+        exit_code = _run_exploit_complexity(["CVE-2024-3094"])
+
+    assert exit_code == 0
+
+
+def test_run_exploit_complexity_json(monkeypatch, capsys):
+    from manus_use.cli import _run_exploit_complexity
+
+    with (
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_cvss_vector") as mock_cvss,
+        patch("manus_use.tools.score_exploit_complexity._fetch_trickest_markdown") as mock_trick,
+        patch("manus_use.tools.score_exploit_complexity._fetch_nvd_references") as mock_refs,
+    ):
+        mock_cvss.return_value = {"attackVector": "NETWORK", "privilegesRequired": "NONE", "userInteraction": "NONE"}
+        mock_trick.return_value = None
+        mock_refs.return_value = []
+        exit_code = _run_exploit_complexity(["CVE-2024-3094", "--output", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["cve_id"] == "CVE-2024-3094"
+
+
+def test_run_exploit_complexity_invalid_cve_exits_nonzero():
+    from manus_use.cli import _run_exploit_complexity
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_exploit_complexity(["NOT-A-CVE"])
+    assert exc_info.value.code != 0
+
+
+def test_cli_dispatch_exploit_complexity_in_main(monkeypatch):
+    """main() routes 'exploit-complexity' to _run_exploit_complexity."""
+    import sys
+
+    from manus_use import cli
+
+    called_with: list[list[str]] = []
+
+    def fake_run(argv: list[str]) -> int:
+        called_with.append(argv)
+        return 0
+
+    monkeypatch.setattr(cli, "_run_exploit_complexity", fake_run)
+    monkeypatch.setattr(sys, "argv", ["manus-use", "exploit-complexity", "CVE-2024-3094"])
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    assert called_with[0] == ["CVE-2024-3094"]
+
+
+# ===========================================================================
+# VI agent wiring
+# ===========================================================================
+
+
+def test_vi_agent_imports_score_exploit_complexity():
+    """score_exploit_complexity is importable from the tools package."""
+    from manus_use.tools.score_exploit_complexity import score_exploit_complexity as sec
+
+    assert callable(sec)
+
+
+def test_vi_agent_system_prompt_references_score_exploit_complexity():
+    from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "score_exploit_complexity" in SYSTEM_PROMPT
+
+
+def test_vi_agent_system_prompt_references_attacker_friendly():
+    from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "attacker_friendly" in SYSTEM_PROMPT
+
+
+def test_tool_spec_schema():
+    """TOOL_SPEC has the expected structure for Strands tool registration."""
+    from manus_use.tools.score_exploit_complexity import TOOL_SPEC
+
+    assert TOOL_SPEC["name"] == "score_exploit_complexity"
+    assert "inputSchema" in TOOL_SPEC
+    props = TOOL_SPEC["inputSchema"]["json"]["properties"]
+    assert "cve_id" in props
+    assert "output" in props
+    assert "cve_id" in TOOL_SPEC["inputSchema"]["json"]["required"]
+
+
+# ===========================================================================
+# README coverage
+# ===========================================================================
+
+
+def test_readme_documents_exploit_complexity():
+    import pathlib
+
+    readme = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+    assert readme.exists()
+    content = readme.read_text()
+    assert "exploit-complexity" in content
+
+
+def test_readme_exploit_complexity_documents_output_flag():
+    import pathlib
+
+    readme = pathlib.Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "--output" in content
+    assert "exploit-complexity" in content


### PR DESCRIPTION
## What & Why

Raw CVSS severity scores are a poor proxy for actual attacker effort. A CVSS 9.8 with a 20-line network-reachable exploit requiring no authentication is categorically different from a CVSS 9.8 requiring physical access, kernel debugging, and a multi-stage ROP chain. This PR closes that gap.

`manus-use exploit-complexity CVE-XXXX-YYYY` scores the **practical difficulty** of exploiting a CVE on a 1–5 scale (1 = trivial for an attacker, 5 = very hard to weaponise). It is a composable enrichment layer for the existing `analyze`, `epss-trend`, and `compare` commands.

## Changes

- **`src/manus_use/tools/score_exploit_complexity.py`** — two-stage scoring pipeline:
  1. NVD CVSS v3 vector fields (Attack Vector, Privileges Required, User Interaction) as baseline
  2. Static analysis of PoC source code (fetched from Trickest CVE index, falling back to NVD references) across five weighted dimensions:
     - **Lines of code** (0.15) — exploit size as a proxy for adaptability
     - **Authentication required** (0.25) — credential/privilege setup cost
     - **Network hops** (0.20) — number of remote services to reach
     - **OS/platform dependencies** (0.15) — kernel structs, shellcode, ROP gadgets
     - **Exploit chain length** (0.25) — discrete attack stages
  - Falls back to NVD-only scoring when no public PoC is found
  - `attacker_friendly` boolean (True when overall score ≤ 2.5)
  - Labels: trivial / low / moderate / high / very_high

- **`manus-use exploit-complexity CVE-XXXX-YYYY`** CLI subcommand — `--output {text,json}` support

- **VI agent wiring** — `score_exploit_complexity` added to `VulnerabilityIntelligenceAgent` tool list + new Step 6b in system prompt directing the agent to score and flag `attacker_friendly=true` prominently

- **`README.md`** — new CLI reference section with dimension breakdown table and examples

## Tests

108 new tests in `tests/test_exploit_complexity.py` — all HTTP calls mocked, zero real network I/O.

**658 total tests pass, 3 deselected (integration), 0 failed.** (up from 550)

## Usage

```bash
# Text output (default)
manus-use exploit-complexity CVE-2024-3094

# Machine-readable
manus-use exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
manus-use exploit-complexity CVE-2024-3094 --output json | jq .dimensions
```