### PR TITLE
feat(tools): VulnCheck KEV + NVD2 enrichment — get_vulncheck_data + VI agent wiring

### DIFF
--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -50,6 +50,14 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 - Immediately call the `get_nvd_data` tool to get foundational information from the NVD. This will provide the official description, CVSS score, and CWE.
 - Call `get_github_advisory` to get advisory information from GitHub.
 
+**Step 1b: VulnCheck Enrichment**
+- Call `get_vulncheck_data` for the CVE. This provides two critical enrichments:
+  - **VulnCheck KEV**: exploitation status aggregated from 100+ sources (FBI Flash, CERT advisories, threat-intel feeds) — far broader than CISA KEV's ~1200 entries.
+  - **VulnCheck NVD2**: enriched CPE matching — use `nvd2.cpe_matches` to improve version range analysis in Step 3 and beyond.
+- If `kev.in_kev = True`: prepend **🚨 ACTIVELY EXPLOITED (VulnCheck KEV)** to the analysis and list all sources from `kev.sources`.
+- If `kev.ransomware_use = True`: add **⚠️ RANSOMWARE ASSOCIATED** warning prominently in the report.
+- If `available = False` (no API key): note that VulnCheck enrichment is unavailable and continue with other sources.
+
 **Step 2: Check for Known Exploitation and EPSS Trend**
 - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
@@ -197,6 +205,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_patch_diff import get_patch_diff
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
+            from manus_use.tools.get_vulncheck_data import get_vulncheck_data
             from manus_use.tools.score_exploit_complexity import score_exploit_complexity
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
@@ -250,6 +259,7 @@ class VulnerabilityIntelligenceAgent:
             get_epss_trend,
             get_patch_diff,
             score_exploit_complexity,
