### PR TITLE
feat(tools): PoC freshness checker — check_poc_freshness tool + manus-use poc-freshness subcommand

### DIFF
--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -1,0 +1,38 @@
+
+---
+
+## 2026-06-28 UTC
+
+**Branch:** feat/auto-20260628-0000  
+**PR:** #59  
+**Commit:** 10e1cd6
+
+### Contribution: PoC Freshness Checker
+
+Added `check_poc_freshness` Strands tool and `manus-use poc-freshness CVE-XXXX` CLI subcommand.
+
+**Motivation:** EPSS and CVSS scores do not capture ongoing attacker investment. A CVE with a 0.3 EPSS score backed by an actively-maintained exploit framework is operationally far more dangerous. This tool surfaces that signal.
+
+**Tool: `check_poc_freshness(cve_id, active_days=90)`**
+
+Two-phase pipeline:
+1. Discovery from trickest/cve + NVD references, deduplicated.
+2. Per-repo GitHub REST API classification into 6 states:
+   - `active` — commits within last active_days days (default: 90)
+   - `framework` — >=5 contributors AND >=50 commits AND >=10 watchers
+   - `stale` — exists but no recent activity
+   - `archived` — owner archived the repo
+   - `deleted` — 404 / gone
+   - `non_github` — non-GitHub URLs probed for HTTP status
+
+Active or framework repos trigger a WARNING banner.
+Per-repo metadata: last_commit_date, stars, forks, contributors, commit_count.
+Supports GITHUB_TOKEN / GH_TOKEN env var.
+
+**CLI:** `manus-use poc-freshness CVE-2024-3094 [--days 30] [--output json]`
+
+**VI Agent wiring:** check_poc_freshness added to tool list; new Step 6b in system prompt.
+
+**Tests:** 42 new tests (100% mocked). 592 total passing (up from 550). Ruff clean.
+
+**Suggested next contribution:** PoC quality scorer — for each active PoC repo, assess how weaponised the code is (working RCE, auth bypass, partial trigger, or demo-only) by inspecting README, code structure, and issue tracker signals. Builds on check_poc_freshness output.

--- a/README.md
+++ b/README.md
@@ -235,6 +235,41 @@ having to read the raw diff yourself. Composable with `analyze` and `epss-trend`
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Output format; `json` includes the full commit summary |
 
+### `manus-use poc-freshness <CVE-ID>` — PoC repository freshness check
+
+```bash
+# Check whether PoC repos for a CVE are still actively maintained
+manus-use poc-freshness CVE-2024-3094
+
+# Override the "active" threshold (default: 90 days)
+manus-use poc-freshness CVE-2024-3094 --days 30
+
+# Machine-readable output
+manus-use poc-freshness CVE-2024-3094 --output json
+```
+
+For each discovered PoC repository (sources: trickest/cve index + NVD references),
+reports one of six states:
+
+| Status | Meaning |
+|--------|---------|
+| `active` | Commits within the last `--days` days — attacker is still maintaining it |
+| `framework` | ≥5 contributors, ≥50 commits, ≥10 watchers — grew into a full exploit toolkit |
+| `stale` | Exists but no recent activity |
+| `archived` | Explicitly archived by the owner |
+| `deleted` | 404 / gone |
+| `non_github` | Non-GitHub URL; HTTP status checked |
+
+Active or framework repos trigger a `WARNING: ACTIVE PoC ACTIVITY DETECTED` banner.
+Set `GITHUB_TOKEN` / `GH_TOKEN` for higher GitHub API rate limits.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--days N` | `90` | Days within which a last commit counts as active |
+| `--output {text,json}` | `text` | Output format |
+
 ### `manus-use variants <CVE-ID>` — Variant analysis
 
 ```bash

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -94,6 +94,13 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - A direct link to the commit on GitHub.
   If no commit is found (private repo or non-GitHub), note this and proceed.
 
+**Step 6b: PoC Freshness Check**
+- Call `check_poc_freshness` with the CVE ID (default active_days=90). Include in the report:
+  - How many PoC repos are **active** (commits in last 90 days), **stale**, **archived**, **deleted**, or have grown into a **framework**.
+  - If any repos are active or framework-status, flag this prominently as **ACTIVE PoC ACTIVITY** — it signals the attacker community is still investing in weaponising the bug.
+  - List the per-repo status table (url, status, last_commit_date, stars).
+  If no PoC repos are found, note the absence and proceed.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -184,6 +191,7 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_use.tools.check_poc_freshness import check_poc_freshness
             from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_patch_diff import get_patch_diff
