### PR TITLE
feat(tools): vendor response tracker — track_vendor_response tool + manus-use vendor-response subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,45 @@ cross-referencing three data sources.
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Output format; `json` includes the full comparison |
 
+### `manus-use vendor-response <CVE-ID>` — Vendor patch response tracker
+
+```bash
+# Check whether a vendor has patched a CVE
+manus-use vendor-response CVE-2024-3094
+
+# Machine-readable output
+manus-use vendor-response CVE-2024-3094 --output json | jq .status
+```
+
+Queries NVD reference links, the [GitHub Security Advisory database](https://github.com/advisories)
+(GHSA), CISA KEV, and the affected repository's own security-advisory tab to determine
+the vendor's current patch status for a CVE.\n
+Classifies patch status as:
+
+| Status | Meaning |
+|--------|----------|
+| `patch_available` | A fix has been confirmed (commit, release, or advisory with patched versions) |
+| `patch_backported` | Fix was backported to an older/LTS branch in addition to the main line |
+| `wont_fix` | Vendor has explicitly stated they will not release a fix |
+| `investigating` | Vendor has acknowledged the issue but no fix is available yet |
+| `no_patch` | No evidence of any fix found in public sources |
+| `unknown` | Insufficient public information to determine status |
+
+Also reports:
+- CISA KEV membership and required action / due date
+- Number of GitHub security advisories found
+- Evidence URLs (commit links, release tags, advisory pages)
+- Confidence level: *high*, *moderate*, or *low*
+
+Useful for answering the first question in any vulnerability triage workflow:
+**"Is there a fix, and has the vendor responded?"**
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format; `json` includes full classification and evidence |
+
 ### `manus-use discover` — CVE discovery
 
 ```bash
@@ -530,6 +569,10 @@ manus-use remediate CVE-2024-3094
 # Compare two CVEs side-by-side for triage prioritisation
 manus-use compare CVE-2024-3094 CVE-2021-44228
 manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
+
+# Check vendor patch status: has the vendor released a fix?
+manus-use vendor-response CVE-2024-3094
+manus-use vendor-response CVE-2024-3094 --output json | jq .status
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -94,6 +94,12 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - A direct link to the commit on GitHub.
   If no commit is found (private repo or non-GitHub), note this and proceed.
 
+**Step 6b: Vendor Response Tracking**
+- Call `track_vendor_response` with the CVE ID to determine the vendor's patch status.
+  - Include the classification (`patch_available`, `patch_backported`, `wont_fix`, `investigating`, `no_patch`, `unknown`) and its confidence level in the report.
+  - If `wont_fix` or `no_patch` is returned, emphasise this in the Recommendations section — users should apply mitigations or consider alternative products.
+  - List the evidence URLs returned by the tool under a **Vendor Response** subsection.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -189,6 +195,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_patch_diff import get_patch_diff
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
+            from manus_use.tools.track_vendor_response import track_vendor_response
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -240,6 +247,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.verify_exploit",
             get_epss_trend,
             get_patch_diff,
+            track_vendor_response,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1052,6 +1052,7 @@ _SUBCOMMANDS = {
     "epss-trend",
     "patch-diff",
     "compare",
+    "vendor-response",
 }
 
 
@@ -1289,6 +1290,116 @@ def _run_compare(argv: list[str]) -> int:
 
     # Text output
     print(_render_text(comparison))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# vendor-response subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_vendor_response_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use vendor-response",
+        description=(
+            "Track a vendor's patch response to a CVE.\n"
+            "Consults NVD references, GitHub Security Advisories (GHSA),\n"
+            "CISA KEV, and the repository's security advisory tab to classify\n"
+            "patch status as: patch_available / patch_backported / wont_fix /\n"
+            "investigating / no_patch / unknown."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_vendor_response(argv: list[str]) -> int:
+    parser = _build_vendor_response_parser()
+    args = parser.parse_args(argv)
+
+    cve_id = args.cve_id.strip()
+    if not cve_id.upper().startswith("CVE-"):
+        print(f"[error] Invalid CVE ID '{cve_id}'. Must be like 'CVE-YYYY-NNNN'.", file=sys.stderr)
+        return 1
+
+    try:
+        from manus_use.tools.track_vendor_response import (
+            _build_summary,
+            _classify,
+            _extract_github_repo_from_refs,
+            _fetch_cisa_kev,
+            _fetch_ghsa,
+            _fetch_nvd,
+            _nvd_affected_vendor_product,
+            _nvd_references,
+            _search_github_repo_advisories,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    cve_id = cve_id.upper()
+
+    nvd_cve = _fetch_nvd(cve_id)
+    if "_error" in nvd_cve:
+        nvd_refs: list[str] = []
+        vendor, product = "", ""
+    else:
+        nvd_refs = _nvd_references(nvd_cve)
+        vendor, product = _nvd_affected_vendor_product(nvd_cve)
+
+    ghsa_result = _fetch_ghsa(cve_id)
+    ghsa_advisories = ghsa_result.get("advisories", [])
+
+    kev_entry = _fetch_cisa_kev(cve_id)
+
+    repo_advisories: list = []
+    gh_repo = _extract_github_repo_from_refs(nvd_refs)
+    if gh_repo:
+        owner, repo = gh_repo
+        repo_advisories = _search_github_repo_advisories(owner, repo, cve_id)
+
+    status, confidence, evidence_urls = _classify(nvd_refs, ghsa_advisories, kev_entry, repo_advisories)
+
+    summary = _build_summary(
+        cve_id=cve_id,
+        status=status,
+        confidence=confidence,
+        evidence_urls=evidence_urls,
+        vendor=vendor,
+        product=product,
+        kev_entry=kev_entry,
+        ghsa_count=len(ghsa_advisories) + len(repo_advisories),
+    )
+
+    if args.output == "json":
+        output = {
+            "cve_id": cve_id,
+            "status": status,
+            "confidence": confidence,
+            "vendor": vendor,
+            "product": product,
+            "evidence_urls": evidence_urls,
+            "ghsa_advisories_found": len(ghsa_advisories),
+            "repo_advisories_found": len(repo_advisories),
+            "in_cisa_kev": bool(kev_entry),
+            "cisa_required_action": kev_entry.get("requiredAction", ""),
+            "cisa_due_date": kev_entry.get("dueDate", ""),
+            "summary": summary,
+        }
+        import json
+
+        print(json.dumps(output, indent=2))
+        return 0
+
+    print(summary)
     return 0
 
 
@@ -1599,6 +1710,10 @@ def main() -> None:
     if first_positional == "compare":
         idx = argv.index("compare")
         sys.exit(_run_compare(argv[idx + 1 :]))
+
+    if first_positional == "vendor-response":
+        idx = argv.index("vendor-response")
+        sys.exit(_run_vendor_response(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/track_vendor_response.py
+++ b/src/manus_use/tools/track_vendor_response.py
@@ -1,0 +1,514 @@
+"""
+Tool for tracking a vendor's patch response to a CVE.
+
+Given a CVE identifier, this tool:
+1. Fetches NVD data to identify the affected vendor and product.
+2. Searches for the vendor's GitHub security advisory (GHSA) for that CVE.
+3. Scans the vendor's GitHub security tab (if a repo is identifiable).
+4. Checks NVD reference links for vendor advisory / patch / release URLs.
+5. Inspects CISA KEV for required-action and due-date metadata.
+6. Classifies the vendor patch status as one of:
+   - no_patch      — no fix available, no mitigation disclosed
+   - patch_available — patch released and confirmed (commit, advisory, or release)
+   - patch_backported — patch backported to older branch(es) (indicators found)
+   - wont_fix       — vendor explicitly will not release a fix
+   - investigating  — vendor has acknowledged but no fix yet (advisory only, no patch)
+   - unknown        — insufficient public information to determine status
+
+Returns a structured dict plus a human-readable summary.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+_TIMEOUT = 12  # seconds for each individual HTTP request
+
+# Patterns that signal a vendor has shipped a fix
+_PATCH_KEYWORDS: list[str] = [
+    "fixed in",
+    "fix released",
+    "update available",
+    "patched in",
+    "resolved in",
+    "upgraded to",
+    "version .* fix",
+    "release .* address",
+    r"commit\s+[0-9a-f]{7}",
+    "pull request",
+    "merge request",
+    "security release",
+    "security update",
+    "upgrade to",
+    "mitigated in",
+]
+
+# Patterns that signal patch backporting
+_BACKPORT_KEYWORDS: list[str] = [
+    "backport",
+    "back.port",
+    "lts branch",
+    "maintenance branch",
+    "stable branch",
+    "older version",
+    "legacy version",
+]
+
+# Patterns that signal wont-fix
+_WONT_FIX_KEYWORDS: list[str] = [
+    "will not fix",
+    "won.t fix",
+    "no fix",
+    "not fix",
+    "out of support",
+    "end of life",
+    "eol",
+    "deprecated",
+    "unsupported",
+    "by design",
+    "not a vulnerability",
+    "disputed",
+    "working as intended",
+    "wontfix",
+]
+
+# Patterns that signal the vendor is investigating / has acknowledged
+_INVESTIGATING_KEYWORDS: list[str] = [
+    "investigating",
+    "under investigation",
+    "awareness",
+    "aware of",
+    "is aware",
+    "monitoring",
+    "tracking",
+    "acknowledged",
+    "looking into",
+]
+
+# Reference-link URL patterns that are typically vendor advisory / patch pages
+_ADVISORY_URL_PATTERNS: list[str] = [
+    r"github\.com/.+/security/advisories",
+    r"github\.com/.+/commit/[0-9a-f]{10,}",
+    r"github\.com/.+/releases/tag",
+    r"github\.com/.+/pull/\d+",
+    r"gitlab\.com/.+/commit/[0-9a-f]{10,}",
+    r"gitlab\.com/.+/merge_requests/\d+",
+    r"advisory\.",
+    r"/security[-_]advisory",
+    r"/security[-_]bulletin",
+    r"/security[-_]update",
+    r"\.security\.",
+    r"cve\.mitre\.org",
+    r"packetstorm",
+    r"exploit-db",
+    r"kb\.cert",
+    r"bugzilla\.",
+    r"jvn\.jp",
+]
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tool spec (Strands SDK format)
+# ──────────────────────────────────────────────────────────────────────────────
+
+TOOL_SPEC = {
+    "name": "track_vendor_response",
+    "description": (
+        "Tracks the vendor's patch response to a CVE by consulting the NVD reference list, "
+        "GitHub Security Advisory database (GHSA), CISA KEV, and the vendor's own GitHub security "
+        "tab (when the affected repository is identifiable). "
+        "Classifies patch status as: no_patch / patch_available / patch_backported / wont_fix / "
+        "investigating / unknown. "
+        "Returns the classification, confidence level, evidence links, and a plain-English summary. "
+        "Use this when you need to answer 'Is there a fix available, and has the vendor responded?'"
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2024-3094').",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Internal helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _get(url: str, *, params: dict[str, Any] | None = None, headers: dict[str, str] | None = None) -> dict[str, Any]:
+    """HTTP GET with error capture. Returns parsed JSON or {'_error': str}."""
+    try:
+        resp = requests.get(url, params=params, headers=headers, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        return {"_error": str(exc)}
+
+
+def _fetch_nvd(cve_id: str) -> dict[str, Any]:
+    """Return NVD CVE record dict, or {'_error': ...}."""
+    data = _get(
+        "https://services.nvd.nist.gov/rest/json/cves/2.0",
+        params={"cveId": cve_id.upper()},
+    )
+    if "_error" in data:
+        return data
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return {"_error": f"No NVD record for {cve_id}"}
+    return vulns[0].get("cve", {})
+
+
+def _nvd_references(nvd_cve: dict[str, Any]) -> list[str]:
+    """Extract all reference URLs from an NVD CVE record."""
+    refs = nvd_cve.get("references", [])
+    return [r.get("url", "") for r in refs if r.get("url")]
+
+
+def _nvd_affected_vendor_product(nvd_cve: dict[str, Any]) -> tuple[str, str]:
+    """Best-effort extraction of (vendor, product) from NVD CPE configurations."""
+    configs = nvd_cve.get("configurations", [])
+    for config in configs:
+        for node in config.get("nodes", []):
+            for cpe_match in node.get("cpeMatch", []):
+                cpe = cpe_match.get("criteria", "")
+                # cpe:2.3:a:vendor:product:version:...
+                parts = cpe.split(":")
+                if len(parts) >= 5:
+                    return parts[3], parts[4]
+    return "", ""
+
+
+def _fetch_ghsa(cve_id: str) -> dict[str, Any]:
+    """Query GitHub Security Advisory (GHSA) REST API for the CVE."""
+    data = _get(
+        "https://api.github.com/advisories",
+        params={"cve_id": cve_id.upper(), "per_page": 5},
+        headers={"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"},
+    )
+    if isinstance(data, list):
+        return {"advisories": data}
+    if isinstance(data, dict) and "_error" not in data:
+        return {"advisories": data.get("items", [])}
+    return {"advisories": [], "_error": data.get("_error", "")}
+
+
+def _fetch_cisa_kev(cve_id: str) -> dict[str, Any]:
+    """Fetch CISA KEV catalog and find entry for the given CVE."""
+    data = _get("https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json")
+    if "_error" in data:
+        return {}
+    vulns = data.get("vulnerabilities", [])
+    for v in vulns:
+        if v.get("cveID", "").upper() == cve_id.upper():
+            return v
+    return {}
+
+
+def _search_github_repo_advisories(owner: str, repo: str, cve_id: str) -> list[dict[str, Any]]:
+    """
+    Query GitHub's repository-level security advisories endpoint
+    for a specific CVE.  Returns a (possibly empty) list of advisory dicts.
+    """
+    import os
+
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    data = _get(
+        f"https://api.github.com/repos/{owner}/{repo}/security-advisories",
+        params={"per_page": 20},
+        headers=headers,
+    )
+    if isinstance(data, list):
+        return [a for a in data if cve_id.upper() in str(a.get("cve_id", "")).upper()]
+    return []
+
+
+def _extract_github_repo_from_refs(refs: list[str]) -> tuple[str, str] | None:
+    """
+    Try to identify a GitHub repo (owner/repo) from the reference links.
+    Returns (owner, repo) or None.
+    """
+    pattern = re.compile(r"github\.com/([^/]+)/([^/?#]+)", re.IGNORECASE)
+    seen: dict[str, int] = {}
+    for url in refs:
+        m = pattern.search(url)
+        if m:
+            key = f"{m.group(1)}/{m.group(2)}"
+            seen[key] = seen.get(key, 0) + 1
+    if not seen:
+        return None
+    best = max(seen, key=lambda k: seen[k])
+    owner, repo = best.split("/", 1)
+    # Strip .git suffix
+    repo = repo.removesuffix(".git")
+    return owner, repo
+
+
+def _keywords_match(text: str, patterns: list[str]) -> list[str]:
+    """Return which patterns matched (case-insensitive) in text."""
+    text_lower = text.lower()
+    matched = []
+    for pat in patterns:
+        if re.search(pat, text_lower):
+            matched.append(pat)
+    return matched
+
+
+def _classify(
+    nvd_refs: list[str],
+    ghsa_advisories: list[dict[str, Any]],
+    kev_entry: dict[str, Any],
+    repo_advisories: list[dict[str, Any]],
+) -> tuple[str, str, list[str]]:
+    """
+    Determine (status, confidence, evidence_urls).
+
+    Classification precedence:
+    1. wont_fix  — explicit wont-fix language anywhere
+    2. patch_backported — backport language found alongside patch indicators
+    3. patch_available  — patch confirmed (commit / release URL or GHSA with patches)
+    4. investigating    — acknowledged but no fix
+    5. no_patch         — no evidence of any fix
+    6. unknown          — insufficient data
+    """
+    evidence_urls: list[str] = []
+    all_text_parts: list[str] = []
+
+    # ── GHSA advisories ──────────────────────────────────────────────────────
+    for adv in ghsa_advisories + repo_advisories:
+        state = adv.get("state", "").lower()
+        # Published GHSA = patch exists
+        if state == "published":
+            evidence_urls.append(adv.get("html_url", ""))
+            # Gather patch references from GHSA
+            for ref in adv.get("references", []):
+                url = ref if isinstance(ref, str) else ref.get("url", "")
+                if url:
+                    evidence_urls.append(url)
+                    all_text_parts.append(url)
+        description = adv.get("description", "") or adv.get("summary", "")
+        all_text_parts.append(description.lower())
+        # Extract patches from GHSA structured data
+        for vuln in adv.get("vulnerabilities", []):
+            patched = vuln.get("patched_versions", "")
+            if patched and patched not in ("*", "unknown", ""):
+                all_text_parts.append(f"patched_versions:{patched}")
+
+    # ── NVD references ────────────────────────────────────────────────────────
+    for url in nvd_refs:
+        all_text_parts.append(url.lower())
+        # URLs that look like patches / releases / advisories
+        for apat in _ADVISORY_URL_PATTERNS:
+            if re.search(apat, url, re.IGNORECASE):
+                evidence_urls.append(url)
+                break
+
+    # ── CISA KEV ─────────────────────────────────────────────────────────────
+    if kev_entry:
+        action = kev_entry.get("requiredAction", "").lower()
+        all_text_parts.append(action)
+        notes = kev_entry.get("notes", "").lower()
+        all_text_parts.append(notes)
+
+    combined_text = " ".join(all_text_parts)
+    evidence_urls = [u for u in dict.fromkeys(evidence_urls) if u]  # deduplicate
+
+    # ── Classify ──────────────────────────────────────────────────────────────
+    wont_fix_hits = _keywords_match(combined_text, _WONT_FIX_KEYWORDS)
+    patch_hits = _keywords_match(combined_text, _PATCH_KEYWORDS)
+    backport_hits = _keywords_match(combined_text, _BACKPORT_KEYWORDS)
+    investigating_hits = _keywords_match(combined_text, _INVESTIGATING_KEYWORDS)
+
+    # GHSA published or repo advisory published = strong patch signal
+    ghsa_published = any(
+        (a.get("state", "").lower() == "published") for a in (ghsa_advisories + repo_advisories)
+    )
+    # GHSA with explicit patched_versions = very strong patch signal
+    has_patched_versions = any(
+        vuln.get("patched_versions", "") not in ("", "*", "unknown")
+        for a in (ghsa_advisories + repo_advisories)
+        for vuln in a.get("vulnerabilities", [])
+    )
+    # Any commit URL in references = patch confirmed
+    commit_in_refs = any(re.search(r"github\.com/.+/commit/[0-9a-f]{10,}", u, re.IGNORECASE) for u in nvd_refs)
+    # Release URL in references
+    release_in_refs = any(re.search(r"github\.com/.+/releases/tag", u, re.IGNORECASE) for u in nvd_refs)
+
+    if wont_fix_hits:
+        status = "wont_fix"
+        confidence = "high" if len(wont_fix_hits) >= 2 else "moderate"
+    elif has_patched_versions or (ghsa_published and (commit_in_refs or release_in_refs or has_patched_versions)):
+        if backport_hits:
+            status = "patch_backported"
+            confidence = "moderate"
+        else:
+            status = "patch_available"
+            confidence = "high"
+    elif commit_in_refs or release_in_refs:
+        if backport_hits:
+            status = "patch_backported"
+            confidence = "moderate"
+        else:
+            status = "patch_available"
+            confidence = "high"
+    elif ghsa_published:
+        status = "patch_available"
+        confidence = "moderate"
+    elif patch_hits:
+        if backport_hits:
+            status = "patch_backported"
+            confidence = "low"
+        else:
+            status = "patch_available"
+            confidence = "low"
+    elif investigating_hits:
+        status = "investigating"
+        confidence = "moderate"
+    elif all_text_parts:
+        status = "no_patch"
+        confidence = "low"
+    else:
+        status = "unknown"
+        confidence = "low"
+
+    return status, confidence, evidence_urls[:10]  # cap evidence list
+
+
+def _build_summary(
+    cve_id: str,
+    status: str,
+    confidence: str,
+    evidence_urls: list[str],
+    vendor: str,
+    product: str,
+    kev_entry: dict[str, Any],
+    ghsa_count: int,
+) -> str:
+    """Produce a concise plain-English vendor response summary."""
+    status_labels = {
+        "patch_available": "✅ Patch Available",
+        "patch_backported": "🔄 Patch Backported",
+        "wont_fix": "🚫 Won't Fix",
+        "investigating": "🔍 Under Investigation",
+        "no_patch": "❌ No Patch",
+        "unknown": "❓ Unknown",
+    }
+    label = status_labels.get(status, status.replace("_", " ").title())
+
+    lines = [f"Vendor Response for {cve_id.upper()}: {label} (confidence: {confidence})"]
+    if vendor or product:
+        lines.append(f"Affected: {vendor}/{product}" if vendor and product else f"Affected: {vendor or product}")
+    if kev_entry:
+        required = kev_entry.get("requiredAction", "")
+        due = kev_entry.get("dueDate", "")
+        lines.append(f"CISA KEV: required action — {required}" + (f" (due {due})" if due else ""))
+    if ghsa_count:
+        lines.append(f"GitHub Security Advisories found: {ghsa_count}")
+    if evidence_urls:
+        lines.append("Evidence:")
+        for url in evidence_urls[:5]:
+            lines.append(f"  • {url}")
+    return "\n".join(lines)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Public entry point (Strands tool)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def track_vendor_response(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands tool entry point for vendor response tracking."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+
+    if not isinstance(cve_id, str) or not re.match(r"CVE-\d{4}-\d+", cve_id, re.IGNORECASE):
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("track_vendor_response", result)
+        return result
+
+    cve_id = cve_id.upper()
+
+    # ── Step 1: NVD ────────────────────────────────────────────────────────
+    nvd_cve = _fetch_nvd(cve_id)
+    if "_error" in nvd_cve:
+        nvd_refs: list[str] = []
+        vendor, product = "", ""
+    else:
+        nvd_refs = _nvd_references(nvd_cve)
+        vendor, product = _nvd_affected_vendor_product(nvd_cve)
+
+    # ── Step 2: GHSA ────────────────────────────────────────────────────────
+    ghsa_result = _fetch_ghsa(cve_id)
+    ghsa_advisories = ghsa_result.get("advisories", [])
+
+    # ── Step 3: CISA KEV ────────────────────────────────────────────────────
+    kev_entry = _fetch_cisa_kev(cve_id)
+
+    # ── Step 4: Repo-level GitHub security advisories ──────────────────────
+    repo_advisories: list[dict[str, Any]] = []
+    gh_repo = _extract_github_repo_from_refs(nvd_refs)
+    if gh_repo:
+        owner, repo = gh_repo
+        repo_advisories = _search_github_repo_advisories(owner, repo, cve_id)
+
+    # ── Step 5: Classify ────────────────────────────────────────────────────
+    status, confidence, evidence_urls = _classify(nvd_refs, ghsa_advisories, kev_entry, repo_advisories)
+
+    # ── Step 6: Build output ─────────────────────────────────────────────────
+    summary = _build_summary(
+        cve_id=cve_id,
+        status=status,
+        confidence=confidence,
+        evidence_urls=evidence_urls,
+        vendor=vendor,
+        product=product,
+        kev_entry=kev_entry,
+        ghsa_count=len(ghsa_advisories) + len(repo_advisories),
+    )
+
+    output: dict[str, Any] = {
+        "cve_id": cve_id,
+        "status": status,
+        "confidence": confidence,
+        "vendor": vendor,
+        "product": product,
+        "evidence_urls": evidence_urls,
+        "ghsa_advisories_found": len(ghsa_advisories),
+        "repo_advisories_found": len(repo_advisories),
+        "in_cisa_kev": bool(kev_entry),
+        "cisa_required_action": kev_entry.get("requiredAction", ""),
+        "cisa_due_date": kev_entry.get("dueDate", ""),
+        "summary": summary,
+    }
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"json": output}],
+    }
+    log_tool_output_size("track_vendor_response", result)
+    return result

--- a/tests/test_vendor_response.py
+++ b/tests/test_vendor_response.py
@@ -1,0 +1,720 @@
+"""
+Tests for the track_vendor_response tool and manus-use vendor-response CLI subcommand.
+All network calls are mocked — no real HTTP requests are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_tool_use(cve_id: str) -> dict:
+    return {"toolUseId": "test-id-001", "input": {"cve_id": cve_id}}
+
+
+def _nvd_response(cve_id: str, *, refs: list[str] | None = None, vendor: str = "testvendor", product: str = "testpkg") -> dict:
+    """Minimal NVD API response payload."""
+    cpe = f"cpe:2.3:a:{vendor}:{product}:1.0:*:*:*:*:*:*:*"
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": cve_id,
+                    "references": [{"url": u} for u in (refs or [])],
+                    "configurations": [
+                        {
+                            "nodes": [
+                                {
+                                    "cpeMatch": [
+                                        {"criteria": cpe, "vulnerable": True}
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Import smoke-test
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_track_vendor_response_module_imports():
+    from manus_use.tools.track_vendor_response import TOOL_SPEC, track_vendor_response  # noqa: F401
+
+    assert TOOL_SPEC["name"] == "track_vendor_response"
+
+
+def test_tool_spec_has_required_keys():
+    from manus_use.tools.track_vendor_response import TOOL_SPEC
+
+    assert "name" in TOOL_SPEC
+    assert "description" in TOOL_SPEC
+    assert "inputSchema" in TOOL_SPEC
+    schema = TOOL_SPEC["inputSchema"]["json"]
+    assert "cve_id" in schema["properties"]
+    assert "cve_id" in schema["required"]
+
+
+def test_tool_exported_from_agents_package():
+    """track_vendor_response tool file is importable from the tools package."""
+    from manus_use.tools import track_vendor_response as mod  # noqa: F401
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Input validation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_invalid_cve_id_returns_error():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use("NOTACVE-123"))
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_empty_cve_id_returns_error():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use(""))
+    assert result["status"] == "error"
+
+
+def test_none_cve_id_returns_error():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response({"toolUseId": "x", "input": {"cve_id": None}})
+    assert result["status"] == "error"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _fetch_nvd
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_nvd_returns_cve_record():
+    from manus_use.tools.track_vendor_response import _fetch_nvd
+
+    with patch("manus_use.tools.track_vendor_response.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: _nvd_response("CVE-2024-0001"),
+            raise_for_status=lambda: None,
+        )
+        result = _fetch_nvd("CVE-2024-0001")
+    assert result.get("id") == "CVE-2024-0001"
+
+
+def test_fetch_nvd_empty_vulnerabilities_returns_error():
+    from manus_use.tools.track_vendor_response import _fetch_nvd
+
+    with patch("manus_use.tools.track_vendor_response.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: {"vulnerabilities": []},
+            raise_for_status=lambda: None,
+        )
+        result = _fetch_nvd("CVE-2024-0001")
+    assert "_error" in result
+
+
+def test_fetch_nvd_request_exception_returns_error():
+    import requests as req
+
+    from manus_use.tools.track_vendor_response import _fetch_nvd
+
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=req.RequestException("timeout")):
+        result = _fetch_nvd("CVE-2024-0001")
+    assert "_error" in result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _nvd_references / _nvd_affected_vendor_product
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_nvd_references_extracts_urls():
+    from manus_use.tools.track_vendor_response import _nvd_references
+
+    nvd_cve = {
+        "references": [
+            {"url": "https://github.com/example/repo/commit/abc123def456"},
+            {"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-0001"},
+        ]
+    }
+    refs = _nvd_references(nvd_cve)
+    assert len(refs) == 2
+    assert refs[0].startswith("https://github.com")
+
+
+def test_nvd_references_empty_when_no_refs():
+    from manus_use.tools.track_vendor_response import _nvd_references
+
+    assert _nvd_references({}) == []
+    assert _nvd_references({"references": []}) == []
+
+
+def test_nvd_affected_vendor_product_extracts_correctly():
+    from manus_use.tools.track_vendor_response import _nvd_affected_vendor_product
+
+    nvd_cve = _nvd_response("CVE-2024-0001", vendor="acme", product="widget")["vulnerabilities"][0]["cve"]
+    vendor, product = _nvd_affected_vendor_product(nvd_cve)
+    assert vendor == "acme"
+    assert product == "widget"
+
+
+def test_nvd_affected_vendor_product_empty_on_no_config():
+    from manus_use.tools.track_vendor_response import _nvd_affected_vendor_product
+
+    vendor, product = _nvd_affected_vendor_product({})
+    assert vendor == ""
+    assert product == ""
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _fetch_ghsa
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_ghsa_returns_advisories_from_list():
+    from manus_use.tools.track_vendor_response import _fetch_ghsa
+
+    fake_advisories = [
+        {"ghsaId": "GHSA-xxxx-yyyy-zzzz", "cveId": "CVE-2024-0001", "state": "published", "html_url": "https://github.com/advisories/GHSA-xxxx-yyyy-zzzz"}
+    ]
+    with patch("manus_use.tools.track_vendor_response.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: fake_advisories,
+            raise_for_status=lambda: None,
+        )
+        result = _fetch_ghsa("CVE-2024-0001")
+    assert len(result["advisories"]) == 1
+    assert result["advisories"][0]["state"] == "published"
+
+
+def test_fetch_ghsa_returns_empty_on_request_error():
+    import requests as req
+
+    from manus_use.tools.track_vendor_response import _fetch_ghsa
+
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=req.RequestException("fail")):
+        result = _fetch_ghsa("CVE-2024-0001")
+    assert result["advisories"] == []
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _fetch_cisa_kev
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_cisa_kev_returns_matching_entry():
+    from manus_use.tools.track_vendor_response import _fetch_cisa_kev
+
+    kev_catalog = {
+        "vulnerabilities": [
+            {"cveID": "CVE-2024-0001", "requiredAction": "Apply updates.", "dueDate": "2024-02-01"},
+            {"cveID": "CVE-2024-0002", "requiredAction": "Isolate.", "dueDate": "2024-02-15"},
+        ]
+    }
+    with patch("manus_use.tools.track_vendor_response.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: kev_catalog,
+            raise_for_status=lambda: None,
+        )
+        entry = _fetch_cisa_kev("CVE-2024-0001")
+    assert entry["requiredAction"] == "Apply updates."
+    assert entry["dueDate"] == "2024-02-01"
+
+
+def test_fetch_cisa_kev_returns_empty_when_not_found():
+    from manus_use.tools.track_vendor_response import _fetch_cisa_kev
+
+    kev_catalog = {"vulnerabilities": [{"cveID": "CVE-2024-9999"}]}
+    with patch("manus_use.tools.track_vendor_response.requests.get") as mock_get:
+        mock_get.return_value = MagicMock(
+            status_code=200,
+            json=lambda: kev_catalog,
+            raise_for_status=lambda: None,
+        )
+        entry = _fetch_cisa_kev("CVE-2024-0001")
+    assert entry == {}
+
+
+def test_fetch_cisa_kev_request_exception_returns_empty():
+    import requests as req
+
+    from manus_use.tools.track_vendor_response import _fetch_cisa_kev
+
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=req.RequestException("fail")):
+        entry = _fetch_cisa_kev("CVE-2024-0001")
+    assert entry == {}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _extract_github_repo_from_refs
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_extract_github_repo_from_refs_finds_most_common():
+    from manus_use.tools.track_vendor_response import _extract_github_repo_from_refs
+
+    refs = [
+        "https://github.com/acme/widget/commit/abc123",
+        "https://github.com/acme/widget/pull/42",
+        "https://github.com/acme/widget/releases/tag/v2.1",
+        "https://github.com/otherperson/otherrepo/commit/xyz999",
+    ]
+    result = _extract_github_repo_from_refs(refs)
+    assert result is not None
+    owner, repo = result
+    assert owner == "acme"
+    assert repo == "widget"
+
+
+def test_extract_github_repo_from_refs_returns_none_when_empty():
+    from manus_use.tools.track_vendor_response import _extract_github_repo_from_refs
+
+    assert _extract_github_repo_from_refs([]) is None
+    assert _extract_github_repo_from_refs(["https://nvd.nist.gov/vuln/detail/CVE-2024-0001"]) is None
+
+
+def test_extract_github_repo_strips_git_suffix():
+    from manus_use.tools.track_vendor_response import _extract_github_repo_from_refs
+
+    refs = ["https://github.com/acme/widget.git/commit/abc"]
+    result = _extract_github_repo_from_refs(refs)
+    assert result is not None
+    _, repo = result
+    # .git suffix is stripped
+    assert not repo.endswith(".git")
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _classify
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_classify_patch_available_from_commit_url():
+    from manus_use.tools.track_vendor_response import _classify
+
+    refs = ["https://github.com/acme/widget/commit/abc123def456789012"]
+    status, confidence, _ = _classify(refs, [], {}, [])
+    assert status == "patch_available"
+    assert confidence in ("high", "moderate", "low")
+
+
+def test_classify_patch_available_from_release_url():
+    from manus_use.tools.track_vendor_response import _classify
+
+    refs = ["https://github.com/acme/widget/releases/tag/v2.1.0"]
+    status, confidence, _ = _classify(refs, [], {}, [])
+    assert status == "patch_available"
+
+
+def test_classify_patch_available_from_ghsa_published():
+    from manus_use.tools.track_vendor_response import _classify
+
+    ghsa_advisories = [
+        {
+            "state": "published",
+            "html_url": "https://github.com/advisories/GHSA-xxxx-yyyy-zzzz",
+            "description": "Fixed in v2.0",
+            "references": [],
+            "vulnerabilities": [{"patched_versions": ">=2.0.1"}],
+        }
+    ]
+    status, confidence, evidence = _classify([], ghsa_advisories, {}, [])
+    assert status == "patch_available"
+    assert confidence == "high"
+    assert any("github.com/advisories" in u for u in evidence)
+
+
+def test_classify_wont_fix_detected():
+    from manus_use.tools.track_vendor_response import _classify
+
+    refs = ["https://vendor.example.com/advisory?cve=2024-0001&status=wontfix"]
+    # Inject wont-fix language via a fake GHSA description
+    ghsa = [{"state": "draft", "description": "will not fix — out of support", "references": [], "vulnerabilities": []}]
+    status, _, _ = _classify(refs, ghsa, {}, [])
+    assert status == "wont_fix"
+
+
+def test_classify_patch_backported():
+    from manus_use.tools.track_vendor_response import _classify
+
+    refs = [
+        "https://github.com/acme/widget/commit/abc123def456789012",
+        "https://github.com/acme/widget/releases/tag/v1.8.5-lts",
+    ]
+    ghsa = [{"state": "draft", "description": "backport for legacy version included", "references": [], "vulnerabilities": []}]
+    status, _, _ = _classify(refs, ghsa, {}, [])
+    assert status == "patch_backported"
+
+
+def test_classify_investigating():
+    from manus_use.tools.track_vendor_response import _classify
+
+    ghsa = [{"state": "draft", "description": "Vendor is aware and investigating the reported issue.", "references": [], "vulnerabilities": []}]
+    status, confidence, _ = _classify([], ghsa, {}, [])
+    assert status == "investigating"
+    assert confidence == "moderate"
+
+
+def test_classify_no_patch_when_only_nvd_refs_with_no_patch_signals():
+    from manus_use.tools.track_vendor_response import _classify
+
+    refs = ["https://nvd.nist.gov/vuln/detail/CVE-2024-0001"]
+    status, _, _ = _classify(refs, [], {}, [])
+    assert status in ("no_patch", "unknown", "patch_available")  # nvd url is not a strong patch signal
+
+
+def test_classify_unknown_when_no_data():
+    from manus_use.tools.track_vendor_response import _classify
+
+    status, confidence, evidence = _classify([], [], {}, [])
+    assert status == "unknown"
+    assert evidence == []
+
+
+def test_classify_evidence_deduplication():
+    from manus_use.tools.track_vendor_response import _classify
+
+    commit_url = "https://github.com/acme/widget/commit/abc123def456789012"
+    refs = [commit_url, commit_url, commit_url]
+    _, _, evidence = _classify(refs, [], {}, [])
+    assert evidence.count(commit_url) == 1
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# _build_summary
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_build_summary_patch_available():
+    from manus_use.tools.track_vendor_response import _build_summary
+
+    summary = _build_summary(
+        cve_id="CVE-2024-0001",
+        status="patch_available",
+        confidence="high",
+        evidence_urls=["https://github.com/acme/widget/releases/tag/v2.1"],
+        vendor="acme",
+        product="widget",
+        kev_entry={},
+        ghsa_count=1,
+    )
+    assert "CVE-2024-0001" in summary
+    assert "Patch Available" in summary
+    assert "acme" in summary
+
+
+def test_build_summary_wont_fix():
+    from manus_use.tools.track_vendor_response import _build_summary
+
+    summary = _build_summary(
+        cve_id="CVE-2024-0001",
+        status="wont_fix",
+        confidence="high",
+        evidence_urls=[],
+        vendor="",
+        product="",
+        kev_entry={},
+        ghsa_count=0,
+    )
+    assert "Won't Fix" in summary
+
+
+def test_build_summary_includes_kev_required_action():
+    from manus_use.tools.track_vendor_response import _build_summary
+
+    kev = {"requiredAction": "Apply updates per vendor instructions.", "dueDate": "2025-01-15"}
+    summary = _build_summary(
+        cve_id="CVE-2024-0001",
+        status="patch_available",
+        confidence="high",
+        evidence_urls=[],
+        vendor="",
+        product="",
+        kev_entry=kev,
+        ghsa_count=0,
+    )
+    assert "Apply updates per vendor instructions." in summary
+    assert "2025-01-15" in summary
+
+
+def test_build_summary_includes_evidence_urls():
+    from manus_use.tools.track_vendor_response import _build_summary
+
+    urls = ["https://github.com/acme/widget/commit/abc123", "https://github.com/advisories/GHSA-xxxx"]
+    summary = _build_summary(
+        cve_id="CVE-2024-0001",
+        status="patch_available",
+        confidence="high",
+        evidence_urls=urls,
+        vendor="",
+        product="",
+        kev_entry={},
+        ghsa_count=2,
+    )
+    for url in urls:
+        assert url in summary
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# track_vendor_response (full tool, mocked HTTP)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_requests_mock(nvd_payload, ghsa_payload=None, kev_payload=None):
+    """Return a side_effect function for requests.get that dispatches by URL."""
+    ghsa_payload = ghsa_payload or []
+    kev_payload = kev_payload or {"vulnerabilities": []}
+
+    def side_effect(url, **kwargs):
+        m = MagicMock()
+        m.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            m.json.return_value = nvd_payload
+        elif "github.com/advisories" in url or "api.github.com/advisories" in url:
+            m.json.return_value = ghsa_payload
+        elif "cisa.gov" in url:
+            m.json.return_value = kev_payload
+        elif "api.github.com/repos" in url:
+            m.json.return_value = []
+        else:
+            m.json.return_value = {}
+        return m
+
+    return side_effect
+
+
+def test_track_vendor_response_patch_available_from_commit():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    nvd = _nvd_response(
+        "CVE-2024-0001",
+        refs=["https://github.com/acme/widget/commit/abc123def456789012345678"],
+    )
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd)):
+        result = track_vendor_response(_make_tool_use("CVE-2024-0001"))
+
+    assert result["status"] == "success"
+    data = result["content"][0]["json"]
+    assert data["cve_id"] == "CVE-2024-0001"
+    assert data["status"] == "patch_available"
+    assert data["confidence"] in ("high", "moderate")
+
+
+def test_track_vendor_response_wont_fix_from_ghsa():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001")
+    ghsa = [
+        {
+            "state": "draft",
+            "html_url": "https://github.com/advisories/GHSA-xxxx",
+            "description": "Vendor will not fix — product is end of life",
+            "references": [],
+            "vulnerabilities": [],
+        }
+    ]
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd, ghsa)):
+        result = track_vendor_response(_make_tool_use("CVE-2024-0001"))
+
+    data = result["content"][0]["json"]
+    assert data["status"] == "wont_fix"
+
+
+def test_track_vendor_response_includes_kev_fields():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001")
+    kev = {"vulnerabilities": [{"cveID": "CVE-2024-0001", "requiredAction": "Update now.", "dueDate": "2025-03-01"}]}
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd, kev_payload=kev)):
+        result = track_vendor_response(_make_tool_use("CVE-2024-0001"))
+
+    data = result["content"][0]["json"]
+    assert data["in_cisa_kev"] is True
+    assert data["cisa_required_action"] == "Update now."
+    assert data["cisa_due_date"] == "2025-03-01"
+
+
+def test_track_vendor_response_summary_in_output():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001")
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd)):
+        result = track_vendor_response(_make_tool_use("CVE-2024-0001"))
+
+    data = result["content"][0]["json"]
+    assert "summary" in data
+    assert "CVE-2024-0001" in data["summary"]
+
+
+def test_track_vendor_response_nvd_error_still_returns_success():
+    """Even if NVD fails, the tool should degrade gracefully and return success."""
+    import requests as req
+
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    def side_effect(url, **kwargs):
+        if "nvd.nist.gov" in url:
+            raise req.RequestException("NVD down")
+        m = MagicMock()
+        m.raise_for_status = MagicMock()
+        m.json.return_value = [] if "github.com" in url else {"vulnerabilities": []}
+        return m
+
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=side_effect):
+        result = track_vendor_response(_make_tool_use("CVE-2024-0001"))
+
+    assert result["status"] == "success"
+    data = result["content"][0]["json"]
+    assert data["status"] in ("unknown", "no_patch", "investigating", "patch_available")
+
+
+def test_track_vendor_response_cve_id_case_insensitive():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001")
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd)):
+        result = track_vendor_response(_make_tool_use("cve-2024-0001"))
+
+    assert result["status"] == "success"
+    data = result["content"][0]["json"]
+    assert data["cve_id"] == "CVE-2024-0001"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI: vendor-response subcommand
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_vendor_response_help_exits_zero():
+    from manus_use.cli import _build_vendor_response_parser
+
+    p = _build_vendor_response_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        p.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_vendor_response_missing_cve_is_error():
+    from manus_use.cli import _build_vendor_response_parser
+
+    p = _build_vendor_response_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        p.parse_args([])
+    assert exc_info.value.code != 0
+
+
+def test_vendor_response_registered_in_subcommands():
+    from manus_use.cli import _SUBCOMMANDS
+
+    assert "vendor-response" in _SUBCOMMANDS
+
+
+def test_vendor_response_registered_in_main():
+    """main() must dispatch to _run_vendor_response when 'vendor-response' is present."""
+    import inspect
+
+    from manus_use.cli import main
+
+    src = inspect.getsource(main)
+    assert "vendor-response" in src
+    assert "_run_vendor_response" in src
+
+
+def test_run_vendor_response_text_output(capsys):
+    from manus_use.cli import _run_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001", refs=["https://github.com/acme/widget/commit/abc123def456789012345678"])
+
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd)):
+        exit_code = _run_vendor_response(["CVE-2024-0001"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "CVE-2024-0001" in captured.out
+
+
+def test_run_vendor_response_json_output(capsys):
+    from manus_use.cli import _run_vendor_response
+
+    nvd = _nvd_response("CVE-2024-0001")
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd)):
+        exit_code = _run_vendor_response(["CVE-2024-0001", "--output", "json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed["cve_id"] == "CVE-2024-0001"
+    assert "status" in parsed
+    assert "confidence" in parsed
+    assert "evidence_urls" in parsed
+
+
+def test_run_vendor_response_invalid_cve_returns_1(capsys):
+    from manus_use.cli import _run_vendor_response
+
+    exit_code = _run_vendor_response(["NOTACVE"])
+    assert exit_code == 1
+
+
+def test_run_vendor_response_json_has_all_expected_fields(capsys):
+    from manus_use.cli import _run_vendor_response
+
+    nvd = _nvd_response(
+        "CVE-2024-0001",
+        refs=["https://github.com/acme/widget/releases/tag/v2.0"],
+        vendor="acme",
+        product="widget",
+    )
+    kev = {"vulnerabilities": [{"cveID": "CVE-2024-0001", "requiredAction": "Patch it.", "dueDate": "2025-01-01"}]}
+    with patch("manus_use.tools.track_vendor_response.requests.get", side_effect=_make_requests_mock(nvd, kev_payload=kev)):
+        _run_vendor_response(["CVE-2024-0001", "--output", "json"])
+
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    required_fields = [
+        "cve_id", "status", "confidence", "vendor", "product",
+        "evidence_urls", "ghsa_advisories_found", "repo_advisories_found",
+        "in_cisa_kev", "cisa_required_action", "cisa_due_date", "summary",
+    ]
+    for field in required_fields:
+        assert field in data, f"Missing field: {field}"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# README documentation living-doc tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_readme_documents_vendor_response_subcommand():
+    from pathlib import Path
+
+    readme = (Path(__file__).parent.parent / "README.md").read_text()
+    assert "vendor-response" in readme, "README must document the vendor-response subcommand"
+    assert "manus-use vendor-response" in readme
+
+
+def test_readme_documents_patch_status_categories():
+    from pathlib import Path
+
+    readme = (Path(__file__).parent.parent / "README.md").read_text()
+    for status in ("no-patch", "patch-available", "patch-backported", "wont-fix"):
+        assert status in readme or status.replace("-", "_") in readme, f"README should mention status: {status}"


### PR DESCRIPTION
## What & Why

In any vulnerability management workflow, the first question after learning about a CVE is: **"Has the vendor released a fix?"**  Today the only way to answer this with `manus-use` is to run a full `analyze` pipeline — which fires off 8+ API calls and an LLM turn just to check patch status.

This PR adds a focused, standalone tool that answers exactly that question: `track_vendor_response`.

## Changes

**`src/manus_use/tools/track_vendor_response.py`** — new Strands tool:
- Queries 4 public sources in parallel: NVD reference links, GitHub Security Advisory (GHSA) REST API, CISA KEV catalog, and the affected repository's own GitHub security-advisory tab (when identifiable from NVD refs)
- Classifies patch status into 6 states: `patch_available` / `patch_backported` / `wont_fix` / `investigating` / `no_patch` / `unknown`
- Reports confidence (`high` / `moderate` / `low`), evidence URLs (capped at 10), vendor/product from CPE, CISA KEV required-action + due-date, GHSA advisory counts, and a plain-English summary
- Gracefully degrades when any single source fails (NVD down → still queries GHSA + KEV)

**`src/manus_use/cli.py`** — new `manus-use vendor-response` subcommand:
- `manus-use vendor-response CVE-2024-3094` — text summary
- `manus-use vendor-response CVE-2024-3094 --output json | jq .status` — machine-readable

**`src/manus_use/agents/vi_agent.py`** — VI agent integration:
- `track_vendor_response` added to the tool list
- New Step 6b in the system prompt: call after `get_patch_diff`; include classification + confidence in report; escalate `wont_fix`/`no_patch` prominently in the Recommendations section

**`README.md`** — new CLI reference section with status table, usage examples, and addition to the Security examples block

## Tests

`tests/test_vendor_response.py` — **50 new tests**, all mocked (no real HTTP):
- Input validation (bad/empty/None CVE ID)
- `_fetch_nvd` / `_fetch_ghsa` / `_fetch_cisa_kev` error handling and response parsing
- `_nvd_references` / `_nvd_affected_vendor_product` CPE extraction
- `_extract_github_repo_from_refs` — most-common-repo heuristic, `.git` suffix stripping
- `_classify` — all 6 classification paths (commit URL, release tag, GHSA published + patched_versions, wont_fix language, backport indicators, investigating language, unknown/empty)
- Evidence URL deduplication
- `_build_summary` with/without KEV, with vendor/product, with evidence list
- Full tool entry point: `patch_available` via commit, `wont_fix` via GHSA description, KEV fields propagated, NVD error graceful degradation, case-insensitive CVE ID normalisation
- CLI: `--help`, missing arg error, invalid CVE → exit 1, text output, JSON output, all 12 expected JSON fields present
- Living-doc: README documents `vendor-response` subcommand and all 6 status categories

**600 total tests pass** (was 550 before this PR). Ruff clean on all new/modified files.