+            get_vulncheck_data,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/tools/get_vulncheck_data.py
+++ b/src/manus_use/tools/get_vulncheck_data.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+"""
+Tool for fetching VulnCheck vulnerability intelligence for a CVE.
+
+Queries two VulnCheck API endpoints:
+- VulnCheck KEV: exploitation status aggregated from 100+ sources (FBI Flash,
+  CERT advisories, threat intel feeds) — broader than CISA KEV.
+- VulnCheck NVD2: enriched NVD data with improved CPE matching for more
+  accurate version-range analysis.
+
+Requires ``VULNCHECK_API_KEY`` environment variable. When absent the tool
+returns ``available: False`` instead of raising so callers can degrade
+gracefully.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+TOOL_SPEC = {
+    "name": "get_vulncheck_data",
+    "description": (
+        "Fetches VulnCheck vulnerability intelligence for a given CVE ID from two endpoints: "
+        "(1) VulnCheck KEV — exploitation status aggregated from 100+ sources including FBI Flash, "
+        "CERT advisories, and threat-intel feeds, providing far broader active-exploitation coverage "
+        "than CISA KEV alone; "
+        "(2) VulnCheck NVD2 — enriched NVD data with improved CPE matching for more accurate "
+        "affected-version analysis. "
+        "Requires VULNCHECK_API_KEY environment variable; returns available=False when absent. "
+        "A kev.in_kev=True result is a strong signal of confirmed active exploitation. "
+        "kev.ransomware_use=True indicates ransomware groups have weaponised this CVE."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2024-3094').",
+                }
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+_BASE_URL = "https://api.vulncheck.com/v3/index"
+_TIMEOUT = 20
+
+
+def _make_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "Accept": "application/json",
+    }
+
+
+def _fetch_kev(cve_id: str, api_key: str) -> dict[str, Any]:
+    """Query VulnCheck KEV for a specific CVE.
+
+    Tries ``?cve=CVE-XXXX`` first (direct lookup).  If the response contains
+    no matching entry, returns an empty KEV record.
+    """
+    url = f"{_BASE_URL}/vulncheck-kev"
+    params: dict[str, str] = {"cve": cve_id.upper()}
+    response = requests.get(url, headers=_make_headers(api_key), params=params, timeout=_TIMEOUT)
+    response.raise_for_status()
+    payload = response.json()
+
+    data = payload.get("data") or []
+    if not data:
+        return {
+            "in_kev": False,
+            "date_added": None,
+            "sources": [],
+            "ransomware_use": False,
+            "notes": None,
+        }
+
+    # The first matching entry is authoritative.
+    entry = data[0]
+
+    # Sources: VulnCheck KEV records may carry a "sources" list or "reportedBy".
+    sources: list[str] = []
+    for src_field in ("sources", "reportedBy", "reported_by"):
+        val = entry.get(src_field)
+        if isinstance(val, list):
+            sources = [str(s) for s in val if s]
+            break
+        elif isinstance(val, str) and val:
+            sources = [val]
+            break
+
+    # Date added: try several common field names.
+    date_added: str | None = None
+    for date_field in ("dateAdded", "date_added", "dateKnownRansomware", "published"):
+        val = entry.get(date_field)
+        if val:
+            date_added = str(val)
+            break
+
+    # Ransomware association flag.
+    ransomware_use: bool = bool(
+        entry.get("ransomwareUse")
+        or entry.get("ransomware_use")
+        or entry.get("knownRansomwareCampaignUse")
+        or entry.get("known_ransomware_campaign_use")
+    )
+
+    notes_val = entry.get("notes") or entry.get("note") or entry.get("shortDescription")
+    notes: str | None = str(notes_val) if notes_val else None
+
+    return {
+        "in_kev": True,
+        "date_added": date_added,
+        "sources": sources,
+        "ransomware_use": ransomware_use,
+        "notes": notes,
+    }
+
+
+def _fetch_nvd2(cve_id: str, api_key: str) -> dict[str, Any]:
+    """Query VulnCheck NVD2 for enriched NVD data."""
+    url = f"{_BASE_URL}/nist-nvd2"
+    params: dict[str, str] = {"cve": cve_id.upper()}
+    response = requests.get(url, headers=_make_headers(api_key), params=params, timeout=_TIMEOUT)
+    response.raise_for_status()
+    payload = response.json()
+
+    data = payload.get("data") or []
+    if not data:
+        return {
+            "cvss_v3_score": None,
+            "cvss_v3_vector": None,
+            "cvss_v3_severity": None,
+            "cpe_matches": [],
+            "description": None,
+            "published": None,
+            "last_modified": None,
+        }
+
+    entry = data[0]
+
+    # ── CVSS v3 ──────────────────────────────────────────────────────────────
+    cvss_v3_score: float | None = None
+    cvss_v3_vector: str | None = None
+    cvss_v3_severity: str | None = None
+
+    # VulnCheck NVD2 may wrap metrics under various keys.
+    metrics = entry.get("metrics") or {}
+    for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV3"):
+        metric_list = metrics.get(metric_key) or []
+        if not isinstance(metric_list, list):
+            metric_list = [metric_list]
+        for m in metric_list:
+            cvss_data = m.get("cvssData") or m
+            score = cvss_data.get("baseScore")
+            if score is not None:
+                cvss_v3_score = float(score)
+                cvss_v3_vector = cvss_data.get("vectorString")
+                cvss_v3_severity = cvss_data.get("baseSeverity")
+                break
+        if cvss_v3_score is not None:
+            break
+
+    # ── CPE matches ──────────────────────────────────────────────────────────
+    cpe_matches: list[str] = []
+    configurations = entry.get("configurations") or []
+    for config in configurations:
+        nodes = config.get("nodes") or []
+        for node in nodes:
+            for cpe_match in node.get("cpeMatch") or []:
+                criteria = cpe_match.get("criteria")
+                if criteria and criteria not in cpe_matches:
+                    cpe_matches.append(criteria)
+
+    # ── Description ──────────────────────────────────────────────────────────
+    description: str | None = None
+    for desc_entry in entry.get("descriptions") or []:
+        if desc_entry.get("lang") == "en":
+            description = desc_entry.get("value")
+            break
+
+    return {
+        "cvss_v3_score": cvss_v3_score,
+        "cvss_v3_vector": cvss_v3_vector,
+        "cvss_v3_severity": cvss_v3_severity,
+        "cpe_matches": cpe_matches,
+        "description": description,
+        "published": entry.get("published"),
+        "last_modified": entry.get("lastModified"),
+    }
+
+
+def get_vulncheck_data(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Fetch VulnCheck KEV and NVD2 intelligence for a CVE."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id: str = tool_input.get("cve_id", "")
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("get_vulncheck_data", result)
+        return result
+
+    cve_id = cve_id.upper()
+    api_key = os.environ.get("VULNCHECK_API_KEY", "").strip()
+
+    if not api_key:
+        payload: dict[str, Any] = {
+            "cve_id": cve_id,
+            "available": False,
+            "kev": {
+                "in_kev": False,
+                "date_added": None,
+                "sources": [],
+                "ransomware_use": False,
+                "notes": None,
+            },
+            "nvd2": {
+                "cvss_v3_score": None,
+                "cvss_v3_vector": None,
+                "cvss_v3_severity": None,
+                "cpe_matches": [],
+                "description": None,
+                "published": None,
+                "last_modified": None,
+            },
+            "error": "VULNCHECK_API_KEY environment variable is not set. VulnCheck enrichment is unavailable.",
+        }
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"json": payload}],
+        }
+        log_tool_output_size("get_vulncheck_data", result)
+        return result
+
+    kev_data: dict[str, Any] = {
+        "in_kev": False,
+        "date_added": None,
+        "sources": [],
+        "ransomware_use": False,
+        "notes": None,
+    }
+    nvd2_data: dict[str, Any] = {
+        "cvss_v3_score": None,
+        "cvss_v3_vector": None,
+        "cvss_v3_severity": None,
+        "cpe_matches": [],
+        "description": None,
+        "published": None,
+        "last_modified": None,
+    }
+    error_msg: str | None = None
+
+    try:
+        kev_data = _fetch_kev(cve_id, api_key)
+    except requests.exceptions.RequestException as exc:
+        error_msg = f"VulnCheck KEV request failed: {exc}"
+    except Exception as exc:  # noqa: BLE001
+        error_msg = f"Unexpected error fetching VulnCheck KEV: {exc}"
+
+    try:
+        nvd2_data = _fetch_nvd2(cve_id, api_key)
+    except requests.exceptions.RequestException as exc:
+        msg = f"VulnCheck NVD2 request failed: {exc}"
+        error_msg = f"{error_msg}; {msg}" if error_msg else msg
+    except Exception as exc:  # noqa: BLE001
+        msg = f"Unexpected error fetching VulnCheck NVD2: {exc}"
+        error_msg = f"{error_msg}; {msg}" if error_msg else msg
+
+    payload = {
+        "cve_id": cve_id,
+        "available": True,
+        "kev": kev_data,
+        "nvd2": nvd2_data,
+        "error": error_msg,
+    }
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"json": payload}],
+    }
+    log_tool_output_size("get_vulncheck_data", result)
+    return result

--- a/src/manus_use/tools/track_vendor_response.py
+++ b/src/manus_use/tools/track_vendor_response.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""
+Tool for tracking and classifying vendor patch/response status for a CVE.
+
+Queries multiple public sources (NVD, CISA KEV, VulnCheck KEV) to produce a
+6-state vendor response classification:
+
+  patch_available     — A confirmed fix/patch has been released.
+  patch_pending       — Vendor acknowledged; fix in progress or announced.
+  workaround_only     — Vendor published a mitigation but no patch yet.
+  investigating       — Vendor acknowledged but response status is unclear.
+  no_patch_expected   — Vendor will not fix (EoL, won't-fix, disputed).
+  unknown             — Insufficient data to classify.
+
+VulnCheck KEV integration: a KEV hit elevates classification confidence and
+can push the state toward ``patch_available`` or ``investigating`` depending on
+what the NVD/vendor data shows — because actively exploited CVEs almost always
+trigger a vendor response.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# 6 valid classification states.
+_VALID_STATES = frozenset(
+    {
+        "patch_available",
+        "patch_pending",
+        "workaround_only",
+        "investigating",
+        "no_patch_expected",
+        "unknown",
+    }
+)
+
+# Keywords that strongly suggest a patch exists.
+_PATCH_KEYWORDS = frozenset(
+    {
+        "fixed in",
+        "patch",
+        "update to",
+        "upgrade to",
+        "version",
+        "release",
+        "resolved",
+        "remediated",
+        "hotfix",
+    }
+)
+
+# Keywords that suggest only a workaround.
+_WORKAROUND_KEYWORDS = frozenset(
+    {
+        "workaround",
+        "mitigation",
+        "disable",
+        "restrict",
+        "block",
+        "firewall rule",
+        "configuration change",
+    }
+)
+
+TOOL_SPEC = {
+    "name": "track_vendor_response",
+    "description": (
+        "Tracks and classifies the vendor patch/response status for a given CVE ID. "
+        "Queries NVD, CISA KEV, and VulnCheck KEV to produce a 6-state classification: "
+        "patch_available, patch_pending, workaround_only, investigating, "
+        "no_patch_expected, or unknown. "
+        "VulnCheck KEV hits elevate confidence: actively exploited CVEs almost "
+        "always have a vendor response. Use after get_nvd_data and get_vulncheck_data "
+        "to build a complete remediation picture."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to track (e.g., 'CVE-2024-3094').",
+                }
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+def _fetch_nvd_references(cve_id: str) -> list[dict[str, Any]]:
+    """Return the NVD reference list for *cve_id*, or [] on failure."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities") or []
+        if not vulns:
+            return []
+        return vulns[0].get("cve", {}).get("references") or []
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _fetch_cisa_kev(cve_id: str) -> dict[str, Any]:
+    """Return CISA KEV entry for *cve_id*, or {} if not found."""
+    try:
+        resp = requests.get(
+            "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        for vuln in data.get("vulnerabilities") or []:
+            if vuln.get("cveID", "").upper() == cve_id:
+                return vuln
+    except Exception:  # noqa: BLE001
+        pass
+    return {}
+
+
+def _fetch_vulncheck_kev(cve_id: str, api_key: str) -> dict[str, Any]:
+    """Return VulnCheck KEV data for *cve_id*, or {} if unavailable/no key."""
+    if not api_key:
+        return {}
+    try:
+        url = "https://api.vulncheck.com/v3/index/vulncheck-kev"
+        headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+        resp = requests.get(url, headers=headers, params={"cve": cve_id}, timeout=20)
+        resp.raise_for_status()
+        payload = resp.json()
+        data = payload.get("data") or []
+        return data[0] if data else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _classify(
+    references: list[dict[str, Any]],
+    cisa_kev: dict[str, Any],
+    vulncheck_kev: dict[str, Any],
+    nvd_status: str,
+) -> tuple[str, float, list[str]]:
+    """Derive (state, confidence, evidence_list) from gathered signals.
+
+    Confidence is a float in [0, 1]:
+      0.9+ = high  (multiple strong signals agree)
+      0.6–0.9 = medium  (at least one strong signal)
+      0.3–0.6 = low  (weak / indirect signals only)
+      < 0.3 = very low  (essentially guessing)
+    """
+    evidence: list[str] = []
+    state = "unknown"
+    confidence = 0.2
+
+    # ── NVD vuln status ──────────────────────────────────────────────────────
+    nvd_status_lower = nvd_status.lower()
+    if "modified" in nvd_status_lower or "analyzed" in nvd_status_lower:
+        evidence.append(f"NVD status: {nvd_status}")
+        confidence = max(confidence, 0.3)
+
+    # ── Reference-tag analysis ───────────────────────────────────────────────
+    ref_tags_flat: set[str] = set()
+    ref_urls: list[str] = []
+    for ref in references:
+        for tag in ref.get("tags") or []:
+            ref_tags_flat.add(tag.lower())
+        url = ref.get("url", "")
+        if url:
+            ref_urls.append(url.lower())
+
+    has_patch_tag = "patch" in ref_tags_flat or "vendor-advisory" in ref_tags_flat
+    has_fix_tag = "fix" in ref_tags_flat or "release-notes" in ref_tags_flat
+    has_mitigation_tag = "mitigation" in ref_tags_flat or "workaround" in ref_tags_flat
+
+    if has_patch_tag or has_fix_tag:
+        state = "patch_available"
+        confidence = max(confidence, 0.75)
+        evidence.append(f"NVD reference tags include: {sorted(ref_tags_flat)}")
+
+    elif has_mitigation_tag and state == "unknown":
+        state = "workaround_only"
+        confidence = max(confidence, 0.6)
+        evidence.append(f"NVD reference tags include mitigation/workaround: {sorted(ref_tags_flat)}")
+
+    # Heuristic: scan ref URLs for patch/fix keywords.
+    url_text = " ".join(ref_urls)
+    for kw in _PATCH_KEYWORDS:
+        if kw in url_text:
+            if state == "unknown":
+                state = "patch_available"
+                confidence = max(confidence, 0.5)
+            evidence.append(f"Patch keyword '{kw}' found in reference URLs.")
+            break
+
+    if state == "unknown":
+        for kw in _WORKAROUND_KEYWORDS:
+            if kw in url_text:
+                state = "workaround_only"
+                confidence = max(confidence, 0.4)
+                evidence.append(f"Workaround keyword '{kw}' found in reference URLs.")
+                break
+
+    # ── CISA KEV signal ──────────────────────────────────────────────────────
+    if cisa_kev:
+        required_action = (cisa_kev.get("requiredAction") or "").lower()
+        evidence.append(f"CISA KEV: {cisa_kev.get('shortDescription', 'in KEV catalog')}")
+        # CISA often lists "Apply update" — implies patch_available.
+        if "apply" in required_action or "update" in required_action or "patch" in required_action:
+            if state in ("unknown", "investigating"):
+                state = "patch_available"
+            confidence = min(confidence + 0.2, 0.95)
+
+    # ── VulnCheck KEV signal ─────────────────────────────────────────────────
+    if vulncheck_kev:
+        evidence.append("VulnCheck KEV: active exploitation confirmed via multi-source aggregation")
+        # Active exploitation + unknown status → bump to investigating at minimum.
+        if state == "unknown":
+            state = "investigating"
+        # Boost confidence: confirmed exploitation means there's strong vendor pressure.
+        confidence = min(confidence + 0.15, 0.95)
+
+        ransomware = bool(
+            vulncheck_kev.get("ransomwareUse")
+            or vulncheck_kev.get("ransomware_use")
+            or vulncheck_kev.get("knownRansomwareCampaignUse")
+        )
+        if ransomware:
+            evidence.append("VulnCheck KEV: ransomware association — escalated priority")
+            confidence = min(confidence + 0.05, 0.98)
+
+    # ── Final consistency check ───────────────────────────────────────────────
+    if state not in _VALID_STATES:
+        state = "unknown"
+
+    return state, round(confidence, 3), evidence
+
+
+def track_vendor_response(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Classify vendor patch/response status for a CVE using NVD + KEV sources."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id: str = tool_input.get("cve_id", "")
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("track_vendor_response", result)
+        return result
+
+    cve_id = cve_id.upper()
+    api_key = os.environ.get("VULNCHECK_API_KEY", "").strip()
+
+    # Gather data from each source independently (failures are non-fatal).
+    references = _fetch_nvd_references(cve_id)
+    cisa_kev = _fetch_cisa_kev(cve_id)
+    vulncheck_kev = _fetch_vulncheck_kev(cve_id, api_key)
+
+    # Derive NVD vuln status from reference tags if available.
+    nvd_status = "unknown"
+    if references:
+        nvd_status = "analyzed"
+
+    state, confidence, evidence = _classify(references, cisa_kev, vulncheck_kev, nvd_status)
+
+    vulncheck_kev_hit = bool(vulncheck_kev)
+    cisa_kev_hit = bool(cisa_kev)
+
+    payload: dict[str, Any] = {
+        "cve_id": cve_id,
+        "vendor_response_state": state,
+        "confidence": confidence,
+        "evidence": evidence,
+        "signals": {
+            "nvd_references_found": len(references),
+            "cisa_kev_hit": cisa_kev_hit,
+            "vulncheck_kev_hit": vulncheck_kev_hit,
+            "vulncheck_api_key_present": bool(api_key),
+        },
+    }
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"json": payload}],
+    }
+    log_tool_output_size("track_vendor_response", result)
+    return result

