### PR TITLE
feat: multi-source PoC aggregator (search_poc_sources)

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,42 @@ manus-use discover --output json
 | `--dry-run` | off | Discover CVEs but do not submit them |
 | `--config FILE` | — | Override config |
 
+### `manus-use poc-search <CVE-ID>` — Multi-source PoC aggregator
+
+```bash
+# Search all sources for PoC exploits for a CVE
+manus-use poc-search CVE-2024-3094
+
+# Filter to specific sources
+manus-use poc-search CVE-2024-3094 --sources trickest,exploitdb,github
+
+# Machine-readable output
+manus-use poc-search CVE-2024-3094 --output json | jq .exploited_in_wild
+```
+
+Queries five public PoC sources **in parallel** and returns a unified,
+deduplicated result set sorted by exploited-in-wild status and publication date:
+
+| Source | What it provides |
+|---|---|
+| `trickest` | [trickest/cve](https://github.com/trickest/cve) — 250k+ CVE PoC index |
+| `vulncheck_kev` | [VulnCheck KEV](https://vulncheck.com) — exploited-in-wild signal from 100+ intel sources (requires `VULNCHECK_API_KEY`) |
+| `exploitdb` | [Exploit-DB](https://www.exploit-db.com) CSV — cached 24 h |
+| `github` | GitHub repo search for repositories mentioning the CVE |
+| `nvd` | NVD references filtered for GitHub / Exploit-DB / PacketStorm URLs |
+
+When `VULNCHECK_API_KEY` is absent the `vulncheck_kev` source is skipped
+gracefully; all other sources are unaffected.
+
+**⚠️ EXPLOITED IN WILD banner** — printed at the top when VulnCheck KEV
+confirms the CVE is actively exploited in the wild.
+
+| Flag | Default | Description |
+|---|---|---|
+| `--output {text,json}` | `text` | Output format |
+| `--sources LIST` | all | Comma-separated subset: `trickest,vulncheck_kev,exploitdb,github,nvd` |
+
+
 ### `manus-use history` — Browse past runs
 
 ```bash

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -3,7 +3,7 @@
 This module provides :class:`VulnerabilityIntelligenceAgent`, a Strands-based
 agent that produces a comprehensive, actionable vulnerability report for a given
 CVE identifier using free, public data sources (NVD, CISA KEV, OTX, GitHub
-advisories, Exploit-DB, PacketStorm, …) and optional Docker-based exploit
+advisories, Exploit-DB, PacketStorm, â¦) and optional Docker-based exploit
 verification.
 
 The module is written so it can be *imported* without the optional heavy
@@ -27,7 +27,7 @@ __all__ = ["VulnerabilityIntelligenceAgent", "DEFAULT_MODEL_ID"]
 # Kept as a single named constant rather than scattered literals.
 DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
-# Repository root (…/manus-use) — used to locate bundled skills.
+# Repository root (â¦/manus-use) â used to locate bundled skills.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 SYSTEM_PROMPT = """
@@ -52,22 +52,23 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 
 **Step 1b: VulnCheck Enrichment**
 - Call `get_vulncheck_data` for the CVE. This provides two critical enrichments:
-  - **VulnCheck KEV**: exploitation status aggregated from 100+ sources (FBI Flash, CERT advisories, threat-intel feeds) — far broader than CISA KEV's ~1200 entries.
-  - **VulnCheck NVD2**: enriched CPE matching — use `nvd2.cpe_matches` to improve version range analysis in Step 3 and beyond.
-- If `kev.in_kev = True`: prepend **🚨 ACTIVELY EXPLOITED (VulnCheck KEV)** to the analysis and list all sources from `kev.sources`.
-- If `kev.ransomware_use = True`: add **⚠️ RANSOMWARE ASSOCIATED** warning prominently in the report.
+  - **VulnCheck KEV**: exploitation status aggregated from 100+ sources (FBI Flash, CERT advisories, threat-intel feeds) â far broader than CISA KEV's ~1200 entries.
+  - **VulnCheck NVD2**: enriched CPE matching â use `nvd2.cpe_matches` to improve version range analysis in Step 3 and beyond.
+- If `kev.in_kev = True`: prepend **ð¨ ACTIVELY EXPLOITED (VulnCheck KEV)** to the analysis and list all sources from `kev.sources`.
+- If `kev.ransomware_use = True`: add **â ï¸ RANSOMWARE ASSOCIATED** warning prominently in the report.
 - If `available = False` (no API key): note that VulnCheck enrichment is unavailable and continue with other sources.
 
 **Step 2: Check for Known Exploitation and EPSS Trend**
 - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
-- Call `get_epss_trend` with the CVE ID (default 30 days of history). A `spike_detected=true` result (>0.10 jump in 7 days) indicates the vulnerability has recently been weaponised or discovered by attackers — flag this prominently in the report with the spike date and magnitude.
+- Call `get_epss_trend` with the CVE ID (default 30 days of history). A `spike_detected=true` result (>0.10 jump in 7 days) indicates the vulnerability has recently been weaponised or discovered by attackers â flag this prominently in the report with the spike date and magnitude.
 
 **Step 3: Gather Public Exploits and Advisories**
-- First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week — note this in your analysis.
+- First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week â note this in your analysis.
 - Then call `get_trickest_pocs` with the CVE ID for a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily).
 - Then call `search_for_exploits` (GitHub), `search_exploit_db`, and `search_packetstorm` to find additional PoCs not yet indexed by either source.
 - Merge all results, deduplicating URLs.
+- Also call `search_poc_sources` with the CVE ID to run a parallel multi-source search across trickest/cve, VulnCheck KEV, Exploit-DB, GitHub, and NVD references. If `exploited_in_wild=True` in the result, prepend ⚠️ EXPLOITED IN WILD to the report. If `recent_activity=True`, note that fresh PoC activity was observed in the last 30 days.
 
 **Step 4: Mandatory URL Verification and PoC Identification**
 - Consolidate all URLs found from your data gathering into a single list. This includes links from advisories, exploit databases, and threat intelligence pulses.
@@ -104,8 +105,8 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 
 **Step 6b: Exploit Complexity Scoring**
 - Call `score_exploit_complexity` with the CVE ID. Include in the report:
-  - The overall complexity score (1–5) and label (trivial / low / moderate / high / very_high).
-  - The `attacker_friendly` flag — if True, flag prominently that this CVE is easy to weaponise.
+  - The overall complexity score (1â5) and label (trivial / low / moderate / high / very_high).
+  - The `attacker_friendly` flag â if True, flag prominently that this CVE is easy to weaponise.
   - Per-dimension breakdown: lines of code, authentication required, network hops, OS/platform dependencies, exploit chain length.
   - Whether the score was derived from PoC code analysis or NVD CVSS vector only.
   This score contextualises raw CVSS severity: a CVSS 9.8 with complexity_score=1.5 is far more urgent than the same CVSS with complexity_score=4.5.
@@ -207,6 +208,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
             from manus_use.tools.get_vulncheck_data import get_vulncheck_data
             from manus_use.tools.score_exploit_complexity import score_exploit_complexity
+            from manus_use.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -260,6 +262,7 @@ class VulnerabilityIntelligenceAgent:
             get_patch_diff,
             score_exploit_complexity,
             get_vulncheck_data,
+            search_poc_sources,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1368,8 +1368,7 @@ def _build_poc_search_parser() -> argparse.ArgumentParser:
         default="",
         metavar="LIST",
         help=(
-            "Comma-separated sources to query "
-            "(default: all). Valid values: trickest,vulncheck_kev,exploitdb,github,nvd"
+            "Comma-separated sources to query (default: all). Valid values: trickest,vulncheck_kev,exploitdb,github,nvd"
         ),
     )
     return p
@@ -1436,13 +1435,7 @@ def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
     col_date = 12
     col_url = 70
 
-    header = (
-        f"{'Source':<{col_src}}  "
-        f"{'Exploited?':<{col_eaw}}  "
-        f"{'Title':<{col_title}}  "
-        f"{'Date':<{col_date}}  "
-        f"URL"
-    )
+    header = f"{'Source':<{col_src}}  {'Exploited?':<{col_eaw}}  {'Title':<{col_title}}  {'Date':<{col_date}}  URL"
     print(header)
     print("-" * (col_src + col_eaw + col_title + col_date + col_url + 8))
 
@@ -1452,13 +1445,7 @@ def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
         title = (r.get("title") or "")[:col_title]
         date = (r.get("published") or "")[:col_date]
         url = (r.get("url") or "")[:col_url]
-        print(
-            f"{src:<{col_src}}  "
-            f"{eaw_flag:<{col_eaw}}  "
-            f"{title:<{col_title}}  "
-            f"{date:<{col_date}}  "
-            f"{url}"
-        )
+        print(f"{src:<{col_src}}  {eaw_flag:<{col_eaw}}  {title:<{col_title}}  {date:<{col_date}}  {url}")
 
     return 0
 

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1053,6 +1053,7 @@ _SUBCOMMANDS = {
     "patch-diff",
     "compare",
     "exploit-complexity",
+    "poc-search",
 }
 
 
@@ -1338,6 +1339,127 @@ def _run_exploit_complexity(argv: list[str]) -> int:
         return 0
 
     print(_render_text(result))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# poc-search subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_poc_search_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use poc-search",
+        description=(
+            "Search multiple public sources for PoC exploits related to a CVE.\n"
+            "Sources: trickest/cve, VulnCheck KEV, Exploit-DB, GitHub, NVD refs."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    p.add_argument(
+        "--sources",
+        default="",
+        metavar="LIST",
+        help=(
+            "Comma-separated sources to query "
+            "(default: all). Valid values: trickest,vulncheck_kev,exploitdb,github,nvd"
+        ),
+    )
+    return p
+
+
+def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
+    import json as _json
+    import re as _re
+
+    parser = _build_poc_search_parser()
+    args = parser.parse_args(argv)
+    cve_id: str = args.cve_id.strip()
+
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id, _re.IGNORECASE):
+        parser.error(f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN")
+
+    try:
+        from manus_use.tools.search_poc_sources import aggregate_poc_results
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    source_list = None
+    if args.sources.strip():
+        source_list = [s.strip() for s in args.sources.split(",") if s.strip()]
+
+    result = aggregate_poc_results(cve_id, source_list)
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    # ---- text output ----
+    total = result.get("total_found", 0)
+    eaw = result.get("exploited_in_wild", False)
+    recent = result.get("recent_activity", False)
+    sources_checked = result.get("sources_checked", [])
+    sources_failed = result.get("sources_failed", [])
+    results = result.get("results", [])
+
+    if eaw:
+        print()
+        print("  ⚠️  EXPLOITED IN WILD  ⚠️")
+        print("  VulnCheck KEV confirms active exploitation in the wild.")
+        print()
+
+    print(f"PoC Search: {cve_id.upper()}")
+    print(f"  Sources checked : {', '.join(sorted(sources_checked)) or '—'}")
+    if sources_failed:
+        print(f"  Sources failed  : {', '.join(sorted(sources_failed))}")
+    print(f"  Results found   : {total}")
+    if recent:
+        print("  ⚡ Recent activity (last 30 days) detected")
+    print()
+
+    if not results:
+        print("No PoC results found.")
+        return 0
+
+    # Table header
+    col_src = 14
+    col_eaw = 10
+    col_title = 30
+    col_date = 12
+    col_url = 70
+
+    header = (
+        f"{'Source':<{col_src}}  "
+        f"{'Exploited?':<{col_eaw}}  "
+        f"{'Title':<{col_title}}  "
+        f"{'Date':<{col_date}}  "
+        f"URL"
+    )
+    print(header)
+    print("-" * (col_src + col_eaw + col_title + col_date + col_url + 8))
+
+    for r in results:
+        src = (r.get("source") or "")[:col_src]
+        eaw_flag = "YES ⚠️" if r.get("exploited_in_wild") else "no"
+        title = (r.get("title") or "")[:col_title]
+        date = (r.get("published") or "")[:col_date]
+        url = (r.get("url") or "")[:col_url]
+        print(
+            f"{src:<{col_src}}  "
+            f"{eaw_flag:<{col_eaw}}  "
+            f"{title:<{col_title}}  "
+            f"{date:<{col_date}}  "
+            f"{url}"
+        )
+
     return 0
 
 
@@ -1652,6 +1774,10 @@ def main() -> None:
     if first_positional == "exploit-complexity":
         idx = argv.index("exploit-complexity")
         sys.exit(_run_exploit_complexity(argv[idx + 1 :]))
+
+    if first_positional == "poc-search":
+        idx = argv.index("poc-search")
+        sys.exit(_run_poc_search(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/search_poc_sources.py
+++ b/src/manus_use/tools/search_poc_sources.py
@@ -1,0 +1,492 @@
+"""
+Tool: search_poc_sources
+
+Multi-source PoC aggregator for a CVE ID.  Queries five public sources in
+parallel and returns a unified, deduplicated, and ranked result set:
+
+  1. trickest/cve  — GitHub tree API (always checked)
+  2. VulnCheck KEV — exploited-in-wild signal (skipped gracefully when no key)
+  3. Exploit-DB    — CSV index (cached 24 h at /tmp/exploitdb_cache.csv)
+  4. GitHub search — repos/code mentioning the CVE
+  5. NVD refs      — filtered for github.com / exploit-db.com / packetstorm
+
+The tool is deliberately source-agnostic: all results share a common schema
+so consumers can sort, filter, and display them uniformly.
+
+CLI: ``manus-use poc-search CVE-XXXX-YYYY``
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import os
+import re
+import time
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from datetime import datetime, timezone
+from typing import Any
+
+from strands import tool
+
+__all__ = ["search_poc_sources"]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-(\d{4})-\d+$", re.IGNORECASE)
+_EXPLOITDB_CACHE = "/tmp/exploitdb_cache.csv"
+_EXPLOITDB_CSV_URL = (
+    "https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv"
+)
+_EXPLOITDB_CACHE_TTL = 86_400  # 24 hours in seconds
+_GITHUB_API = "https://api.github.com"
+_NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_VULNCHECK_KEV = "https://api.vulncheck.com/v3/index/vulncheck-kev"
+_POC_URL_PATTERNS = re.compile(
+    r"(github\.com|exploit-db\.com|packetstormsecurity\.com)", re.IGNORECASE
+)
+_REQUEST_TIMEOUT = 20  # seconds
+
+# ---------------------------------------------------------------------------
+# Shared HTTP helper
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str, headers: dict[str, str] | None = None) -> Any:
+    """Minimal HTTP GET returning parsed JSON; raises on failure."""
+    import json
+
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+        return json.loads(resp.read().decode())
+
+
+# ---------------------------------------------------------------------------
+# URL normalisation (for deduplication)
+# ---------------------------------------------------------------------------
+
+
+def _normalize_url(url: str) -> str:
+    url = url.strip().lower()
+    url = url.rstrip("/")
+    if url.endswith(".git"):
+        url = url[:-4]
+    return url
+
+
+# ---------------------------------------------------------------------------
+# Source 1: trickest/cve
+# ---------------------------------------------------------------------------
+
+
+def _fetch_trickest(cve_id: str) -> list[dict]:
+    """Return PoC entries from the trickest/cve GitHub tree."""
+    results: list[dict] = []
+    m = _CVE_RE.match(cve_id)
+    if not m:
+        return results
+    year = m.group(1)
+
+    tree_url = "https://api.github.com/repos/trickest/cve/git/trees/main?recursive=0"
+    try:
+        tree_data = _get(tree_url)
+    except Exception as exc:
+        logger.debug("trickest tree fetch failed: %s", exc)
+        return results
+
+    # Find the year folder SHA
+    year_sha = None
+    for item in tree_data.get("tree", []):
+        if item.get("path") == year and item.get("type") == "tree":
+            year_sha = item["sha"]
+            break
+
+    if not year_sha:
+        return results
+
+    # Fetch the year subtree (non-recursive — just list CVE folders)
+    try:
+        year_tree = _get(
+            f"https://api.github.com/repos/trickest/cve/git/trees/{year_sha}"
+        )
+    except Exception as exc:
+        logger.debug("trickest year tree fetch failed: %s", exc)
+        return results
+
+    cve_upper = cve_id.upper()
+    for item in year_tree.get("tree", []):
+        if item.get("path", "").upper() == cve_upper:
+            url = f"https://github.com/trickest/cve/tree/main/{year}/{cve_upper}"
+            results.append(
+                {
+                    "source": "trickest",
+                    "url": url,
+                    "title": f"{cve_upper} — trickest/cve index",
+                    "published": None,
+                    "author": "trickest",
+                    "tags": ["index"],
+                    "exploited_in_wild": False,
+                }
+            )
+            break
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Source 2: VulnCheck KEV
+# ---------------------------------------------------------------------------
+
+
+def _fetch_vulncheck_kev(cve_id: str) -> list[dict]:
+    """Query VulnCheck KEV for exploited-in-wild status."""
+    api_key = os.environ.get("VULNCHECK_API_KEY", "")
+    if not api_key:
+        logger.debug("VULNCHECK_API_KEY not set — skipping VulnCheck KEV")
+        return []
+
+    url = f"{_VULNCHECK_KEV}?cve={urllib.parse.quote(cve_id)}"
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    try:
+        data = _get(url, headers=headers)
+    except Exception as exc:
+        logger.debug("VulnCheck KEV fetch failed: %s", exc)
+        return []
+
+    results: list[dict] = []
+    for entry in data.get("data", []):
+        entry_cve = entry.get("cveID", "") or entry.get("cve_id", "")
+        if entry_cve.upper() != cve_id.upper():
+            continue
+        date_added = entry.get("dateAdded") or entry.get("date_added")
+        sources = entry.get("sources") or []
+        tags = ["kev"]
+        if entry.get("ransomwareUse") or entry.get("ransomware_use"):
+            tags.append("ransomware")
+        results.append(
+            {
+                "source": "vulncheck_kev",
+                "url": f"https://vulncheck.com/browse/kev/{cve_id.lower()}",
+                "title": f"{cve_id} — VulnCheck KEV (exploited in wild)",
+                "published": date_added,
+                "author": ", ".join(sources) if sources else None,
+                "tags": tags,
+                "exploited_in_wild": True,
+            }
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Source 3: Exploit-DB CSV
+# ---------------------------------------------------------------------------
+
+
+def _ensure_exploitdb_cache() -> str | None:
+    """Return path to a fresh Exploit-DB CSV, downloading if needed."""
+    cache_path = _EXPLOITDB_CACHE
+    try:
+        mtime = os.path.getmtime(cache_path)
+        if time.time() - mtime < _EXPLOITDB_CACHE_TTL:
+            return cache_path
+    except FileNotFoundError:
+        pass
+
+    try:
+        req = urllib.request.Request(
+            _EXPLOITDB_CSV_URL, headers={"User-Agent": "manus-use"}
+        )
+        with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+            data = resp.read()
+        with open(cache_path, "wb") as fh:
+            fh.write(data)
+        return cache_path
+    except Exception as exc:
+        logger.debug("Exploit-DB CSV download failed: %s", exc)
+        return None
+
+
+def _fetch_exploitdb(cve_id: str) -> list[dict]:
+    """Filter the Exploit-DB CSV for rows matching the CVE ID."""
+    cache_path = _ensure_exploitdb_cache()
+    if not cache_path:
+        return []
+
+    results: list[dict] = []
+    cve_upper = cve_id.upper()
+    try:
+        with open(cache_path, encoding="utf-8", errors="replace") as fh:
+            reader = csv.DictReader(fh)
+            for row in reader:
+                codes = row.get("codes", "") or ""
+                if cve_upper not in codes.upper():
+                    continue
+                edb_id = (row.get("id") or "").strip()
+                title = (row.get("description") or row.get("title") or "").strip()
+                date_str = (
+                    row.get("date_published") or row.get("date") or ""
+                ).strip()
+                url = (
+                    f"https://www.exploit-db.com/exploits/{edb_id}"
+                    if edb_id
+                    else "https://www.exploit-db.com"
+                )
+                etype = (row.get("type") or "").strip().lower()
+                platform = (row.get("platform") or "").strip().lower()
+                tags = [t for t in [etype, platform] if t]
+                results.append(
+                    {
+                        "source": "exploitdb",
+                        "url": url,
+                        "title": title or f"Exploit-DB #{edb_id}",
+                        "published": date_str or None,
+                        "author": (row.get("author") or "").strip() or None,
+                        "tags": tags,
+                        "exploited_in_wild": False,
+                    }
+                )
+    except Exception as exc:
+        logger.debug("Exploit-DB CSV parse failed: %s", exc)
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Source 4: GitHub repo search
+# ---------------------------------------------------------------------------
+
+
+def _fetch_github(cve_id: str) -> list[dict]:
+    """Search GitHub repositories mentioning the CVE ID."""
+    query = urllib.parse.quote(cve_id)
+    url = (
+        f"{_GITHUB_API}/search/repositories"
+        f"?q={query}&sort=updated&per_page=5"
+    )
+    headers = {"Accept": "application/vnd.github+json"}
+    gh_token = os.environ.get("GITHUB_TOKEN", "")
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+
+    try:
+        data = _get(url, headers=headers)
+    except Exception as exc:
+        logger.debug("GitHub repo search failed: %s", exc)
+        return []
+
+    results: list[dict] = []
+    for item in data.get("items", []):
+        pushed = item.get("pushed_at")
+        published = pushed[:10] if pushed else None
+        results.append(
+            {
+                "source": "github",
+                "url": item.get("html_url", ""),
+                "title": item.get("full_name", item.get("name", "")),
+                "published": published,
+                "author": (item.get("owner") or {}).get("login"),
+                "tags": ["github-repo"],
+                "exploited_in_wild": False,
+            }
+        )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Source 5: NVD references
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd(cve_id: str) -> list[dict]:
+    """Extract PoC-relevant URLs from NVD references."""
+    url = f"{_NVD_API}?cveId={urllib.parse.quote(cve_id)}"
+    try:
+        data = _get(url)
+    except Exception as exc:
+        logger.debug("NVD fetch failed: %s", exc)
+        return []
+
+    results: list[dict] = []
+    for vuln in data.get("vulnerabilities", []):
+        cve_data = vuln.get("cve", {})
+        pub = cve_data.get("published", "")
+        published = pub[:10] if pub else None
+        for ref in cve_data.get("references", []):
+            ref_url = ref.get("url", "")
+            if not _POC_URL_PATTERNS.search(ref_url):
+                continue
+            tags = [t.lower() for t in (ref.get("tags") or [])]
+            results.append(
+                {
+                    "source": "nvd",
+                    "url": ref_url,
+                    "title": ref_url,
+                    "published": published,
+                    "author": None,
+                    "tags": tags,
+                    "exploited_in_wild": False,
+                }
+            )
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+_ALL_SOURCES = ["trickest", "vulncheck_kev", "exploitdb", "github", "nvd"]
+
+# Map source name -> module-level attribute name; looked up dynamically so
+# unit tests can patch individual _fetch_* functions on the module object.
+_SOURCE_FN_NAMES = {
+    "trickest": "_fetch_trickest",
+    "vulncheck_kev": "_fetch_vulncheck_kev",
+    "exploitdb": "_fetch_exploitdb",
+    "github": "_fetch_github",
+    "nvd": "_fetch_nvd",
+}
+
+def _get_source_fn(source: str):
+    """Resolve a source fetcher by name from this module (supports test patching)."""
+    import manus_use.tools.search_poc_sources as _self
+    attr = _SOURCE_FN_NAMES.get(source)
+    if attr is None:
+        return None
+    return getattr(_self, attr, None)
+
+
+def _parse_date(date_str: str | None) -> datetime | None:
+    """Parse ISO date string; return None on failure."""
+    if not date_str:
+        return None
+    for fmt in ("%Y-%m-%d", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M:%SZ"):
+        try:
+            return datetime.strptime(date_str[:19], fmt)
+        except ValueError:
+            continue
+    return None
+
+
+def _is_recent(date_str: str | None, days: int = 30) -> bool:
+    dt = _parse_date(date_str)
+    if dt is None:
+        return False
+    now = datetime.now(timezone.utc).replace(tzinfo=None)
+    return (now - dt).days <= days
+
+
+def aggregate_poc_results(
+    cve_id: str,
+    sources: list[str] | None = None,
+) -> dict:
+    """Fetch PoC data from requested sources in parallel and aggregate."""
+    if sources is None:
+        sources = _ALL_SOURCES
+
+    raw_results: list[dict] = []
+    sources_checked: list[str] = []
+    sources_failed: list[str] = []
+
+    with ThreadPoolExecutor(max_workers=max(1, len(sources))) as pool:
+        futures = {
+            pool.submit(_get_source_fn(s), cve_id): s
+            for s in sources
+            if _get_source_fn(s) is not None
+        }
+        for future in as_completed(futures):
+            src = futures[future]
+            sources_checked.append(src)
+            try:
+                raw_results.extend(future.result())
+            except Exception as exc:
+                logger.debug("Source %s raised: %s", src, exc)
+                sources_failed.append(src)
+
+    # Deduplicate by normalised URL
+    seen: dict[str, dict] = {}
+    for item in raw_results:
+        key = _normalize_url(item.get("url", ""))
+        if not key:
+            continue
+        if key not in seen:
+            seen[key] = item
+        elif item.get("exploited_in_wild"):
+            seen[key]["exploited_in_wild"] = True
+
+    deduped = list(seen.values())
+
+    def _sort_key(r: dict):
+        eaw = 0 if r.get("exploited_in_wild") else 1
+        dt = _parse_date(r.get("published"))
+        date_ts = -dt.timestamp() if dt else float("inf")
+        return (eaw, date_ts)
+
+    deduped.sort(key=_sort_key)
+
+    any_kev = any(r.get("exploited_in_wild") for r in deduped)
+    any_recent = any(_is_recent(r.get("published")) for r in deduped)
+
+    return {
+        "cve_id": cve_id.upper(),
+        "total_found": len(deduped),
+        "exploited_in_wild": any_kev,
+        "recent_activity": any_recent,
+        "sources_checked": sorted(sources_checked),
+        "sources_failed": sorted(sources_failed),
+        "results": deduped,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
+@tool
+def search_poc_sources(cve_id: str, sources: str = "") -> dict:
+    """Search multiple public sources for PoC exploits related to a CVE.
+
+    Queries trickest/cve, VulnCheck KEV (exploited-in-wild), Exploit-DB,
+    GitHub repositories, and NVD references in parallel.  Results are
+    deduplicated by URL and sorted with exploited-in-wild entries first,
+    then by publication date descending.
+
+    Args:
+        cve_id: CVE identifier (e.g. CVE-2024-3094).
+        sources: Optional comma-separated list of sources to query.
+            Valid values: trickest, vulncheck_kev, exploitdb, github, nvd.
+            Leave empty to query all sources.
+
+    Returns:
+        Dictionary with keys: cve_id, total_found, exploited_in_wild,
+        recent_activity, sources_checked, sources_failed, results.
+        Each result has: source, url, title, published, author, tags,
+        exploited_in_wild.
+    """
+    cve_id = cve_id.strip()
+    if not _CVE_RE.match(cve_id):
+        return {
+            "error": f"Invalid CVE identifier: {cve_id!r}",
+            "cve_id": cve_id,
+            "total_found": 0,
+            "exploited_in_wild": False,
+            "recent_activity": False,
+            "sources_checked": [],
+            "sources_failed": [],
+            "results": [],
+        }
+
+    source_list: list[str] | None = None
+    if sources.strip():
+        source_list = [s.strip() for s in sources.split(",") if s.strip()]
+
+    return aggregate_poc_results(cve_id, source_list)

--- a/src/manus_use/tools/search_poc_sources.py
+++ b/src/manus_use/tools/search_poc_sources.py
@@ -41,16 +41,12 @@ logger = logging.getLogger(__name__)
 
 _CVE_RE = re.compile(r"^CVE-(\d{4})-\d+$", re.IGNORECASE)
 _EXPLOITDB_CACHE = "/tmp/exploitdb_cache.csv"
-_EXPLOITDB_CSV_URL = (
-    "https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv"
-)
+_EXPLOITDB_CSV_URL = "https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv"
 _EXPLOITDB_CACHE_TTL = 86_400  # 24 hours in seconds
 _GITHUB_API = "https://api.github.com"
 _NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 _VULNCHECK_KEV = "https://api.vulncheck.com/v3/index/vulncheck-kev"
-_POC_URL_PATTERNS = re.compile(
-    r"(github\.com|exploit-db\.com|packetstormsecurity\.com)", re.IGNORECASE
-)
+_POC_URL_PATTERNS = re.compile(r"(github\.com|exploit-db\.com|packetstormsecurity\.com)", re.IGNORECASE)
 _REQUEST_TIMEOUT = 20  # seconds
 
 # ---------------------------------------------------------------------------
@@ -112,9 +108,7 @@ def _fetch_trickest(cve_id: str) -> list[dict]:
 
     # Fetch the year subtree (non-recursive — just list CVE folders)
     try:
-        year_tree = _get(
-            f"https://api.github.com/repos/trickest/cve/git/trees/{year_sha}"
-        )
+        year_tree = _get(f"https://api.github.com/repos/trickest/cve/git/trees/{year_sha}")
     except Exception as exc:
         logger.debug("trickest year tree fetch failed: %s", exc)
         return results
@@ -200,9 +194,7 @@ def _ensure_exploitdb_cache() -> str | None:
         pass
 
     try:
-        req = urllib.request.Request(
-            _EXPLOITDB_CSV_URL, headers={"User-Agent": "manus-use"}
-        )
+        req = urllib.request.Request(_EXPLOITDB_CSV_URL, headers={"User-Agent": "manus-use"})
         with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
             data = resp.read()
         with open(cache_path, "wb") as fh:
@@ -230,14 +222,8 @@ def _fetch_exploitdb(cve_id: str) -> list[dict]:
                     continue
                 edb_id = (row.get("id") or "").strip()
                 title = (row.get("description") or row.get("title") or "").strip()
-                date_str = (
-                    row.get("date_published") or row.get("date") or ""
-                ).strip()
-                url = (
-                    f"https://www.exploit-db.com/exploits/{edb_id}"
-                    if edb_id
-                    else "https://www.exploit-db.com"
-                )
+                date_str = (row.get("date_published") or row.get("date") or "").strip()
+                url = f"https://www.exploit-db.com/exploits/{edb_id}" if edb_id else "https://www.exploit-db.com"
                 etype = (row.get("type") or "").strip().lower()
                 platform = (row.get("platform") or "").strip().lower()
                 tags = [t for t in [etype, platform] if t]
@@ -266,10 +252,7 @@ def _fetch_exploitdb(cve_id: str) -> list[dict]:
 def _fetch_github(cve_id: str) -> list[dict]:
     """Search GitHub repositories mentioning the CVE ID."""
     query = urllib.parse.quote(cve_id)
-    url = (
-        f"{_GITHUB_API}/search/repositories"
-        f"?q={query}&sort=updated&per_page=5"
-    )
+    url = f"{_GITHUB_API}/search/repositories?q={query}&sort=updated&per_page=5"
     headers = {"Accept": "application/vnd.github+json"}
     gh_token = os.environ.get("GITHUB_TOKEN", "")
     if gh_token:
@@ -355,9 +338,11 @@ _SOURCE_FN_NAMES = {
     "nvd": "_fetch_nvd",
 }
 
+
 def _get_source_fn(source: str):
     """Resolve a source fetcher by name from this module (supports test patching)."""
     import manus_use.tools.search_poc_sources as _self
+
     attr = _SOURCE_FN_NAMES.get(source)
     if attr is None:
         return None
@@ -397,11 +382,7 @@ def aggregate_poc_results(
     sources_failed: list[str] = []
 
     with ThreadPoolExecutor(max_workers=max(1, len(sources))) as pool:
-        futures = {
-            pool.submit(_get_source_fn(s), cve_id): s
-            for s in sources
-            if _get_source_fn(s) is not None
-        }
+        futures = {pool.submit(_get_source_fn(s), cve_id): s for s in sources if _get_source_fn(s) is not None}
         for future in as_completed(futures):
             src = futures[future]
             sources_checked.append(src)

--- a/tests/test_search_poc_sources.py
+++ b/tests/test_search_poc_sources.py
@@ -1,0 +1,929 @@
+"""Tests for search_poc_sources — multi-source PoC aggregator."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_url_response(payload: dict, status: int = 200) -> MagicMock:
+    resp = MagicMock()
+    resp.read.return_value = json.dumps(payload).encode()
+    resp.status = status
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+def _patch_urlopen(payload: dict):
+    return patch(
+        "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+        return_value=_make_url_response(payload),
+    )
+
+
+# ---------------------------------------------------------------------------
+# _normalize_url
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeUrl:
+    def test_strips_trailing_slash(self):
+        from manus_use.tools.search_poc_sources import _normalize_url
+
+        assert _normalize_url("https://example.com/foo/") == "https://example.com/foo"
+
+    def test_strips_dot_git(self):
+        from manus_use.tools.search_poc_sources import _normalize_url
+
+        assert _normalize_url("https://github.com/user/repo.git") == "https://github.com/user/repo"
+
+    def test_lowercases(self):
+        from manus_use.tools.search_poc_sources import _normalize_url
+
+        assert _normalize_url("HTTPS://EXAMPLE.COM") == "https://example.com"
+
+    def test_strips_both(self):
+        from manus_use.tools.search_poc_sources import _normalize_url
+
+        assert _normalize_url("HTTPS://GitHub.com/u/r.git/") == "https://github.com/u/r"
+
+    def test_empty_string(self):
+        from manus_use.tools.search_poc_sources import _normalize_url
+
+        assert _normalize_url("") == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_date
+# ---------------------------------------------------------------------------
+
+
+class TestParseDate:
+    def test_date_only(self):
+        from manus_use.tools.search_poc_sources import _parse_date
+
+        dt = _parse_date("2024-03-29")
+        assert dt is not None
+        assert dt.year == 2024
+        assert dt.month == 3
+        assert dt.day == 29
+
+    def test_datetime_with_z(self):
+        from manus_use.tools.search_poc_sources import _parse_date
+
+        dt = _parse_date("2024-03-29T12:00:00Z")
+        assert dt is not None
+
+    def test_datetime_without_z(self):
+        from manus_use.tools.search_poc_sources import _parse_date
+
+        dt = _parse_date("2024-03-29T12:00:00")
+        assert dt is not None
+
+    def test_none_input(self):
+        from manus_use.tools.search_poc_sources import _parse_date
+
+        assert _parse_date(None) is None
+
+    def test_garbage_input(self):
+        from manus_use.tools.search_poc_sources import _parse_date
+
+        assert _parse_date("not-a-date") is None
+
+
+# ---------------------------------------------------------------------------
+# _is_recent
+# ---------------------------------------------------------------------------
+
+
+class TestIsRecent:
+    def test_recent_date(self):
+        from datetime import datetime, timezone
+
+        from manus_use.tools.search_poc_sources import _is_recent
+
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        assert _is_recent(today) is True
+
+    def test_old_date(self):
+        from manus_use.tools.search_poc_sources import _is_recent
+
+        assert _is_recent("2020-01-01") is False
+
+    def test_none_date(self):
+        from manus_use.tools.search_poc_sources import _is_recent
+
+        assert _is_recent(None) is False
+
+
+# ---------------------------------------------------------------------------
+# _fetch_trickest
+# ---------------------------------------------------------------------------
+
+
+class TestFetchTrickest:
+    def test_returns_result_when_cve_found(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        tree_payload = {
+            "tree": [
+                {"path": "2024", "type": "tree", "sha": "abc123"},
+            ]
+        }
+        year_payload = {
+            "tree": [
+                {"path": "CVE-2024-3094", "type": "tree", "sha": "def456"},
+            ]
+        }
+        responses = [
+            _make_url_response(tree_payload),
+            _make_url_response(year_payload),
+        ]
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=responses,
+        ):
+            results = _fetch_trickest("CVE-2024-3094")
+
+        assert len(results) == 1
+        assert results[0]["source"] == "trickest"
+        assert "CVE-2024-3094" in results[0]["url"]
+        assert results[0]["exploited_in_wild"] is False
+
+    def test_returns_empty_when_year_not_in_tree(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        tree_payload = {"tree": [{"path": "2023", "type": "tree", "sha": "abc"}]}
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            return_value=_make_url_response(tree_payload),
+        ):
+            results = _fetch_trickest("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_when_cve_not_in_year(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        tree_payload = {"tree": [{"path": "2024", "type": "tree", "sha": "abc"}]}
+        year_payload = {"tree": [{"path": "CVE-2024-0001", "type": "tree"}]}
+        responses = [
+            _make_url_response(tree_payload),
+            _make_url_response(year_payload),
+        ]
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=responses,
+        ):
+            results = _fetch_trickest("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_on_network_error(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=OSError("network down"),
+        ):
+            results = _fetch_trickest("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_on_invalid_cve(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        results = _fetch_trickest("NOT-A-CVE")
+        assert results == []
+
+    def test_case_insensitive_cve_match(self):
+        from manus_use.tools.search_poc_sources import _fetch_trickest
+
+        tree_payload = {"tree": [{"path": "2024", "type": "tree", "sha": "abc"}]}
+        year_payload = {"tree": [{"path": "CVE-2024-3094", "type": "tree"}]}
+        responses = [
+            _make_url_response(tree_payload),
+            _make_url_response(year_payload),
+        ]
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=responses,
+        ):
+            results = _fetch_trickest("cve-2024-3094")
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# _fetch_vulncheck_kev
+# ---------------------------------------------------------------------------
+
+
+class TestFetchVulncheckKev:
+    def test_skips_without_api_key(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("VULNCHECK_API_KEY", None)
+            results = _fetch_vulncheck_kev("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_kev_entry_when_matched(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        payload = {
+            "data": [
+                {
+                    "cveID": "CVE-2024-3094",
+                    "dateAdded": "2024-03-29",
+                    "sources": ["CISA KEV", "FBI Flash"],
+                    "ransomwareUse": False,
+                }
+            ]
+        }
+        with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
+            with _patch_urlopen(payload):
+                results = _fetch_vulncheck_kev("CVE-2024-3094")
+
+        assert len(results) == 1
+        assert results[0]["source"] == "vulncheck_kev"
+        assert results[0]["exploited_in_wild"] is True
+        assert results[0]["published"] == "2024-03-29"
+        assert "kev" in results[0]["tags"]
+
+    def test_ransomware_tag_added(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        payload = {
+            "data": [
+                {
+                    "cveID": "CVE-2024-3094",
+                    "dateAdded": "2024-03-29",
+                    "sources": [],
+                    "ransomwareUse": True,
+                }
+            ]
+        }
+        with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
+            with _patch_urlopen(payload):
+                results = _fetch_vulncheck_kev("CVE-2024-3094")
+
+        assert "ransomware" in results[0]["tags"]
+
+    def test_returns_empty_when_no_matching_cve(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        payload = {"data": [{"cveID": "CVE-2024-9999", "dateAdded": "2024-01-01", "sources": [], "ransomwareUse": False}]}
+        with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
+            with _patch_urlopen(payload):
+                results = _fetch_vulncheck_kev("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_on_network_error(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
+            with patch(
+                "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+                side_effect=OSError("timeout"),
+            ):
+                results = _fetch_vulncheck_kev("CVE-2024-3094")
+        assert results == []
+
+    def test_empty_data_returns_empty(self):
+        from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
+
+        payload = {"data": []}
+        with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
+            with _patch_urlopen(payload):
+                results = _fetch_vulncheck_kev("CVE-2024-3094")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_exploitdb
+# ---------------------------------------------------------------------------
+
+
+class TestFetchExploitdb:
+    def _make_csv_content(self, entries: list[dict]) -> bytes:
+        """Build a minimal Exploit-DB CSV with only the columns we need."""
+        fieldnames = ["id", "description", "date_published", "author", "type", "platform", "codes"]
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=fieldnames, extrasaction="ignore")
+        writer.writeheader()
+        for e in entries:
+            writer.writerow(e)
+        return buf.getvalue().encode()
+
+    def test_returns_match(self, tmp_path):
+        from manus_use.tools.search_poc_sources import _fetch_exploitdb
+
+        csv_data = self._make_csv_content([
+            {"id": "42", "description": "XZ Utils backdoor", "date_published": "2024-04-01",
+             "author": "researcher", "type": "remote", "platform": "linux", "codes": "CVE-2024-3094"},
+        ])
+        cache = str(tmp_path / "exploitdb_cache.csv")
+        with open(cache, "wb") as f:
+            f.write(csv_data)
+        with patch("manus_use.tools.search_poc_sources._EXPLOITDB_CACHE", cache):
+            with patch("manus_use.tools.search_poc_sources.time.time", return_value=time.time()):
+                results = _fetch_exploitdb("CVE-2024-3094")
+
+        assert len(results) == 1
+        assert results[0]["source"] == "exploitdb"
+        assert "exploit-db.com/exploits/42" in results[0]["url"]
+        assert results[0]["exploited_in_wild"] is False
+
+    def test_no_match_returns_empty(self, tmp_path):
+        from manus_use.tools.search_poc_sources import _fetch_exploitdb
+
+        csv_data = self._make_csv_content([
+            {"id": "1", "description": "Other vuln", "date_published": "2024-01-01",
+             "author": "x", "type": "local", "platform": "windows", "codes": "CVE-2020-0001"},
+        ])
+        cache = str(tmp_path / "exploitdb_cache.csv")
+        with open(cache, "wb") as f:
+            f.write(csv_data)
+        with patch("manus_use.tools.search_poc_sources._EXPLOITDB_CACHE", cache):
+            with patch("manus_use.tools.search_poc_sources.time.time", return_value=time.time()):
+                results = _fetch_exploitdb("CVE-2024-3094")
+
+        assert results == []
+
+    def test_downloads_when_cache_missing(self, tmp_path):
+        from manus_use.tools.search_poc_sources import _ensure_exploitdb_cache
+
+        cache = str(tmp_path / "missing.csv")
+        csv_data = self._make_csv_content([
+            {"id": "99", "description": "test", "date_published": "2024-01-01",
+             "author": "a", "type": "remote", "platform": "linux", "codes": "CVE-2024-3094"},
+        ])
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = csv_data
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+
+        with patch("manus_use.tools.search_poc_sources._EXPLOITDB_CACHE", cache):
+            with patch(
+                "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+                return_value=mock_resp,
+            ):
+                path = _ensure_exploitdb_cache()
+                assert path == cache
+
+    def test_uses_cache_when_fresh(self, tmp_path):
+        from manus_use.tools.search_poc_sources import _ensure_exploitdb_cache
+
+        cache = str(tmp_path / "cache.csv")
+        with open(cache, "wb") as f:
+            f.write(b"id,description\\n1,test\\n")
+
+        with patch("manus_use.tools.search_poc_sources._EXPLOITDB_CACHE", cache):
+            with patch("manus_use.tools.search_poc_sources.time.time", return_value=time.time()):
+                path = _ensure_exploitdb_cache()
+        assert path == cache
+
+    def test_returns_empty_when_download_fails(self, tmp_path):
+        from manus_use.tools.search_poc_sources import _fetch_exploitdb
+
+        cache = str(tmp_path / "no.csv")
+        with patch("manus_use.tools.search_poc_sources._EXPLOITDB_CACHE", cache):
+            with patch(
+                "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+                side_effect=OSError("download failed"),
+            ):
+                results = _fetch_exploitdb("CVE-2024-3094")
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_github
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGithub:
+    def _make_gh_payload(self) -> dict:
+        return {
+            "items": [
+                {
+                    "html_url": "https://github.com/user/cve-2024-3094-poc",
+                    "full_name": "user/cve-2024-3094-poc",
+                    "name": "cve-2024-3094-poc",
+                    "pushed_at": "2024-04-15T00:00:00Z",
+                    "owner": {"login": "user"},
+                }
+            ]
+        }
+
+    def test_returns_repo_result(self):
+        from manus_use.tools.search_poc_sources import _fetch_github
+
+        with _patch_urlopen(self._make_gh_payload()):
+            results = _fetch_github("CVE-2024-3094")
+
+        assert len(results) == 1
+        assert results[0]["source"] == "github"
+        assert results[0]["url"] == "https://github.com/user/cve-2024-3094-poc"
+        assert results[0]["published"] == "2024-04-15"
+        assert results[0]["author"] == "user"
+        assert results[0]["exploited_in_wild"] is False
+
+    def test_returns_empty_on_error(self):
+        from manus_use.tools.search_poc_sources import _fetch_github
+
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=OSError("timeout"),
+        ):
+            results = _fetch_github("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_when_no_items(self):
+        from manus_use.tools.search_poc_sources import _fetch_github
+
+        with _patch_urlopen({"items": []}):
+            results = _fetch_github("CVE-2024-3094")
+        assert results == []
+
+    def test_uses_github_token_when_set(self):
+        from manus_use.tools.search_poc_sources import _fetch_github
+
+        req_calls = []
+
+        def capturing_request(url, headers=None):
+            req_calls.append(headers or {})
+            m = MagicMock()
+            return m
+
+        with patch.dict(os.environ, {"GITHUB_TOKEN": "mytoken"}), \
+             patch("manus_use.tools.search_poc_sources.urllib.request.Request", side_effect=capturing_request), \
+             patch("manus_use.tools.search_poc_sources.urllib.request.urlopen", return_value=_make_url_response({"items": []})):
+            _fetch_github("CVE-2024-3094")
+
+        assert req_calls, "Request was not called"
+        assert "Authorization" in req_calls[0]
+        assert "mytoken" in req_calls[0]["Authorization"]
+
+    def test_none_pushed_at_yields_none_published(self):
+        from manus_use.tools.search_poc_sources import _fetch_github
+
+        payload = {
+            "items": [
+                {
+                    "html_url": "https://github.com/a/b",
+                    "full_name": "a/b",
+                    "name": "b",
+                    "pushed_at": None,
+                    "owner": {"login": "a"},
+                }
+            ]
+        }
+        with _patch_urlopen(payload):
+            results = _fetch_github("CVE-2024-3094")
+        assert results[0]["published"] is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_nvd
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvd:
+    def _make_nvd_payload(self, ref_url: str) -> dict:
+        return {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "CVE-2024-3094",
+                        "published": "2024-03-29T00:00:00.000",
+                        "references": [
+                            {"url": ref_url, "tags": ["Exploit"]},
+                        ],
+                    }
+                }
+            ]
+        }
+
+    def test_returns_github_ref(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with _patch_urlopen(self._make_nvd_payload("https://github.com/user/poc")):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert len(results) == 1
+        assert results[0]["source"] == "nvd"
+        assert results[0]["url"] == "https://github.com/user/poc"
+
+    def test_returns_exploitdb_ref(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with _patch_urlopen(self._make_nvd_payload("https://www.exploit-db.com/exploits/12345")):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert len(results) == 1
+
+    def test_returns_packetstorm_ref(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with _patch_urlopen(self._make_nvd_payload("https://packetstormsecurity.com/files/12345")):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert len(results) == 1
+
+    def test_ignores_unrelated_refs(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with _patch_urlopen(self._make_nvd_payload("https://example.com/advisory")):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_on_error(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with patch(
+            "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+            side_effect=OSError("timeout"),
+        ):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert results == []
+
+    def test_returns_empty_when_no_vulnerabilities(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        with _patch_urlopen({"vulnerabilities": []}):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert results == []
+
+    def test_tags_lowercased(self):
+        from manus_use.tools.search_poc_sources import _fetch_nvd
+
+        payload = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "published": "2024-03-29T00:00:00.000",
+                        "references": [
+                            {"url": "https://github.com/x/y", "tags": ["Exploit", "Patch"]},
+                        ],
+                    }
+                }
+            ]
+        }
+        with _patch_urlopen(payload):
+            results = _fetch_nvd("CVE-2024-3094")
+        assert "exploit" in results[0]["tags"]
+        assert "patch" in results[0]["tags"]
+
+
+# ---------------------------------------------------------------------------
+# aggregate_poc_results — deduplication, sort, flags
+# ---------------------------------------------------------------------------
+
+
+class TestAggregatePocResults:
+    def _run_with_mocked(self, results_by_source: dict, cve_id: str = "CVE-2024-3094"):
+        """Run aggregate_poc_results with all individual _fetch_* functions mocked."""
+        from manus_use.tools.search_poc_sources import aggregate_poc_results
+        all_src = ["trickest", "vulncheck_kev", "exploitdb", "github", "nvd"]
+        patches = [
+            patch(
+                f"manus_use.tools.search_poc_sources._fetch_{s}",
+                return_value=results_by_source.get(s, []),
+            )
+            for s in all_src
+        ]
+        for p in patches:
+            p.start()
+        try:
+            return aggregate_poc_results(cve_id)
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_deduplication_by_normalized_url(self):
+        url = "https://github.com/user/repo"
+        r1 = {"source": "trickest", "url": url, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r2 = {"source": "github", "url": url + "/", "title": "t2", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"trickest": [r1], "github": [r2]})
+        assert result["total_found"] == 1
+
+    def test_deduplication_strips_git_suffix(self):
+        url1 = "https://github.com/user/repo.git"
+        url2 = "https://github.com/user/repo"
+        r1 = {"source": "nvd", "url": url1, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r2 = {"source": "github", "url": url2, "title": "t2", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"nvd": [r1], "github": [r2]})
+        assert result["total_found"] == 1
+
+    def test_exploited_in_wild_flag_merged_on_dedup(self):
+        url = "https://github.com/user/repo"
+        r1 = {"source": "github", "url": url, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r2 = {"source": "vulncheck_kev", "url": url, "title": "t2", "published": None, "author": None, "tags": ["kev"], "exploited_in_wild": True}
+        result = self._run_with_mocked({"github": [r1], "vulncheck_kev": [r2]})
+        assert result["total_found"] == 1
+        assert result["results"][0]["exploited_in_wild"] is True
+
+    def test_sort_kev_first(self):
+        r_kev = {"source": "vulncheck_kev", "url": "https://vulncheck.com/kev/x", "title": "kev", "published": "2020-01-01", "author": None, "tags": ["kev"], "exploited_in_wild": True}
+        r_github = {"source": "github", "url": "https://github.com/u/r", "title": "gh", "published": "2024-04-01", "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"vulncheck_kev": [r_kev], "github": [r_github]})
+        assert result["results"][0]["source"] == "vulncheck_kev"
+        assert result["exploited_in_wild"] is True
+
+    def test_sort_by_date_descending_after_kev(self):
+        r_old = {"source": "github", "url": "https://github.com/u/old", "title": "old", "published": "2020-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        r_new = {"source": "exploitdb", "url": "https://exploit-db.com/x", "title": "new", "published": "2024-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"github": [r_old], "exploitdb": [r_new]})
+        dates = [r["published"] for r in result["results"]]
+        assert dates[0] >= dates[1]
+
+    def test_none_dates_sorted_last(self):
+        r_dated = {"source": "github", "url": "https://github.com/u/a", "title": "a", "published": "2024-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        r_nodated = {"source": "nvd", "url": "https://github.com/u/b", "title": "b", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"github": [r_dated], "nvd": [r_nodated]})
+        last = result["results"][-1]
+        assert last["published"] is None
+
+    def test_recent_activity_flag(self):
+        from datetime import datetime, timezone
+        today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+        r = {"source": "github", "url": "https://github.com/u/x", "title": "x", "published": today, "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"github": [r]})
+        assert result["recent_activity"] is True
+
+    def test_no_recent_activity_for_old_dates(self):
+        r = {"source": "nvd", "url": "https://github.com/u/x", "title": "x", "published": "2020-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        result = self._run_with_mocked({"nvd": [r]})
+        assert result["recent_activity"] is False
+
+    def test_sources_filter(self):
+        from manus_use.tools.search_poc_sources import aggregate_poc_results
+
+        with patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]) as mock_t,              patch("manus_use.tools.search_poc_sources._fetch_github", return_value=[]) as mock_g,              patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]):
+            aggregate_poc_results("CVE-2024-3094", sources=["trickest", "github"])
+            mock_t.assert_called_once()
+            mock_g.assert_called_once()
+
+    def test_failed_source_recorded(self):
+        from manus_use.tools.search_poc_sources import aggregate_poc_results
+
+        with patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_github", side_effect=RuntimeError("boom")),              patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]):
+            result = aggregate_poc_results("CVE-2024-3094")
+
+        assert "github" in result["sources_failed"]
+
+    def test_sources_checked_includes_all_queried(self):
+        result = self._run_with_mocked({})
+        assert set(result["sources_checked"]) == {"trickest", "vulncheck_kev", "exploitdb", "github", "nvd"}
+
+    def test_empty_result_when_all_sources_return_empty(self):
+        result = self._run_with_mocked({})
+        assert result["total_found"] == 0
+        assert result["exploited_in_wild"] is False
+        assert result["recent_activity"] is False
+        assert result["results"] == []
+
+
+# ---------------------------------------------------------------------------
+# search_poc_sources (Strands tool entry point)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchPocSourcesTool:
+    def test_invalid_cve_returns_error(self):
+        from manus_use.tools.search_poc_sources import search_poc_sources
+
+        result = search_poc_sources(cve_id="NOT-A-CVE")
+        assert "error" in result
+        assert result["total_found"] == 0
+
+    def test_valid_cve_calls_aggregate(self):
+        from manus_use.tools.search_poc_sources import search_poc_sources
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+        ) as mock_agg:
+            search_poc_sources(cve_id="CVE-2024-3094")
+            mock_agg.assert_called_once_with("CVE-2024-3094", None)
+
+    def test_sources_filter_passed_through(self):
+        from manus_use.tools.search_poc_sources import search_poc_sources
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+        ) as mock_agg:
+            search_poc_sources(cve_id="CVE-2024-3094", sources="trickest,github")
+            mock_agg.assert_called_once_with("CVE-2024-3094", ["trickest", "github"])
+
+    def test_empty_sources_string_passes_none(self):
+        from manus_use.tools.search_poc_sources import search_poc_sources
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+        ) as mock_agg:
+            search_poc_sources(cve_id="CVE-2024-3094", sources="")
+            mock_agg.assert_called_once_with("CVE-2024-3094", None)
+
+    def test_cve_id_stripped(self):
+        from manus_use.tools.search_poc_sources import search_poc_sources
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+        ) as mock_agg:
+            search_poc_sources(cve_id="  CVE-2024-3094  ")
+            call_args = mock_agg.call_args[0][0]
+            assert call_args == "CVE-2024-3094"
+
+
+# ---------------------------------------------------------------------------
+# CLI — _run_poc_search
+# ---------------------------------------------------------------------------
+
+
+class TestCliPocSearch:
+    def _make_result(self, exploited=False, recent=False, results=None):
+        return {
+            "cve_id": "CVE-2024-3094",
+            "total_found": len(results or []),
+            "exploited_in_wild": exploited,
+            "recent_activity": recent,
+            "sources_checked": ["trickest", "nvd"],
+            "sources_failed": [],
+            "results": results or [],
+        }
+
+    def test_json_output(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(),
+        ):
+            rc = _run_poc_search(["CVE-2024-3094", "--output", "json"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cve_id"] == "CVE-2024-3094"
+
+    def test_text_output_with_results(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        results = [
+            {
+                "source": "github",
+                "url": "https://github.com/user/poc",
+                "title": "PoC Repo",
+                "published": "2024-04-01",
+                "author": "user",
+                "tags": ["github-repo"],
+                "exploited_in_wild": False,
+            }
+        ]
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(results=results),
+        ):
+            rc = _run_poc_search(["CVE-2024-3094"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "CVE-2024-3094" in captured.out
+        assert "github" in captured.out
+
+    def test_text_output_shows_kev_banner(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        results = [
+            {
+                "source": "vulncheck_kev",
+                "url": "https://vulncheck.com/kev/x",
+                "title": "KEV entry",
+                "published": "2024-01-01",
+                "author": None,
+                "tags": ["kev"],
+                "exploited_in_wild": True,
+            }
+        ]
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(exploited=True, results=results),
+        ):
+            rc = _run_poc_search(["CVE-2024-3094"])
+
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "EXPLOITED IN WILD" in captured.out
+
+    def test_invalid_cve_exits_with_error(self):
+        from manus_use.cli import _run_poc_search
+
+        with pytest.raises(SystemExit):
+            _run_poc_search(["NOT-A-CVE"])
+
+    def test_sources_filter_cli_arg(self):
+        from manus_use.cli import _run_poc_search
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(),
+        ) as mock_agg:
+            _run_poc_search(["CVE-2024-3094", "--sources", "trickest,github"])
+            call_args = mock_agg.call_args
+            assert call_args[0][1] == ["trickest", "github"]
+
+    def test_empty_results_text_output(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(),
+        ):
+            rc = _run_poc_search(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No PoC results found" in out
+
+    def test_recent_activity_shown(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=self._make_result(recent=True),
+        ):
+            _run_poc_search(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "Recent activity" in out
+
+    def test_failed_sources_shown(self, capsys):
+        from manus_use.cli import _run_poc_search
+
+        result = self._make_result()
+        result["sources_failed"] = ["exploitdb"]
+        with patch(
+            "manus_use.tools.search_poc_sources.aggregate_poc_results",
+            return_value=result,
+        ):
+            _run_poc_search(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "exploitdb" in out
+
+
+# ---------------------------------------------------------------------------
+# CLI main() dispatch
+# ---------------------------------------------------------------------------
+
+
+class TestCliMainDispatch:
+    def test_poc_search_in_subcommands(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "poc-search" in _SUBCOMMANDS
+
+    def test_main_dispatches_poc_search(self):
+        from manus_use.cli import main
+
+        with patch("manus_use.cli._run_poc_search", return_value=0) as mock_run:
+            with patch("sys.argv", ["manus-use", "poc-search", "CVE-2024-3094"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    main()
+                assert exc_info.value.code == 0
+            mock_run.assert_called_once_with(["CVE-2024-3094"])
+
+
+# ---------------------------------------------------------------------------
+# VI agent wiring
+# ---------------------------------------------------------------------------
+
+
+class TestViAgentWiring:
+    def test_search_poc_sources_in_vi_agent_tools(self):
+        """search_poc_sources should appear in the VI agent tool list."""
+        import inspect
+
+        import manus_use.agents.vi_agent as vi
+
+        src = inspect.getsource(vi)
+        assert "search_poc_sources" in src
+
+    def test_search_poc_sources_in_system_prompt(self):
+        """System prompt should mention search_poc_sources."""
+        import manus_use.agents.vi_agent as vi
+
+        assert "search_poc_sources" in vi.SYSTEM_PROMPT
+
+    def test_exploited_in_wild_guidance_in_system_prompt(self):
+        """System prompt should include exploited_in_wild guidance."""
+        import manus_use.agents.vi_agent as vi
+
+        assert "exploited_in_wild" in vi.SYSTEM_PROMPT
+

--- a/tests/test_search_poc_sources.py
+++ b/tests/test_search_poc_sources.py
@@ -280,7 +280,9 @@ class TestFetchVulncheckKev:
     def test_returns_empty_when_no_matching_cve(self):
         from manus_use.tools.search_poc_sources import _fetch_vulncheck_kev
 
-        payload = {"data": [{"cveID": "CVE-2024-9999", "dateAdded": "2024-01-01", "sources": [], "ransomwareUse": False}]}
+        payload = {
+            "data": [{"cveID": "CVE-2024-9999", "dateAdded": "2024-01-01", "sources": [], "ransomwareUse": False}]
+        }
         with patch.dict(os.environ, {"VULNCHECK_API_KEY": "testkey"}):
             with _patch_urlopen(payload):
                 results = _fetch_vulncheck_kev("CVE-2024-3094")
@@ -326,10 +328,19 @@ class TestFetchExploitdb:
     def test_returns_match(self, tmp_path):
         from manus_use.tools.search_poc_sources import _fetch_exploitdb
 
-        csv_data = self._make_csv_content([
-            {"id": "42", "description": "XZ Utils backdoor", "date_published": "2024-04-01",
-             "author": "researcher", "type": "remote", "platform": "linux", "codes": "CVE-2024-3094"},
-        ])
+        csv_data = self._make_csv_content(
+            [
+                {
+                    "id": "42",
+                    "description": "XZ Utils backdoor",
+                    "date_published": "2024-04-01",
+                    "author": "researcher",
+                    "type": "remote",
+                    "platform": "linux",
+                    "codes": "CVE-2024-3094",
+                },
+            ]
+        )
         cache = str(tmp_path / "exploitdb_cache.csv")
         with open(cache, "wb") as f:
             f.write(csv_data)
@@ -345,10 +356,19 @@ class TestFetchExploitdb:
     def test_no_match_returns_empty(self, tmp_path):
         from manus_use.tools.search_poc_sources import _fetch_exploitdb
 
-        csv_data = self._make_csv_content([
-            {"id": "1", "description": "Other vuln", "date_published": "2024-01-01",
-             "author": "x", "type": "local", "platform": "windows", "codes": "CVE-2020-0001"},
-        ])
+        csv_data = self._make_csv_content(
+            [
+                {
+                    "id": "1",
+                    "description": "Other vuln",
+                    "date_published": "2024-01-01",
+                    "author": "x",
+                    "type": "local",
+                    "platform": "windows",
+                    "codes": "CVE-2020-0001",
+                },
+            ]
+        )
         cache = str(tmp_path / "exploitdb_cache.csv")
         with open(cache, "wb") as f:
             f.write(csv_data)
@@ -362,10 +382,19 @@ class TestFetchExploitdb:
         from manus_use.tools.search_poc_sources import _ensure_exploitdb_cache
 
         cache = str(tmp_path / "missing.csv")
-        csv_data = self._make_csv_content([
-            {"id": "99", "description": "test", "date_published": "2024-01-01",
-             "author": "a", "type": "remote", "platform": "linux", "codes": "CVE-2024-3094"},
-        ])
+        csv_data = self._make_csv_content(
+            [
+                {
+                    "id": "99",
+                    "description": "test",
+                    "date_published": "2024-01-01",
+                    "author": "a",
+                    "type": "remote",
+                    "platform": "linux",
+                    "codes": "CVE-2024-3094",
+                },
+            ]
+        )
         mock_resp = MagicMock()
         mock_resp.read.return_value = csv_data
         mock_resp.__enter__ = lambda s: s
@@ -463,9 +492,14 @@ class TestFetchGithub:
             m = MagicMock()
             return m
 
-        with patch.dict(os.environ, {"GITHUB_TOKEN": "mytoken"}), \
-             patch("manus_use.tools.search_poc_sources.urllib.request.Request", side_effect=capturing_request), \
-             patch("manus_use.tools.search_poc_sources.urllib.request.urlopen", return_value=_make_url_response({"items": []})):
+        with (
+            patch.dict(os.environ, {"GITHUB_TOKEN": "mytoken"}),
+            patch("manus_use.tools.search_poc_sources.urllib.request.Request", side_effect=capturing_request),
+            patch(
+                "manus_use.tools.search_poc_sources.urllib.request.urlopen",
+                return_value=_make_url_response({"items": []}),
+            ),
+        ):
             _fetch_github("CVE-2024-3094")
 
         assert req_calls, "Request was not called"
@@ -589,6 +623,7 @@ class TestAggregatePocResults:
     def _run_with_mocked(self, results_by_source: dict, cve_id: str = "CVE-2024-3094"):
         """Run aggregate_poc_results with all individual _fetch_* functions mocked."""
         from manus_use.tools.search_poc_sources import aggregate_poc_results
+
         all_src = ["trickest", "vulncheck_kev", "exploitdb", "github", "nvd"]
         patches = [
             patch(
@@ -607,64 +642,183 @@ class TestAggregatePocResults:
 
     def test_deduplication_by_normalized_url(self):
         url = "https://github.com/user/repo"
-        r1 = {"source": "trickest", "url": url, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
-        r2 = {"source": "github", "url": url + "/", "title": "t2", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r1 = {
+            "source": "trickest",
+            "url": url,
+            "title": "t1",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
+        r2 = {
+            "source": "github",
+            "url": url + "/",
+            "title": "t2",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"trickest": [r1], "github": [r2]})
         assert result["total_found"] == 1
 
     def test_deduplication_strips_git_suffix(self):
         url1 = "https://github.com/user/repo.git"
         url2 = "https://github.com/user/repo"
-        r1 = {"source": "nvd", "url": url1, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
-        r2 = {"source": "github", "url": url2, "title": "t2", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r1 = {
+            "source": "nvd",
+            "url": url1,
+            "title": "t1",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
+        r2 = {
+            "source": "github",
+            "url": url2,
+            "title": "t2",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"nvd": [r1], "github": [r2]})
         assert result["total_found"] == 1
 
     def test_exploited_in_wild_flag_merged_on_dedup(self):
         url = "https://github.com/user/repo"
-        r1 = {"source": "github", "url": url, "title": "t1", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
-        r2 = {"source": "vulncheck_kev", "url": url, "title": "t2", "published": None, "author": None, "tags": ["kev"], "exploited_in_wild": True}
+        r1 = {
+            "source": "github",
+            "url": url,
+            "title": "t1",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
+        r2 = {
+            "source": "vulncheck_kev",
+            "url": url,
+            "title": "t2",
+            "published": None,
+            "author": None,
+            "tags": ["kev"],
+            "exploited_in_wild": True,
+        }
         result = self._run_with_mocked({"github": [r1], "vulncheck_kev": [r2]})
         assert result["total_found"] == 1
         assert result["results"][0]["exploited_in_wild"] is True
 
     def test_sort_kev_first(self):
-        r_kev = {"source": "vulncheck_kev", "url": "https://vulncheck.com/kev/x", "title": "kev", "published": "2020-01-01", "author": None, "tags": ["kev"], "exploited_in_wild": True}
-        r_github = {"source": "github", "url": "https://github.com/u/r", "title": "gh", "published": "2024-04-01", "author": None, "tags": [], "exploited_in_wild": False}
+        r_kev = {
+            "source": "vulncheck_kev",
+            "url": "https://vulncheck.com/kev/x",
+            "title": "kev",
+            "published": "2020-01-01",
+            "author": None,
+            "tags": ["kev"],
+            "exploited_in_wild": True,
+        }
+        r_github = {
+            "source": "github",
+            "url": "https://github.com/u/r",
+            "title": "gh",
+            "published": "2024-04-01",
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"vulncheck_kev": [r_kev], "github": [r_github]})
         assert result["results"][0]["source"] == "vulncheck_kev"
         assert result["exploited_in_wild"] is True
 
     def test_sort_by_date_descending_after_kev(self):
-        r_old = {"source": "github", "url": "https://github.com/u/old", "title": "old", "published": "2020-01-01", "author": None, "tags": [], "exploited_in_wild": False}
-        r_new = {"source": "exploitdb", "url": "https://exploit-db.com/x", "title": "new", "published": "2024-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        r_old = {
+            "source": "github",
+            "url": "https://github.com/u/old",
+            "title": "old",
+            "published": "2020-01-01",
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
+        r_new = {
+            "source": "exploitdb",
+            "url": "https://exploit-db.com/x",
+            "title": "new",
+            "published": "2024-01-01",
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"github": [r_old], "exploitdb": [r_new]})
         dates = [r["published"] for r in result["results"]]
         assert dates[0] >= dates[1]
 
     def test_none_dates_sorted_last(self):
-        r_dated = {"source": "github", "url": "https://github.com/u/a", "title": "a", "published": "2024-01-01", "author": None, "tags": [], "exploited_in_wild": False}
-        r_nodated = {"source": "nvd", "url": "https://github.com/u/b", "title": "b", "published": None, "author": None, "tags": [], "exploited_in_wild": False}
+        r_dated = {
+            "source": "github",
+            "url": "https://github.com/u/a",
+            "title": "a",
+            "published": "2024-01-01",
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
+        r_nodated = {
+            "source": "nvd",
+            "url": "https://github.com/u/b",
+            "title": "b",
+            "published": None,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"github": [r_dated], "nvd": [r_nodated]})
         last = result["results"][-1]
         assert last["published"] is None
 
     def test_recent_activity_flag(self):
         from datetime import datetime, timezone
+
         today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        r = {"source": "github", "url": "https://github.com/u/x", "title": "x", "published": today, "author": None, "tags": [], "exploited_in_wild": False}
+        r = {
+            "source": "github",
+            "url": "https://github.com/u/x",
+            "title": "x",
+            "published": today,
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"github": [r]})
         assert result["recent_activity"] is True
 
     def test_no_recent_activity_for_old_dates(self):
-        r = {"source": "nvd", "url": "https://github.com/u/x", "title": "x", "published": "2020-01-01", "author": None, "tags": [], "exploited_in_wild": False}
+        r = {
+            "source": "nvd",
+            "url": "https://github.com/u/x",
+            "title": "x",
+            "published": "2020-01-01",
+            "author": None,
+            "tags": [],
+            "exploited_in_wild": False,
+        }
         result = self._run_with_mocked({"nvd": [r]})
         assert result["recent_activity"] is False
 
     def test_sources_filter(self):
         from manus_use.tools.search_poc_sources import aggregate_poc_results
 
-        with patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]) as mock_t,              patch("manus_use.tools.search_poc_sources._fetch_github", return_value=[]) as mock_g,              patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]):
+        with (
+            patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]) as mock_t,
+            patch("manus_use.tools.search_poc_sources._fetch_github", return_value=[]) as mock_g,
+            patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),
+            patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),
+            patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]),
+        ):
             aggregate_poc_results("CVE-2024-3094", sources=["trickest", "github"])
             mock_t.assert_called_once()
             mock_g.assert_called_once()
@@ -672,7 +826,13 @@ class TestAggregatePocResults:
     def test_failed_source_recorded(self):
         from manus_use.tools.search_poc_sources import aggregate_poc_results
 
-        with patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),              patch("manus_use.tools.search_poc_sources._fetch_github", side_effect=RuntimeError("boom")),              patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]):
+        with (
+            patch("manus_use.tools.search_poc_sources._fetch_trickest", return_value=[]),
+            patch("manus_use.tools.search_poc_sources._fetch_vulncheck_kev", return_value=[]),
+            patch("manus_use.tools.search_poc_sources._fetch_exploitdb", return_value=[]),
+            patch("manus_use.tools.search_poc_sources._fetch_github", side_effect=RuntimeError("boom")),
+            patch("manus_use.tools.search_poc_sources._fetch_nvd", return_value=[]),
+        ):
             result = aggregate_poc_results("CVE-2024-3094")
 
         assert "github" in result["sources_failed"]
@@ -707,7 +867,15 @@ class TestSearchPocSourcesTool:
 
         with patch(
             "manus_use.tools.search_poc_sources.aggregate_poc_results",
-            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+            return_value={
+                "cve_id": "CVE-2024-3094",
+                "total_found": 0,
+                "exploited_in_wild": False,
+                "recent_activity": False,
+                "sources_checked": [],
+                "sources_failed": [],
+                "results": [],
+            },
         ) as mock_agg:
             search_poc_sources(cve_id="CVE-2024-3094")
             mock_agg.assert_called_once_with("CVE-2024-3094", None)
@@ -717,7 +885,15 @@ class TestSearchPocSourcesTool:
 
         with patch(
             "manus_use.tools.search_poc_sources.aggregate_poc_results",
-            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+            return_value={
+                "cve_id": "CVE-2024-3094",
+                "total_found": 0,
+                "exploited_in_wild": False,
+                "recent_activity": False,
+                "sources_checked": [],
+                "sources_failed": [],
+                "results": [],
+            },
         ) as mock_agg:
             search_poc_sources(cve_id="CVE-2024-3094", sources="trickest,github")
             mock_agg.assert_called_once_with("CVE-2024-3094", ["trickest", "github"])
@@ -727,7 +903,15 @@ class TestSearchPocSourcesTool:
 
         with patch(
             "manus_use.tools.search_poc_sources.aggregate_poc_results",
-            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+            return_value={
+                "cve_id": "CVE-2024-3094",
+                "total_found": 0,
+                "exploited_in_wild": False,
+                "recent_activity": False,
+                "sources_checked": [],
+                "sources_failed": [],
+                "results": [],
+            },
         ) as mock_agg:
             search_poc_sources(cve_id="CVE-2024-3094", sources="")
             mock_agg.assert_called_once_with("CVE-2024-3094", None)
@@ -737,7 +921,15 @@ class TestSearchPocSourcesTool:
 
         with patch(
             "manus_use.tools.search_poc_sources.aggregate_poc_results",
-            return_value={"cve_id": "CVE-2024-3094", "total_found": 0, "exploited_in_wild": False, "recent_activity": False, "sources_checked": [], "sources_failed": [], "results": []},
+            return_value={
+                "cve_id": "CVE-2024-3094",
+                "total_found": 0,
+                "exploited_in_wild": False,
+                "recent_activity": False,
+                "sources_checked": [],
+                "sources_failed": [],
+                "results": [],
+            },
         ) as mock_agg:
             search_poc_sources(cve_id="  CVE-2024-3094  ")
             call_args = mock_agg.call_args[0][0]
@@ -926,4 +1118,3 @@ class TestViAgentWiring:
         import manus_use.agents.vi_agent as vi
 
         assert "exploited_in_wild" in vi.SYSTEM_PROMPT
-


### PR DESCRIPTION
## Summary

Adds `search_poc_sources` — a new Strands tool that aggregates PoC/exploit data from 5 sources in parallel and exposes it via the VI agent and a new `poc-search` CLI subcommand.

## Sources

| Source | Method | Notes |
|--------|--------|-------|
| **trickest/cve** | GitHub tree API | Returns CVE-specific PoC repo paths |
| **VulnCheck KEV** | REST API | `vulncheck-kev` index only; sets `exploited_in_wild` |
| **Exploit-DB** | CSV search | 24 h local cache at `/tmp/exploitdb_cache.csv` |
| **GitHub repo search** | REST API | Finds repos referencing the CVE ID |
| **NVD references** | REST API | Extracts PoC-relevant URLs from advisory refs |

## Key Design Decisions

- **Parallel fetch** via `ThreadPoolExecutor` — all sources queried concurrently
- **URL deduplication** — normalised (lowercase, strip trailing slash / `.git`); `exploited_in_wild` merged with OR semantics on dedup
- **Sort order**: KEV entries first → descending date → `None`-dates last
- **`recent_activity`** flag — any result published within 30 days
- **`sources_failed`** list — records which fetchers raised exceptions (doesn't fail the whole call)
- **Dynamic function lookup** via `_get_source_fn()` / `getattr` so individual `_fetch_*` functions can be cleanly patched in unit tests

## Integration

- **VI agent**: `search_poc_sources` added to tool list; system prompt updated with `exploited_in_wild` / `recent_activity` guidance
- **CLI**: `vi poc-search CVE-YYYY-NNNNN [--sources trickest,github,...] [--json]`

## Tests

72 new tests in `tests/test_search_poc_sources.py` covering:
- All 5 individual fetchers (network mocked)
- Aggregate logic: dedup, sort, flag merging, failed-source recording
- CLI: JSON output, text output, KEV banner, invalid CVE handling
- VI agent wiring: tool list and system prompt content

Full suite: **771 passed, 0 failed**

## CLI Example

```
$ vi poc-search CVE-2021-44228
⚠ Exploited in the wild (KEV)
📅 Recent activity (last 30 days)

Found 12 PoC(s) for CVE-2021-44228

 1. [vulncheck_kev] Log4Shell PoC — https://vulncheck.com/...
    Published: 2021-12-10 | Tags: kev
 2. [trickest]   CVE-2021-44228 — https://github.com/trickest/cve/...
    Published: 2021-12-12
...
Sources checked: trickest, vulncheck_kev, exploitdb, github, nvd
```