@@ -240,6 +248,7 @@ class VulnerabilityIntelligenceAgent:
             "manus_use.tools.verify_exploit",
             get_epss_trend,
             get_patch_diff,
+            check_poc_freshness,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1052,6 +1052,7 @@ _SUBCOMMANDS = {
     "epss-trend",
     "patch-diff",
     "compare",
+    "poc-freshness",
 }
 
 
@@ -1289,6 +1290,57 @@ def _run_compare(argv: list[str]) -> int:
 
     # Text output
     print(_render_text(comparison))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# poc-freshness subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_poc_freshness_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="manus-use poc-freshness",
+        description=(
+            "Check the freshness of all known public PoC repositories for a CVE. "
+            "Reports per-repo status: active / stale / archived / deleted / framework."
+        ),
+    )
+    parser.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    parser.add_argument(
+        "--days",
+        dest="active_days",
+        type=int,
+        default=90,
+        help="Days within which a last commit counts as active (default: 90)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return parser
+
+
+def _run_poc_freshness(argv: list[str]) -> int:
+    parser = _build_poc_freshness_parser()
+    args = parser.parse_args(argv)
+    cve_id: str = args.cve_id.strip().upper()
+    try:
+        from manus_use.tools.check_poc_freshness import check_poc_freshness
+    except ImportError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    result = check_poc_freshness(cve_id=cve_id, active_days=args.active_days)
+    if args.output == "json":
+        import json
+
+        # Parse the text report and emit a JSON summary
+        # The tool returns structured text; wrap it for JSON consumers
+        print(json.dumps({"cve_id": cve_id, "active_days": args.active_days, "report": result}))
+    else:
+        print(result)
     return 0
 
 
@@ -1599,6 +1651,10 @@ def main() -> None:
     if first_positional == "compare":
         idx = argv.index("compare")
         sys.exit(_run_compare(argv[idx + 1 :]))
+
+    if first_positional == "poc-freshness":
+        idx = argv.index("poc-freshness")
+        sys.exit(_run_poc_freshness(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/check_poc_freshness.py
+++ b/src/manus_use/tools/check_poc_freshness.py
@@ -1,0 +1,362 @@
+"""Tool: check_poc_freshness
+
+Given a CVE ID, discovers all known public PoC repositories from
+trickest/cve and NVD reference links, then checks GitHub REST API
+freshness for each discovered repo.
+
+Status categories:
+  active    -- commits within last active_days days
+  stale     -- no recent commits but repo exists
+  archived  -- owner archived it
+  deleted   -- 404 / gone
+  framework -- >=5 contributors, >=50 commits, >=10 watchers
+  non_github -- non-GitHub URLs
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import urllib.error
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from strands import tool
+
+__all__ = ["check_poc_freshness"]
+
+_CVE_YEAR_RE = re.compile(r"CVE-(\d{4})-\d+", re.IGNORECASE)
+_TRICKEST_RAW = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+_GITHUB_REPO_RE = re.compile(
+    r"https://github\.com/([A-Za-z0-9_.-]+)/([A-Za-z0-9_.-]+?)(?:\.git|/|$)"
+)
+_GITHUB_COMMIT_RE = re.compile(
+    r"https://github\.com/[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+/commit/[0-9a-f]+"
+)
+_URL_RE = re.compile(r"https?://\S+")
+
+_STATUS_ICON: dict[str, str] = {
+    "active": "\U0001f7e2",
+    "framework": "\U0001f534",
+    "stale": "\U0001f7e1",
+    "archived": "\u26aa",
+    "deleted": "\u274c",
+    "unknown": "\u2753",
+}
+
+
+def _github_token() -> str | None:
+    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+
+
+def _fetch_json(url: str) -> dict[str, Any] | list[Any] | None:
+    import json
+    headers: dict[str, str] = {"User-Agent": "manus-use/poc-freshness"}
+    token = _github_token()
+    if token and "api.github.com" in url:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _fetch_text(url: str) -> tuple[int, str]:
+    try:
+        req = urllib.request.Request(url, headers={"User-Agent": "manus-use/poc-freshness"})
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            return resp.status, resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        return exc.code, ""
+    except Exception as exc:  # noqa: BLE001
+        return -1, str(exc)
+
+
+def _fetch_trickest_poc_urls(cve_id: str) -> list[str]:
+    """Return GitHub PoC repo URLs from trickest/cve."""
+    match = _CVE_YEAR_RE.match(cve_id)
+    if not match:
+        return []
+    year = match.group(1)
+    url = _TRICKEST_RAW.format(year=year, cve_id=cve_id)
+    status, text = _fetch_text(url)
+    if status != 200:
+        return []
+    urls: list[str] = []
+    for line in text.splitlines():
+        for raw_url in _URL_RE.findall(line):
+            raw_url = raw_url.rstrip(")")
+            if "github.com" in raw_url and not _GITHUB_COMMIT_RE.match(raw_url):
+                m = _GITHUB_REPO_RE.match(raw_url)
+                if m:
+                    canonical = f"https://github.com/{m.group(1)}/{m.group(2)}"
+                    urls.append(canonical)
+    return list(dict.fromkeys(urls))
+
+
+def _fetch_nvd_poc_urls(cve_id: str) -> list[str]:
+    """Return GitHub repo URLs referenced in the NVD advisory."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id}"
+    data = _fetch_json(url)
+    if not isinstance(data, dict):
+        return []
+    try:
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return []
+        refs = vulns[0]["cve"].get("references", [])
+    except (KeyError, IndexError):
+        return []
+    urls: list[str] = []
+    for ref in refs:
+        raw_url: str = ref.get("url", "")
+        if "github.com" in raw_url and not _GITHUB_COMMIT_RE.match(raw_url):
+            m = _GITHUB_REPO_RE.match(raw_url)
+            if m:
+                canonical = f"https://github.com/{m.group(1)}/{m.group(2)}"
+                urls.append(canonical)
+    return list(dict.fromkeys(urls))
+
+
+def _get_commit_count(owner: str, repo: str) -> int | None:
+    """Approximate commit count via GitHub API Link-header pagination."""
+    import json as _json
+    url = f"https://api.github.com/repos/{owner}/{repo}/commits?per_page=1"
+    headers: dict[str, str] = {"User-Agent": "manus-use/poc-freshness"}
+    token = _github_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    try:
+        req = urllib.request.Request(url, headers=headers)
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            link_header = resp.getheader("Link", "")
+            last_match = re.search(r'page=(\d+)>; rel="last"', link_header)
+            if last_match:
+                return int(last_match.group(1))
+            body = _json.loads(resp.read().decode("utf-8"))
+            if isinstance(body, list):
+                return len(body)
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def _classify_github_repo(
+    owner: str, repo: str, active_days: int, now: datetime
+) -> dict[str, Any]:
+    """Return freshness record for a single GitHub repo."""
+    api_url = f"https://api.github.com/repos/{owner}/{repo}"
+    data = _fetch_json(api_url)
+    record: dict[str, Any] = {
+        "url": f"https://github.com/{owner}/{repo}",
+        "owner": owner,
+        "repo": repo,
+        "status": "unknown",
+        "last_commit_date": None,
+        "days_since_commit": None,
+        "stars": None,
+        "watchers": None,
+        "forks": None,
+        "contributors": None,
+        "commit_count": None,
+        "archived": False,
+        "is_framework": False,
+        "note": "",
+    }
+    if not isinstance(data, dict):
+        record["status"] = "deleted"
+        record["note"] = "Repository returned 404 or network error"
+        return record
+    archived: bool = bool(data.get("archived", False))
+    record["archived"] = archived
+    record["stars"] = data.get("stargazers_count", 0)
+    record["watchers"] = data.get("watchers_count", 0)
+    record["forks"] = data.get("forks_count", 0)
+    pushed_at: str | None = data.get("pushed_at")
+    if pushed_at:
+        try:
+            last_push = datetime.fromisoformat(pushed_at.replace("Z", "+00:00"))
+            days_ago = (now - last_push).days
+            record["last_commit_date"] = last_push.strftime("%Y-%m-%d")
+            record["days_since_commit"] = days_ago
+        except ValueError:
+            pass
+    contribs_url = (
+        f"https://api.github.com/repos/{owner}/{repo}/contributors?per_page=100&anon=false"
+
+    )
+    contribs_data = _fetch_json(contribs_url)
+    if isinstance(contribs_data, list):
+        record["contributors"] = len(contribs_data)
+    record["commit_count"] = _get_commit_count(owner, repo)
+    days_since: int | None = record["days_since_commit"]
+    n_contribs: int = record.get("contributors") or 0
+    n_commits: int = record.get("commit_count") or 0
+    n_watchers: int = record.get("watchers") or 0
+    is_framework: bool = n_contribs >= 5 and n_commits >= 50 and n_watchers >= 10
+    record["is_framework"] = is_framework
+    if archived:
+        record["status"] = "archived"
+        record["note"] = "Repository was archived by its owner"
+    elif is_framework:
+        record["status"] = "framework"
+        record["note"] = (
+            "Grown into a full exploit framework "
+            f"({n_contribs} contributors, {n_commits} commits, {n_watchers} watchers)"
+        )
+    elif days_since is None:
+        record["status"] = "unknown"
+        record["note"] = "Could not determine last push date"
+    elif days_since <= active_days:
+        record["status"] = "active"
+        record["note"] = f"Last commit {days_since} day(s) ago"
+    else:
+        record["status"] = "stale"
+        record["note"] = f"Last commit {days_since} day(s) ago (>{active_days}-day threshold)"
+    return record
+
+
+def _probe_non_github_url(url: str) -> dict[str, Any]:
+    status, _ = _fetch_text(url)
+    return {
+        "url": url,
+        "status": "non_github",
+        "http_status": status,
+        "note": "accessible" if status == 200 else f"HTTP {status}",
+    }
+
+
+@tool
+def check_poc_freshness(cve_id: str, active_days: int = 90) -> str:
+    """Check freshness of all known public PoC repos for a CVE.
+
+    For each discovered PoC repository reports one of:
+    - active     -- commits within the last active_days days
+    - framework  -- grown into a full exploit framework (>=5 contributors,
+                    >=50 commits, >=10 watchers)
+    - stale      -- exists but no recent commits
+    - archived   -- explicitly archived by owner
+    - deleted    -- 404 / gone
+    - non_github -- non-GitHub URLs (Exploit-DB entries, etc.)
+
+    Sources: trickest/cve index (250k+ CVEs, fast, no rate limit)
+    and NVD reference links.
+
+    Args:
+        cve_id: CVE identifier, e.g. "CVE-2024-3094".
+        active_days: Days within which a last commit counts as active (default: 90).
+
+    Returns:
+        Structured text report with per-repo freshness status and summary.
+    """
+    cve_id = cve_id.strip().upper()
+    if not _CVE_YEAR_RE.match(cve_id):
+        return f"Invalid CVE ID format: {cve_id!r}. Expected: CVE-YYYY-NNNNN"
+
+    now = datetime.now(tz=timezone.utc)
+    cutoff = now - timedelta(days=active_days)
+
+    trickest_urls = _fetch_trickest_poc_urls(cve_id)
+    nvd_urls = _fetch_nvd_poc_urls(cve_id)
+    all_urls = list(dict.fromkeys(trickest_urls + nvd_urls))
+
+    github_repos: list[str] = []
+    other_urls: list[str] = []
+    for url in all_urls:
+        m = _GITHUB_REPO_RE.match(url)
+        if m:
+            canonical = f"https://github.com/{m.group(1)}/{m.group(2)}"
+            if canonical not in github_repos:
+                github_repos.append(canonical)
+        elif "github.com" not in url:
+            if url not in other_urls:
+                other_urls.append(url)
+
+    if not github_repos and not other_urls:
+        return (
+            f"No public PoC repositories found for {cve_id}.\n\n"
+            "Sources checked: trickest/cve index, NVD references.\n"
+            "The CVE may be too new, not yet indexed, or have no public PoCs."
+        )
+
+    gh_records: list[dict[str, Any]] = []
+    for url in github_repos:
+        m = _GITHUB_REPO_RE.match(url)
+        if m:
+            gh_records.append(
+                _classify_github_repo(m.group(1), m.group(2), active_days, now)
+            )
+
+    other_records: list[dict[str, Any]] = [
+        _probe_non_github_url(u) for u in other_urls[:10]
+    ]
+
+    status_counts: dict[str, int] = {
+        s: 0
+        for s in ("active", "stale", "archived", "deleted", "framework", "unknown")
+    }
+    for r in gh_records:
+        st: str = r.get("status", "unknown")
+        status_counts[st] = status_counts.get(st, 0) + 1
+
+    lines: list[str] = [
+        f"## PoC Freshness Report: {cve_id}",
+        "Active threshold : {} days  (cut-off: {})".format(
+            active_days, cutoff.strftime("%Y-%m-%d")
+        ),
+        "Sources          : trickest/cve, NVD references",
+        "Report generated : {}".format(now.strftime("%Y-%m-%d %H:%M UTC")),
+        "",
+        "### Summary",
+        f"  GitHub PoC repos found : {len(gh_records)}",
+        "  Active (<={}d)         : {}".format(active_days, status_counts["active"]),
+        "  Stale (>{}d)           : {}".format(active_days, status_counts["stale"]),
+        "  Archived               : {}".format(status_counts["archived"]),
+        "  Deleted / 404          : {}".format(status_counts["deleted"]),
+        "  Grown to framework     : {}".format(status_counts["framework"]),
+        f"  Non-GitHub URLs        : {len(other_records)}",
+        "",
+    ]
+
+    active_repos = [r for r in gh_records if r["status"] in ("active", "framework")]
+    if active_repos:
+        lines.append(
+            "WARNING: ACTIVE PoC ACTIVITY DETECTED"
+            " -- attacker community is still investing in this bug."
+        )
+        lines.append("")
+
+    if gh_records:
+        lines.append("### GitHub PoC Repositories")
+        for r in gh_records:
+            icon = _STATUS_ICON.get(r["status"], "?")
+            lines.append(
+                "{} [{}]  {}".format(icon, r["status"].upper(), r["url"])
+            )
+            lines.append("   {}".format(r["note"]))
+            meta_parts: list[str] = []
+            if r.get("last_commit_date"):
+                meta_parts.append("last commit: {}".format(r["last_commit_date"]))
+            if r.get("stars") is not None:
+                meta_parts.append("stars: {}".format(r["stars"]))
+            if r.get("forks") is not None:
+                meta_parts.append("forks: {}".format(r["forks"]))
+            if r.get("contributors") is not None:
+                meta_parts.append("contributors: {}".format(r["contributors"]))
+            if r.get("commit_count") is not None:
+                meta_parts.append("commits: {}".format(r["commit_count"]))
+            if meta_parts:
+                lines.append("   ({})".format(", ".join(meta_parts)))
+            lines.append("")
+
+    if other_records:
+        lines.append("### Non-GitHub PoC URLs")
+        for r in other_records:
+            ok_str = "OK" if r.get("http_status") == 200 else "DEAD"
+            lines.append("[{}] {}  -- {}".format(ok_str, r["url"], r["note"]))
+        lines.append("")
+
+    return "\n".join(lines)

--- a/tests/test_poc_freshness.py
+++ b/tests/test_poc_freshness.py
@@ -1,0 +1,705 @@
+"""Tests for check_poc_freshness tool and poc-freshness CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+from manus_use.tools.check_poc_freshness import (
+    _classify_github_repo,
+    _fetch_nvd_poc_urls,
+    _fetch_trickest_poc_urls,
+    _probe_non_github_url,
+    check_poc_freshness,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+NOW = datetime(2026, 6, 28, 0, 0, 0, tzinfo=timezone.utc)
+ACTIVE_DAYS = 90
+STALE_THRESHOLD = ACTIVE_DAYS + 1
+
+
+def _make_repo_data(
+    archived: bool = False,
+    pushed_at: str = "2026-06-20T00:00:00Z",
+    stars: int = 5,
+    watchers: int = 5,
+    forks: int = 2,
+) -> dict[str, Any]:
+    return {
+        "archived": archived,
+        "pushed_at": pushed_at,
+        "stargazers_count": stars,
+        "watchers_count": watchers,
+        "forks_count": forks,
+    }
+
+
+# ---------------------------------------------------------------------------
+# _fetch_trickest_poc_urls
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTrickestPocUrls:
+    def test_invalid_cve_returns_empty(self):
+        assert _fetch_trickest_poc_urls("NOT-A-CVE") == []
+
+    def test_http_error_returns_empty(self):
+
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(404, ""),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        assert result == []
+
+    def test_parses_github_urls_from_markdown(self):
+        markdown = """### POC
+#### Github
+- https://github.com/owner/exploit-repo
+- https://github.com/another/poc (some note)
+"""
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(200, markdown),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        assert "https://github.com/owner/exploit-repo" in result
+        assert "https://github.com/another/poc" in result
+
+    def test_excludes_commit_urls(self):
+        markdown = """### POC
+#### Github
+- https://github.com/owner/repo/commit/abc123def456
+- https://github.com/owner/repo
+"""
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(200, markdown),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        # commit URL should be excluded; repo URL should be included
+        assert all("/commit/" not in u for u in result)
+        assert "https://github.com/owner/repo" in result
+
+    def test_deduplicates_urls(self):
+        markdown = """### POC
+#### Github
+- https://github.com/owner/repo
+- https://github.com/owner/repo
+"""
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(200, markdown),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        assert result.count("https://github.com/owner/repo") == 1
+
+    def test_strips_trailing_parens(self):
+        markdown = """### POC
+#### Github
+- https://github.com/owner/repo)
+"""
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(200, markdown),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        assert "https://github.com/owner/repo" in result
+        assert "https://github.com/owner/repo)" not in result
+
+    def test_empty_response_returns_empty(self):
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text",
+            return_value=(200, "### Description\nNo PoCs here."),
+        ):
+            result = _fetch_trickest_poc_urls("CVE-2024-3094")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_nvd_poc_urls
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdPocUrls:
+    def test_none_data_returns_empty(self):
+        with patch("manus_use.tools.check_poc_freshness._fetch_json", return_value=None):
+            result = _fetch_nvd_poc_urls("CVE-2024-3094")
+        assert result == []
+
+    def test_no_vulnerabilities_returns_empty(self):
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_json",
+            return_value={"vulnerabilities": []},
+        ):
+            result = _fetch_nvd_poc_urls("CVE-2024-3094")
+        assert result == []
+
+    def test_parses_github_refs(self):
+        nvd_data = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "references": [
+                            {"url": "https://github.com/owner/vuln-repo"},
+                            {"url": "https://example.com/advisory"},
+                        ]
+                    }
+                }
+            ]
+        }
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_json", return_value=nvd_data
+        ):
+            result = _fetch_nvd_poc_urls("CVE-2024-3094")
+        assert "https://github.com/owner/vuln-repo" in result
+        assert "https://example.com/advisory" not in result
+
+    def test_excludes_commit_refs(self):
+        nvd_data = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "references": [
+                            {
+                                "url": "https://github.com/owner/repo/commit/abc123"
+                            },
+                            {"url": "https://github.com/owner/repo"},
+                        ]
+                    }
+                }
+            ]
+        }
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_json", return_value=nvd_data
+        ):
+            result = _fetch_nvd_poc_urls("CVE-2024-3094")
+        assert all("/commit/" not in u for u in result)
+        assert "https://github.com/owner/repo" in result
+
+    def test_deduplicates(self):
+        nvd_data = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "references": [
+                            {"url": "https://github.com/owner/repo"},
+                            {"url": "https://github.com/owner/repo"},
+                        ]
+                    }
+                }
+            ]
+        }
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_json", return_value=nvd_data
+        ):
+            result = _fetch_nvd_poc_urls("CVE-2024-3094")
+        assert result.count("https://github.com/owner/repo") == 1
+
+
+# ---------------------------------------------------------------------------
+# _classify_github_repo
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyGithubRepo:
+    def _mock_classify(
+        self,
+        repo_data: dict[str, Any] | None,
+        contribs: list | None = None,
+        commit_count: int | None = 3,
+        active_days: int = ACTIVE_DAYS,
+        now: datetime = NOW,
+    ) -> dict[str, Any]:
+        contribs = contribs if contribs is not None else [{"login": "user1"}]
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[repo_data, contribs],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=commit_count,
+            ),
+        ):
+            return _classify_github_repo("owner", "repo", active_days, now)
+
+    def test_deleted_when_data_is_none(self):
+        record = self._mock_classify(None)
+        assert record["status"] == "deleted"
+
+    def test_archived_when_repo_archived(self):
+        record = self._mock_classify(
+            _make_repo_data(archived=True, pushed_at="2026-01-01T00:00:00Z")
+        )
+        assert record["status"] == "archived"
+        assert record["archived"] is True
+
+    def test_active_when_pushed_recently(self):
+        # pushed 8 days ago -- well within 90-day threshold
+        recent = (NOW - timedelta(days=8)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        record = self._mock_classify(_make_repo_data(pushed_at=recent))
+        assert record["status"] == "active"
+        assert record["days_since_commit"] == 8
+
+    def test_stale_when_pushed_long_ago(self):
+        old = (NOW - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        record = self._mock_classify(_make_repo_data(pushed_at=old))
+        assert record["status"] == "stale"
+        assert record["days_since_commit"] == 200
+
+    def test_framework_when_thresholds_met(self):
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        # 10 watchers, 6 contributors, 60 commits
+        many_contribs = [{"login": f"u{i}"} for i in range(6)]
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent, watchers=10),
+                    many_contribs,
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=60,
+            ),
+        ):
+            record = _classify_github_repo("owner", "repo", ACTIVE_DAYS, NOW)
+        assert record["status"] == "framework"
+        assert record["is_framework"] is True
+
+    def test_not_framework_when_contributors_too_few(self):
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        few_contribs = [{"login": "u1"}, {"login": "u2"}]  # < 5
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent, watchers=10),
+                    few_contribs,
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=60,
+            ),
+        ):
+            record = _classify_github_repo("owner", "repo", ACTIVE_DAYS, NOW)
+        assert record["is_framework"] is False
+
+    def test_stars_forks_watchers_populated(self):
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        record = self._mock_classify(
+            _make_repo_data(pushed_at=recent, stars=42, watchers=7, forks=3)
+        )
+        assert record["stars"] == 42
+        assert record["watchers"] == 7
+        assert record["forks"] == 3
+
+    def test_unknown_when_push_date_missing(self):
+        data = {
+            "archived": False,
+            "pushed_at": None,
+            "stargazers_count": 0,
+            "watchers_count": 0,
+            "forks_count": 0,
+        }
+        record = self._mock_classify(data, contribs=[], commit_count=None)
+        assert record["status"] == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _probe_non_github_url
+# ---------------------------------------------------------------------------
+
+
+class TestProbeNonGithubUrl:
+    def test_accessible_when_200(self):
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text", return_value=(200, "body")
+        ):
+            result = _probe_non_github_url("https://exploit-db.com/exploits/12345")
+        assert result["status"] == "non_github"
+        assert result["http_status"] == 200
+        assert "accessible" in result["note"]
+
+    def test_dead_when_404(self):
+        with patch(
+            "manus_use.tools.check_poc_freshness._fetch_text", return_value=(404, "")
+        ):
+            result = _probe_non_github_url("https://exploit-db.com/exploits/99999")
+        assert result["http_status"] == 404
+        assert "404" in result["note"]
+
+
+# ---------------------------------------------------------------------------
+# check_poc_freshness (main tool)
+# ---------------------------------------------------------------------------
+
+
+class TestCheckPocFreshness:
+    def test_invalid_cve_id(self):
+        result = check_poc_freshness("not-a-cve")
+        assert "Invalid CVE ID" in result
+
+    def test_no_pocs_found(self):
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+        ):
+            result = check_poc_freshness("CVE-9999-99999")
+        assert "No public PoC repositories found" in result
+
+    def test_report_header_present(self):
+        recent_push = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/hacker/exploit"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent_push),
+                    [],  # contributors
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=5,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "PoC Freshness Report: CVE-2024-3094" in result
+
+    def test_active_repo_triggers_warning(self):
+        recent_push = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/hacker/exploit"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent_push),
+                    [],
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "ACTIVE PoC ACTIVITY" in result
+
+    def test_stale_repo_no_warning(self):
+        old_push = (NOW - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/hacker/old-poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=old_push),
+                    [],
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "ACTIVE PoC ACTIVITY" not in result
+        assert "STALE" in result.upper() or "stale" in result
+
+    def test_summary_counts_correct(self):
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        old = (NOW - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=[
+                    "https://github.com/h1/active-poc",
+                    "https://github.com/h2/stale-poc",
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent),
+                    [],  # contribs for first repo
+                    _make_repo_data(pushed_at=old),
+                    [],  # contribs for second repo
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "GitHub PoC repos found : 2" in result
+
+    def test_deleted_repo_reported(self):
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/hacker/gone-poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                return_value=None,  # 404
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=None,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "DELETED" in result or "deleted" in result
+
+    def test_archived_repo_reported(self):
+        old = (NOW - timedelta(days=200)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/hacker/archived-poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(archived=True, pushed_at=old),
+                    [],
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "ARCHIVED" in result
+
+    def test_deduplicates_across_sources(self):
+        """Same repo from trickest + NVD should only appear once."""
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/owner/shared-poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=["https://github.com/owner/shared-poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent),
+                    [],
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert result.count("owner/shared-poc") == 1
+
+    def test_custom_active_days(self):
+        # With active_days=30 a 60-day-old commit should be stale
+        old_for_30 = (NOW - timedelta(days=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/h/poc"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[_make_repo_data(pushed_at=old_for_30), []],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=3,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094", active_days=30)
+        assert "Active threshold : 30 days" in result
+        # Should be stale with 30-day threshold
+        assert "stale" in result.lower()
+
+    def test_non_github_urls_included(self):
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=["https://exploit-db.com/exploits/12345"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_text",
+                return_value=(200, "body"),
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        # Non-GitHub URLs should be probed and listed
+        assert "exploit-db.com" in result
+
+    def test_framework_repo_triggers_warning(self):
+        recent = (NOW - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        many_contribs = [{"login": f"u{i}"} for i in range(6)]
+        with (
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_trickest_poc_urls",
+                return_value=["https://github.com/org/big-framework"],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_nvd_poc_urls",
+                return_value=[],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._fetch_json",
+                side_effect=[
+                    _make_repo_data(pushed_at=recent, watchers=15),
+                    many_contribs,
+                ],
+            ),
+            patch(
+                "manus_use.tools.check_poc_freshness._get_commit_count",
+                return_value=80,
+            ),
+        ):
+            result = check_poc_freshness("CVE-2024-3094")
+        assert "ACTIVE PoC ACTIVITY" in result
+        assert "framework" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: poc-freshness
+# ---------------------------------------------------------------------------
+
+
+class TestPocFreshnessCLI:
+    """Test the poc-freshness CLI subcommand dispatch."""
+
+    def _run(self, argv: list[str]) -> int:
+        from manus_use.cli import _run_poc_freshness
+
+        return _run_poc_freshness(argv)
+
+    def test_text_output(self, capsys):
+        with patch(
+            "manus_use.tools.check_poc_freshness.check_poc_freshness",
+            return_value="## PoC Freshness Report: CVE-2024-3094\nfoo",
+        ):
+            rc = self._run(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PoC Freshness Report" in out
+
+    def test_json_output(self, capsys):
+        with patch(
+            "manus_use.tools.check_poc_freshness.check_poc_freshness",
+            return_value="report text",
+        ):
+            rc = self._run(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["cve_id"] == "CVE-2024-3094"
+        assert "report" in parsed
+
+    def test_custom_days(self, capsys):
+        with patch(
+            "manus_use.tools.check_poc_freshness.check_poc_freshness",
+            return_value="ok",
+        ) as mock_tool:
+            self._run(["CVE-2024-3094", "--days", "30"])
+        mock_tool.assert_called_once_with(cve_id="CVE-2024-3094", active_days=30)
+
+    def test_cve_normalised_uppercase(self, capsys):
+        with patch(
+            "manus_use.tools.check_poc_freshness.check_poc_freshness",
+            return_value="ok",
+        ) as mock_tool:
+            self._run(["cve-2024-3094"])
+        mock_tool.assert_called_once_with(cve_id="CVE-2024-3094", active_days=90)
+
+    def test_subcommand_in_subcommands_set(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "poc-freshness" in _SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# VulnerabilityIntelligenceAgent wiring
+# ---------------------------------------------------------------------------
+
+
+class TestVIAgentWiring:
+    """Verify check_poc_freshness is wired into the VI agent tool list."""
+
+    def test_check_poc_freshness_importable_from_vi_agent_module(self):
+        """The import used inside __init__ must resolve correctly."""
+        from manus_use.tools.check_poc_freshness import check_poc_freshness as cpf
+
+        assert callable(cpf)
+
+    def test_vi_agent_system_prompt_references_check_poc_freshness(self):
+        from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+        assert "check_poc_freshness" in SYSTEM_PROMPT
+
+    def test_vi_agent_system_prompt_references_poc_freshness_step(self):
+        from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+        assert "PoC Freshness" in SYSTEM_PROMPT


### PR DESCRIPTION
## What & Why

Answers the question: **"Is the attacker community still actively maintaining PoC exploit code for this CVE?"**

This is a critical signal that complements EPSS and CVSS: a bug with a 0.3 EPSS score that has an actively-maintained 80-star GitHub exploit framework is far more dangerous than the score alone suggests. Previously the only way to answer this question was to manually browse GitHub — this tool automates it.

## Changes

- **`src/manus_use/tools/check_poc_freshness.py`** — new Strands tool
  - Two-source PoC discovery: trickest/cve index (250k+ CVEs, fast, no rate limit) + NVD reference links
  - Per-repo GitHub REST API classification into 6 states:
    - `active` — commits within last N days (default: 90)
    - `framework` — heuristic: >=5 contributors AND >=50 commits AND >=10 watchers
    - `stale` — exists but no recent activity
    - `archived` — owner archived it
    - `deleted` — 404 / gone
    - `non_github` — non-GitHub URLs probed for HTTP status
  - Active/framework repos trigger a prominent WARNING banner
  - Per-repo metadata: last_commit_date, stars, forks, contributors, commit_count
  - GITHUB_TOKEN / GH_TOKEN env var support for higher API rate limits

- **`src/manus_use/agents/vi_agent.py`** — wired `check_poc_freshness` into the VI agent tool list + new Step 6b in system prompt

- **`src/manus_use/cli.py`** — `manus-use poc-freshness CVE-XXXX-YYYY [--days N] [--output {text,json}]`

- **`tests/test_poc_freshness.py`** — 42 new tests (100% mocked)

## Tests

592 total tests pass (up from 550). Ruff: 0 violations in new files.