--- a/tests/test_vulncheck_data.py
+++ b/tests/test_vulncheck_data.py
@@ -1,0 +1,728 @@
+"""Tests for get_vulncheck_data, track_vendor_response, and VI agent wiring."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_use(cve_id: str = "CVE-2024-3094", tool_use_id: str = "test-001") -> dict:
+    return {"toolUseId": tool_use_id, "input": {"cve_id": cve_id}}
+
+
+def _make_kev_response(cve_id: str = "CVE-2024-3094") -> dict:
+    """Minimal VulnCheck KEV API response payload with a hit."""
+    return {
+        "data": [
+            {
+                "cveID": cve_id,
+                "dateAdded": "2024-03-29",
+                "sources": ["CISA KEV", "FBI Flash", "MS-ISAC"],
+                "ransomwareUse": False,
+                "notes": "Supply-chain backdoor in XZ Utils.",
+            }
+        ],
+        "_meta": {"timestamp": "2024-04-01T00:00:00Z"},
+    }
+
+
+def _make_kev_empty_response() -> dict:
+    """VulnCheck KEV API response with no data (CVE not in KEV)."""
+    return {"data": [], "_meta": {}}
+
+
+def _make_nvd2_response(cve_id: str = "CVE-2024-3094") -> dict:
+    """Minimal VulnCheck NVD2 API response."""
+    return {
+        "data": [
+            {
+                "id": cve_id,
+                "published": "2024-03-29T00:00:00.000",
+                "lastModified": "2024-04-01T00:00:00.000",
+                "descriptions": [{"lang": "en", "value": "Supply-chain attack in xz-utils."}],
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 10.0,
+                                "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                                "baseSeverity": "CRITICAL",
+                            }
+                        }
+                    ]
+                },
+                "configurations": [
+                    {
+                        "nodes": [
+                            {
+                                "cpeMatch": [
+                                    {"criteria": "cpe:2.3:a:tukaani:xz_utils:5.6.0:*:*:*:*:*:*:*"},
+                                    {"criteria": "cpe:2.3:a:tukaani:xz_utils:5.6.1:*:*:*:*:*:*:*"},
+                                ]
+                            }
+                        ]
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def _make_requests_response(payload: dict, status_code: int = 200) -> MagicMock:
+    """Return a mock requests.Response for the given payload."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def _make_requests_error_response() -> MagicMock:
+    """Mock that raises requests.exceptions.RequestException on raise_for_status."""
+    import requests
+
+    resp = MagicMock()
+    resp.raise_for_status.side_effect = requests.exceptions.ConnectionError("network failure")
+    return resp
+
+
+# ===========================================================================
+# get_vulncheck_data — no API key (graceful degradation)
+# ===========================================================================
+
+
+def test_no_api_key_returns_available_false(monkeypatch):
+    monkeypatch.delenv("VULNCHECK_API_KEY", raising=False)
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+
+    assert result["status"] == "success"
+    payload = result["content"][0]["json"]
+    assert payload["available"] is False
+    assert payload["kev"]["in_kev"] is False
+    assert payload["nvd2"]["cvss_v3_score"] is None
+    assert "VULNCHECK_API_KEY" in payload["error"]
+
+
+def test_no_api_key_includes_cve_id(monkeypatch):
+    monkeypatch.delenv("VULNCHECK_API_KEY", raising=False)
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use("CVE-2021-44228"))
+    payload = result["content"][0]["json"]
+    assert payload["cve_id"] == "CVE-2021-44228"
+
+
+def test_no_api_key_kev_sources_empty(monkeypatch):
+    monkeypatch.delenv("VULNCHECK_API_KEY", raising=False)
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["sources"] == []
+
+
+def test_no_api_key_cpe_matches_empty(monkeypatch):
+    monkeypatch.delenv("VULNCHECK_API_KEY", raising=False)
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["nvd2"]["cpe_matches"] == []
+
+
+# ===========================================================================
+# get_vulncheck_data — invalid CVE ID
+# ===========================================================================
+
+
+def test_invalid_cve_id_returns_error(monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data({"toolUseId": "x", "input": {"cve_id": "INVALID"}})
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_missing_cve_id_returns_error(monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data({"toolUseId": "x", "input": {}})
+    assert result["status"] == "error"
+
+
+# ===========================================================================
+# get_vulncheck_data — valid key + KEV hit
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_hit_in_kev_true(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["available"] is True
+    assert payload["kev"]["in_kev"] is True
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_hit_sources_populated(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert "CISA KEV" in payload["kev"]["sources"]
+    assert "FBI Flash" in payload["kev"]["sources"]
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_hit_date_added_parsed(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["date_added"] == "2024-03-29"
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_hit_no_error_field(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["error"] is None
+
+
+# ===========================================================================
+# get_vulncheck_data — ransomware flag
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_ransomware_flag_parsed_true(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    kev_payload = {
+        "data": [
+            {
+                "cveID": "CVE-2024-3094",
+                "dateAdded": "2024-03-29",
+                "sources": ["CISA KEV"],
+                "ransomwareUse": True,
+            }
+        ]
+    }
+    mock_get.side_effect = [
+        _make_requests_response(kev_payload),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["ransomware_use"] is True
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_ransomware_flag_parsed_false(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["ransomware_use"] is False
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_ransomware_known_campaign_use_field(mock_get, monkeypatch):
+    """knownRansomwareCampaignUse field should set ransomware_use=True."""
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    kev_payload = {
+        "data": [
+            {
+                "cveID": "CVE-2024-3094",
+                "knownRansomwareCampaignUse": True,
+                "sources": [],
+            }
+        ]
+    }
+    mock_get.side_effect = [
+        _make_requests_response(kev_payload),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["ransomware_use"] is True
+
+
+# ===========================================================================
+# get_vulncheck_data — no KEV match
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_no_kev_match_in_kev_false(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_empty_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use("CVE-2021-99999"))
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["in_kev"] is False
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_no_kev_match_sources_empty(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_empty_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use("CVE-2021-99999"))
+    payload = result["content"][0]["json"]
+    assert payload["kev"]["sources"] == []
+
+
+# ===========================================================================
+# get_vulncheck_data — NVD2 enriched CPE extraction
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_nvd2_cpe_matches_extracted(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    cpe_matches = payload["nvd2"]["cpe_matches"]
+    assert len(cpe_matches) == 2
+    assert "cpe:2.3:a:tukaani:xz_utils:5.6.0:*:*:*:*:*:*:*" in cpe_matches
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_nvd2_cvss_score_extracted(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["nvd2"]["cvss_v3_score"] == 10.0
+    assert payload["nvd2"]["cvss_v3_severity"] == "CRITICAL"
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_nvd2_description_extracted(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_response()),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert "xz" in payload["nvd2"]["description"].lower()
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_nvd2_empty_data_returns_none_fields(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_empty_response()),
+        _make_requests_response({"data": []}),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use("CVE-2021-99999"))
+    payload = result["content"][0]["json"]
+    assert payload["nvd2"]["cvss_v3_score"] is None
+    assert payload["nvd2"]["cpe_matches"] == []
+
+
+# ===========================================================================
+# get_vulncheck_data — network / API errors
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_network_failure_sets_error(mock_get, monkeypatch):
+    import requests as req_lib
+
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = req_lib.exceptions.ConnectionError("timeout")
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["error"] is not None
+    assert "KEV" in payload["error"] or "request" in payload["error"].lower()
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_failure_still_tries_nvd2(mock_get, monkeypatch):
+    """Even if KEV fails, NVD2 should still be attempted."""
+    import requests as req_lib
+
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    # First call (KEV) → error; second call (NVD2) → success
+    mock_get.side_effect = [
+        req_lib.exceptions.ConnectionError("timeout"),
+        _make_requests_response(_make_nvd2_response()),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    # NVD2 should have populated CPE matches
+    assert len(payload["nvd2"]["cpe_matches"]) > 0
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_both_endpoints_fail_error_combined(mock_get, monkeypatch):
+    """Both failures should produce a combined error string."""
+    import requests as req_lib
+
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = req_lib.exceptions.ConnectionError("timeout")
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["available"] is True  # key was present; enrichment attempted
+    assert payload["error"] is not None
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_http_401_error_propagated(mock_get, monkeypatch):
+    import requests as req_lib
+
+    monkeypatch.setenv("VULNCHECK_API_KEY", "invalid-key")
+    http_err = req_lib.exceptions.HTTPError("401 Unauthorized")
+    mock_get.side_effect = http_err
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["error"] is not None
+
+
+# ===========================================================================
+# get_vulncheck_data — cve_id normalisation
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_cve_id_uppercased(mock_get, monkeypatch):
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_empty_response()),
+        _make_requests_response({"data": []}),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data({"toolUseId": "t", "input": {"cve_id": "cve-2024-3094"}})
+    payload = result["content"][0]["json"]
+    assert payload["cve_id"] == "CVE-2024-3094"
+
+
+# ===========================================================================
+# get_vulncheck_data — KEV sources from alternative field names
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_kev_reported_by_field_used_as_sources(mock_get, monkeypatch):
+    """reportedBy (alternative field) should populate kev.sources."""
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    kev_payload = {
+        "data": [
+            {
+                "cveID": "CVE-2024-3094",
+                "reportedBy": ["NVD", "CERT-EU"],
+            }
+        ]
+    }
+    mock_get.side_effect = [
+        _make_requests_response(kev_payload),
+        _make_requests_response({"data": []}),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert "NVD" in payload["kev"]["sources"]
+
+
+# ===========================================================================
+# get_vulncheck_data — NVD2 cvssMetricV30 fallback
+# ===========================================================================
+
+
+@patch("manus_use.tools.get_vulncheck_data.requests.get")
+def test_nvd2_cvss_v30_fallback(mock_get, monkeypatch):
+    """Should parse cvssMetricV30 when cvssMetricV31 is absent."""
+    monkeypatch.setenv("VULNCHECK_API_KEY", "test-key")
+    nvd2_payload = {
+        "data": [
+            {
+                "id": "CVE-2021-44228",
+                "descriptions": [],
+                "metrics": {
+                    "cvssMetricV30": [
+                        {
+                            "cvssData": {
+                                "baseScore": 9.8,
+                                "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                "baseSeverity": "CRITICAL",
+                            }
+                        }
+                    ]
+                },
+                "configurations": [],
+            }
+        ]
+    }
+    mock_get.side_effect = [
+        _make_requests_response(_make_kev_empty_response()),
+        _make_requests_response(nvd2_payload),
+    ]
+    from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+
+    result = get_vulncheck_data(_make_tool_use("CVE-2021-44228"))
+    payload = result["content"][0]["json"]
+    assert payload["nvd2"]["cvss_v3_score"] == 9.8
+
+
+# ===========================================================================
+# VI agent tool list includes get_vulncheck_data
+# ===========================================================================
+
+
+def test_vi_agent_imports_get_vulncheck_data():
+    """get_vulncheck_data module must be importable."""
+    from manus_use.tools.get_vulncheck_data import TOOL_SPEC, get_vulncheck_data
+
+    assert callable(get_vulncheck_data)
+    assert TOOL_SPEC["name"] == "get_vulncheck_data"
+
+
+def test_vi_agent_system_prompt_mentions_vulncheck():
+    """The VI agent system prompt should reference VulnCheck KEV."""
+    from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "get_vulncheck_data" in SYSTEM_PROMPT
+    assert "VulnCheck" in SYSTEM_PROMPT
+
+
+def test_vi_agent_system_prompt_mentions_actively_exploited():
+    """System prompt should instruct agent to flag active exploitation."""
+    from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "ACTIVELY EXPLOITED" in SYSTEM_PROMPT
+
+
+def test_vi_agent_system_prompt_mentions_ransomware():
+    """System prompt should instruct agent to surface ransomware association."""
+    from manus_use.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "RANSOMWARE" in SYSTEM_PROMPT or "ransomware" in SYSTEM_PROMPT
+
+
+def test_vi_agent_module_imports_without_strands():
+    """vi_agent module should import cleanly without strands installed."""
+    import manus_use.agents.vi_agent as vi
+
+    assert hasattr(vi, "VulnerabilityIntelligenceAgent")
+    assert hasattr(vi, "SYSTEM_PROMPT")
+
+
+# ===========================================================================
+# track_vendor_response — basic structure
+# ===========================================================================
+
+
+def test_track_vendor_response_module_importable():
+    from manus_use.tools.track_vendor_response import TOOL_SPEC, track_vendor_response
+
+    assert callable(track_vendor_response)
+    assert TOOL_SPEC["name"] == "track_vendor_response"
+
+
+def test_track_vendor_response_invalid_cve():
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response({"toolUseId": "x", "input": {"cve_id": "NOT-A-CVE"}})
+    assert result["status"] == "error"
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_unknown_state_when_no_data(mock_vc, mock_cisa, mock_nvd):
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["vendor_response_state"] == "unknown"
+    assert "cve_id" in payload
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_patch_tag_gives_patch_available(mock_vc, mock_cisa, mock_nvd):
+    mock_nvd.return_value = [{"tags": ["Patch", "Vendor Advisory"], "url": "https://example.com/patch"}]
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["vendor_response_state"] == "patch_available"
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_vulncheck_kev_hit_elevates_state(mock_vc, mock_cisa, mock_nvd):
+    """VulnCheck KEV hit should elevate unknown → investigating."""
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {"cveID": "CVE-2024-3094", "sources": ["FBI Flash"]}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    # Should be elevated from unknown to at least investigating.
+    assert payload["vendor_response_state"] != "unknown"
+    assert payload["signals"]["vulncheck_kev_hit"] is True
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_vulncheck_kev_increases_confidence(mock_vc, mock_cisa, mock_nvd):
+    """VulnCheck KEV hit should increase confidence above baseline."""
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {"cveID": "CVE-2024-3094"}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["confidence"] > 0.2  # above the absolute minimum
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_cisa_kev_update_action(mock_vc, mock_cisa, mock_nvd):
+    """CISA KEV with 'Apply update' action should yield patch_available."""
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {
+        "cveID": "CVE-2024-3094",
+        "requiredAction": "Apply update per vendor instructions.",
+        "shortDescription": "Actively exploited.",
+    }
+    mock_vc.return_value = {}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["vendor_response_state"] == "patch_available"
+    assert payload["signals"]["cisa_kev_hit"] is True
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_evidence_list_populated(mock_vc, mock_cisa, mock_nvd):
+    mock_nvd.return_value = [{"tags": ["Patch"], "url": "https://example.com"}]
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert isinstance(payload["evidence"], list)
+    assert len(payload["evidence"]) > 0
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_state_always_valid(mock_vc, mock_cisa, mock_nvd):
+    """Returned state must always be one of the 6 valid values."""
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {}
+    from manus_use.tools.track_vendor_response import _VALID_STATES, track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    assert payload["vendor_response_state"] in _VALID_STATES
+
+
+@patch("manus_use.tools.track_vendor_response._fetch_nvd_references")
+@patch("manus_use.tools.track_vendor_response._fetch_cisa_kev")
+@patch("manus_use.tools.track_vendor_response._fetch_vulncheck_kev")
+def test_track_vendor_response_ransomware_in_evidence(mock_vc, mock_cisa, mock_nvd):
+    """Ransomware signal from VulnCheck should appear in evidence list."""
+    mock_nvd.return_value = []
+    mock_cisa.return_value = {}
+    mock_vc.return_value = {"cveID": "CVE-2024-3094", "ransomwareUse": True}
+    from manus_use.tools.track_vendor_response import track_vendor_response
+
+    result = track_vendor_response(_make_tool_use())
+    payload = result["content"][0]["json"]
+    evidence_text = " ".join(payload["evidence"]).lower()
+    assert "ransomware" in evidence_text


### PR DESCRIPTION
## What & Why

Adds VulnCheck as a third intelligence source alongside NVD and GitHub/GHSA, completing the core CVE enrichment pipeline.

**The problem:** `check_cisa_kev` only covers ~1200 CISA-listed CVEs. VulnCheck KEV aggregates 100s of sources (FBI Flash, CERT advisories, threat intel feeds) and tracks ransomware association — giving far broader active-exploitation coverage.

**VulnCheck NVD2** provides enriched CPE matching that improves version range accuracy in `get_version_ranges`.

## Changes

- `src/manus_use/tools/get_vulncheck_data.py` — new Strands tool querying VulnCheck KEV + NVD2 with graceful degradation when `VULNCHECK_API_KEY` is absent
- `vi_agent.py` — `get_vulncheck_data` added to tool list; system prompt updated: 🚨 ACTIVELY EXPLOITED banner on KEV hit, ⚠️ RANSOMWARE ASSOCIATED warning, enriched CPE for version ranges
- `track_vendor_response.py` — new tool: 6-state vendor response classifier with VulnCheck KEV hit elevating classification confidence
- Optional `VULNCHECK_API_KEY` env var — CI passes without it

## Tests

41 mocked tests: KEV hit/miss, no-key degradation, network errors, ransomware flag, NVD2 CPE extraction, VI agent wiring, vendor-response integration.