### PR TITLE
feat(tools): get_dependency_blast_radius + manus-use blast-radius CLI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: ["main"]
   pull_request:
     branches: ["main"]
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/README.md
+++ b/README.md
@@ -425,6 +425,55 @@ CLI subcommands are tracked in open PRs and will merge shortly.
 | `manus-use cluster-variants <CVE-ID>` | [#67](https://github.com/manus-use/manus-use/pull/67) | CVE variant cluster analysis — groups related CVEs by same component, same CWE, and same researcher/disclosure domain |
 
 
+### `manus-use blast-radius <SPEC>` — Dependency blast radius
+
+```bash
+# Estimate exposure for a specific package version
+manus-use blast-radius requests@2.28.0
+
+# Qualify the ecosystem explicitly
+manus-use blast-radius pypi:urllib3@1.26.5
+manus-use blast-radius npm:lodash@4.17.20
+manus-use blast-radius maven:log4j-core@2.14.1
+
+# Start from a CVE — auto-discovers all affected packages
+manus-use blast-radius CVE-2021-44228
+
+# Machine-readable output
+manus-use blast-radius CVE-2021-44228 --output json | jq .summary
+manus-use blast-radius CVE-2021-44228 --output json | jq '.packages[0].blast_radius'
+```
+
+For a given package or CVE, this command estimates how broadly a vulnerability
+can propagate by measuring downstream exposure:
+
+| Metric | Source |
+|---|---|
+| npm dependent packages | npm search API (no key required) |
+| npm weekly / monthly downloads | npm downloads API |
+| PyPI package metadata + downloads | PyPI JSON API + pypistats.org |
+| Maven artifact metadata | Maven Central Solr search |
+| Affected packages / version ranges | NVD + OSV.dev + GitHub Advisory DB |
+
+Blast-radius labels:
+
+| Label | Weekly downloads or npm dependents |
+|---|---|
+| **CRITICAL** | ≥ 5 M downloads or ≥ 50 K dependents |
+| **HIGH** | ≥ 500 K downloads or ≥ 5 K dependents |
+| **MEDIUM** | ≥ 50 K downloads or ≥ 500 dependents |
+| **LOW** | any measurable signal |
+| **UNKNOWN** | no data available |
+
+Composable with `epss-trend`, `exploit-complexity`, and `analyze` to answer:
+*"CVSS 9.8 + EPSS spike + CRITICAL blast radius = patch immediately."*
+
+| Flag | Default | Description |
+|---|---|---|
+| `--max-packages N` | 10 | Max affected packages to enrich |
+| `--output {text,json}` | `text` | Output format |
+
+
 ### `manus-use history` — Browse past runs
 
 ```bash
@@ -652,6 +701,11 @@ manus-use exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
 # Find PoC exploits across five public sources in parallel
 manus-use poc-search CVE-2024-3094
 manus-use poc-search CVE-2024-3094 --output json | jq .exploited_in_wild
+
+# Estimate how many downstream packages are exposed to a CVE
+manus-use blast-radius CVE-2021-44228
+manus-use blast-radius requests@2.28.0
+manus-use blast-radius CVE-2021-44228 --output json | jq .summary
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -210,13 +210,13 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_use.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_use.tools.get_epss_trend import get_epss_trend
             from manus_use.tools.get_github_advisory import get_github_advisory
             from manus_use.tools.get_patch_diff import get_patch_diff
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
             from manus_use.tools.get_vulncheck_data import get_vulncheck_data
-            from manus_use.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_use.tools.score_exploit_complexity import score_exploit_complexity
             from manus_use.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -111,6 +111,15 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - Whether the score was derived from PoC code analysis or NVD CVSS vector only.
   This score contextualises raw CVSS severity: a CVSS 9.8 with complexity_score=1.5 is far more urgent than the same CVSS with complexity_score=4.5.
 
+
+**Step 6c: Dependency Blast Radius**
+- Call `get_dependency_blast_radius` with the CVE ID. Include in the report:
+  - The blast-radius label (CRITICAL / HIGH / MEDIUM / LOW) for each affected package.
+  - The total weekly downloads and dependent-package count for the most-exposed package.
+  - The ecosystems affected (PyPI, npm, Maven, etc.).
+  Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
+  A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -207,6 +216,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_poc_week import get_poc_week
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
             from manus_use.tools.get_vulncheck_data import get_vulncheck_data
+            from manus_use.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_use.tools.score_exploit_complexity import score_exploit_complexity
             from manus_use.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -263,6 +273,7 @@ class VulnerabilityIntelligenceAgent:
             score_exploit_complexity,
             get_vulncheck_data,
             search_poc_sources,
+            get_dependency_blast_radius,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1055,6 +1055,7 @@ _SUBCOMMANDS = {
     "exploit-complexity",
     "poc-search",
     "changelog",
+    "blast-radius",
 }
 
 
@@ -1686,6 +1687,178 @@ def _run_changelog_generate(args: argparse.Namespace, root: "_Path") -> int:  # 
     return 0
 
 
+# ---------------------------------------------------------------------------
+# blast-radius subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_blast_radius_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-use blast-radius",
+        description=(
+            "Estimate the downstream blast radius of a vulnerable package or CVE.\n"
+            "Given a package spec (requests@2.28.0, npm:axios@1.6.0, CVE-2021-44228),\n"
+            "reports dependent-package counts and download stats for all affected packages."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "spec",
+        metavar="SPEC",
+        help=(
+            "Package spec (name@version, ecosystem:name@version) or CVE ID. "
+            "Examples: requests@2.28.0  npm:lodash@4.17.20  CVE-2021-44228"
+        ),
+    )
+    p.add_argument(
+        "--max-packages",
+        type=int,
+        default=10,
+        metavar="N",
+        help="Maximum number of affected packages to enrich with stats (default: 10)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_blast_radius(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_blast_radius_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_use.tools.get_dependency_blast_radius import (
+            _ECOSYSTEM_LABEL,
+            _blast_score,
+            _enrich_package,
+            _fetch_ghsa_affected,
+            _fetch_nvd_affected,
+            _fetch_osv_affected,
+            _parse_input,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    spec = args.spec.strip()
+    max_packages = args.max_packages
+
+    try:
+        parsed = _parse_input(spec)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    all_packages: list[dict] = []
+    cve_id_label = ""
+
+    if parsed["kind"] == "cve":
+        cve_id_label = parsed["cve_id"]
+        nvd_pkgs = _fetch_nvd_affected(cve_id_label)
+        osv_pkgs = _fetch_osv_affected(cve_id_label)
+        ghsa_pkgs = _fetch_ghsa_affected(cve_id_label)
+
+        seen: dict[tuple, dict] = {}
+        for pkg in osv_pkgs + ghsa_pkgs + nvd_pkgs:
+            key = (pkg["name"].lower(), (pkg.get("ecosystem") or "").lower())
+            if key not in seen:
+                seen[key] = pkg
+        all_packages = list(seen.values())[:max_packages]
+    else:
+        all_packages = [
+            {
+                "name": parsed["name"],
+                "ecosystem": parsed["ecosystem"] or "",
+                "version_range": parsed["version"] or "all",
+                "source": "direct",
+            }
+        ]
+
+    if not all_packages:
+        print(f"No affected package records found for {spec!r}.")
+        return 1
+
+    enriched: list[dict] = []
+    for pkg in all_packages:
+        stats = _enrich_package(pkg["name"], pkg.get("ecosystem", ""))
+        stats["version_range"] = pkg.get("version_range", "")
+        stats["source"] = pkg.get("source", "")
+        stats["blast_radius"] = _blast_score(stats)
+        enriched.append(stats)
+
+    _sev = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+    enriched.sort(key=lambda r: _sev.get(r.get("blast_radius", "UNKNOWN"), 4))
+
+    if args.output == "json":
+        out = {
+            "spec": spec,
+            "cve_id": cve_id_label or None,
+            "packages": enriched,
+            "summary": {
+                "highest_blast_radius": enriched[0].get("blast_radius") if enriched else None,
+                "total_packages": len(enriched),
+                "total_weekly_downloads": sum(
+                    r.get("weekly_downloads") or 0 for r in enriched if r.get("weekly_downloads") is not None
+                ),
+                "total_dependent_packages": sum(r.get("dependent_packages_count") or 0 for r in enriched),
+            },
+        }
+        print(_json.dumps(out, indent=2))
+        return 0
+
+    # Text output
+    title = cve_id_label or spec
+    print()
+    print(f"Dependency Blast Radius — {title}")
+    print("=" * 60)
+    print(f"Affected packages found: {len(enriched)}")
+    print()
+
+    for i, r in enumerate(enriched):
+        eco = r.get("ecosystem") or "Unknown"
+        eco_label = _ECOSYSTEM_LABEL.get(eco, eco)
+        pkg_name = r.get("package_name") or r.get("name", "unknown")
+        blast = r.get("blast_radius", "UNKNOWN")
+        ver_range = r.get("version_range", "")
+
+        print(f"[{i + 1}] {pkg_name}  ({eco_label})")
+        print(f"    Blast radius:     {blast}")
+        if ver_range:
+            print(f"    Vulnerable range: {ver_range}")
+        if r.get("dependent_packages_count") is not None:
+            print(f"    npm dependents:   {r['dependent_packages_count']:,}")
+        if r.get("weekly_downloads") is not None:
+            print(f"    Weekly downloads: {r['weekly_downloads']:,}")
+        if r.get("monthly_downloads") is not None:
+            print(f"    Monthly downloads:{r['monthly_downloads']:,}")
+        if r.get("latest_version"):
+            print(f"    Latest version:   {r['latest_version']}")
+        if r.get("full_id"):
+            print(f"    Maven artifact:   {r['full_id']}")
+        if r.get("description"):
+            print(f"    Description:      {r['description'][:80]}")
+        print()
+
+    # Summary
+    top_blast = enriched[0].get("blast_radius", "UNKNOWN") if enriched else "UNKNOWN"
+    top_pkg = enriched[0].get("package_name", "") if enriched else ""
+    print(f"Summary: highest blast radius is {top_blast} ({top_pkg})")
+    total_weekly = sum(r.get("weekly_downloads") or 0 for r in enriched if r.get("weekly_downloads") is not None)
+    total_dep = sum(r.get("dependent_packages_count") or 0 for r in enriched)
+    if total_weekly:
+        print(f"         Total weekly downloads: {total_weekly:,}")
+    if total_dep:
+        print(f"         Total npm dependents:   {total_dep:,}")
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2011,6 +2184,10 @@ def main() -> None:
     if first_positional == "changelog":
         idx = argv.index("changelog")
         sys.exit(_run_changelog(argv[idx + 1 :]))
+
+    if first_positional == "blast-radius":
+        idx = argv.index("blast-radius")
+        sys.exit(_run_blast_radius(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_use/tools/get_dependency_blast_radius.py
+++ b/src/manus_use/tools/get_dependency_blast_radius.py
@@ -166,12 +166,14 @@ def _fetch_nvd_affected(cve_id: str) -> list[dict[str, str]]:
                     else:
                         ver_range = version if version != "*" else "all versions"
 
-                    result.append({
-                        "name": product,
-                        "version_range": ver_range,
-                        "ecosystem": "unknown",
-                        "source": "nvd",
-                    })
+                    result.append(
+                        {
+                            "name": product,
+                            "version_range": ver_range,
+                            "ecosystem": "unknown",
+                            "source": "nvd",
+                        }
+                    )
 
     # Deduplicate by name
     seen: set[str] = set()
@@ -216,12 +218,14 @@ def _fetch_osv_affected(cve_id: str) -> list[dict[str, str]]:
             ranges = affected.get("ranges", [])
             ver_range = _summarise_osv_ranges(ranges, affected.get("versions", []))
 
-            result.append({
-                "name": name,
-                "ecosystem": ecosystem,
-                "version_range": ver_range,
-                "source": "osv",
-            })
+            result.append(
+                {
+                    "name": name,
+                    "ecosystem": ecosystem,
+                    "version_range": ver_range,
+                    "source": "osv",
+                }
+            )
 
     return result
 
@@ -280,12 +284,14 @@ def _fetch_ghsa_affected(cve_id: str) -> list[dict[str, str]]:
             patched = vuln.get("first_patched_version", {})
             patched_ver = patched.get("identifier", "") if isinstance(patched, dict) else ""
             ver_range = vulnerable_range or (f"<{patched_ver}" if patched_ver else "unspecified")
-            result.append({
-                "name": name,
-                "ecosystem": ecosystem,
-                "version_range": ver_range,
-                "source": "ghsa",
-            })
+            result.append(
+                {
+                    "name": name,
+                    "ecosystem": ecosystem,
+                    "version_range": ver_range,
+                    "source": "ghsa",
+                }
+            )
 
     return result
 
@@ -452,7 +458,7 @@ def get_dependency_blast_radius(  # noqa: C901
 
     if parsed["kind"] == "cve":
         cve_id = parsed["cve_id"]
-        sections.append(f"Dependency Blast Radius — {cve_id}\n{'='*50}")
+        sections.append(f"Dependency Blast Radius — {cve_id}\n{'=' * 50}")
 
         # Gather affected packages from multiple sources
         nvd_pkgs = _fetch_nvd_affected(cve_id)
@@ -485,13 +491,15 @@ def get_dependency_blast_radius(  # noqa: C901
         ecosystem = parsed["ecosystem"] or ""
         label = f"{ecosystem}:{name}" if ecosystem else name
         ver_label = f"@{version}" if version else " (all versions)"
-        sections.append(f"Dependency Blast Radius — {label}{ver_label}\n{'='*50}")
-        all_packages = [{
-            "name": name,
-            "ecosystem": ecosystem,
-            "version_range": version or "all",
-            "source": "direct",
-        }]
+        sections.append(f"Dependency Blast Radius — {label}{ver_label}\n{'=' * 50}")
+        all_packages = [
+            {
+                "name": name,
+                "ecosystem": ecosystem,
+                "version_range": version or "all",
+                "source": "direct",
+            }
+        ]
 
     # Enrich each package with stats
     enriched_results: list[dict[str, Any]] = []
@@ -563,14 +571,9 @@ def get_dependency_blast_radius(  # noqa: C901
         max_pkg = top.get("package_name", "")
         sections.append(f"\nSummary: highest blast radius is {max_blast} ({max_pkg})")
         total_weekly = sum(
-            r.get("weekly_downloads") or 0
-            for r in enriched_results
-            if r.get("weekly_downloads") is not None
+            r.get("weekly_downloads") or 0 for r in enriched_results if r.get("weekly_downloads") is not None
         )
-        total_dependents = sum(
-            r.get("dependent_packages_count") or 0
-            for r in enriched_results
-        )
+        total_dependents = sum(r.get("dependent_packages_count") or 0 for r in enriched_results)
         if total_weekly:
             sections.append(f"         Total weekly downloads across all packages: {total_weekly:,}")
         if total_dependents:

--- a/src/manus_use/tools/get_dependency_blast_radius.py
+++ b/src/manus_use/tools/get_dependency_blast_radius.py
@@ -1,0 +1,579 @@
+"""
+Tool: get_dependency_blast_radius
+
+Given a vulnerable package specification (``package@version`` or a CVE ID),
+estimates the downstream exposure — how many packages and repositories depend
+on the affected package, and how widely it is downloaded.
+
+Data sources (all free, no API key required):
+  1. NVD CVE 2.0 API  — maps CVE → affected packages + version ranges
+  2. OSV.dev API       — cross-ecosystem vulnerability data (PyPI, npm, Maven,
+                         Go, RubyGems, crates.io, …)
+  3. GitHub Advisory DB — GHSA packages + ecosystems
+  4. npm registry API  — dependents count + weekly download stats (npm only)
+  5. PyPI JSON API     — package metadata (PyPI only; download counts from
+                         pypistats.org with graceful degradation on 429)
+  6. Maven Central     — artifact metadata + version count (Maven only)
+
+The tool deliberately avoids paid/rate-limited APIs so it works without
+configuration.  When a source is unavailable the result degrades gracefully.
+
+CLI: ``manus-use blast-radius requests@2.28.0``
+     ``manus-use blast-radius CVE-2021-44228``
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["get_dependency_blast_radius"]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d+$", re.IGNORECASE)
+_PKG_RE = re.compile(r"^(?P<name>[^@]+?)(?:@(?P<version>.+))?$")
+
+_NVD_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_OSV_QUERY_URL = "https://api.osv.dev/v1/query"
+_OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{}"
+_GHSA_URL = "https://api.github.com/advisories"
+_NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search"
+_NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
+_PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
+_PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
+_MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+
+_TIMEOUT = 20
+
+# OSV ecosystem → display name mapping
+_ECOSYSTEM_LABEL: dict[str, str] = {
+    "PyPI": "PyPI (Python)",
+    "npm": "npm (JavaScript/Node.js)",
+    "Maven": "Maven (Java)",
+    "Go": "Go modules",
+    "crates.io": "crates.io (Rust)",
+    "RubyGems": "RubyGems (Ruby)",
+    "NuGet": "NuGet (.NET)",
+    "Packagist": "Packagist (PHP)",
+    "Hex": "Hex (Elixir/Erlang)",
+    "Pub": "Pub (Dart/Flutter)",
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str, params: dict | None = None, headers: dict | None = None) -> Any:
+    """GET with timeout; returns parsed JSON or raises."""
+    r = requests.get(url, params=params or {}, headers=headers or {}, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _post(url: str, payload: dict) -> Any:
+    """POST JSON; returns parsed JSON or raises."""
+    r = requests.post(url, json=payload, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+# ---------------------------------------------------------------------------
+# Input normalisation
+# ---------------------------------------------------------------------------
+
+
+def _parse_input(spec: str) -> dict[str, str | None]:
+    """Return {'kind': 'cve'|'package', 'cve_id': ..., 'name': ..., 'version': ..., 'ecosystem': ...}."""
+    spec = spec.strip()
+    if _CVE_RE.match(spec):
+        return {"kind": "cve", "cve_id": spec.upper(), "name": None, "version": None, "ecosystem": None}
+
+    # Accept ecosystem-qualified specs: pypi:requests@2.28.0, npm:axios@1.6.0, maven:log4j-core@2.14.1
+    ecosystem = None
+    if ":" in spec:
+        parts = spec.split(":", 1)
+        if not parts[0].startswith("http"):
+            ecosystem = parts[0]
+            spec = parts[1]
+
+    m = _PKG_RE.match(spec)
+    if not m:
+        raise ValueError(f"Cannot parse package spec: {spec!r}")
+    return {
+        "kind": "package",
+        "cve_id": None,
+        "name": m.group("name").strip(),
+        "version": (m.group("version") or "").strip() or None,
+        "ecosystem": ecosystem,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source 1: NVD — CVE → affected packages
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_affected(cve_id: str) -> list[dict[str, str]]:
+    """Return list of {ecosystem, name, version_range} from NVD CPE configurations."""
+    try:
+        data = _get(_NVD_URL, params={"cveId": cve_id})
+    except Exception as exc:
+        logger.debug("NVD fetch failed for %s: %s", cve_id, exc)
+        return []
+
+    result: list[dict[str, str]] = []
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return result
+
+    cve = vulns[0].get("cve", {})
+    configs = cve.get("configurations", [])
+
+    for config in configs:
+        for node in config.get("nodes", []):
+            for cpe_match in node.get("cpeMatch", []):
+                if not cpe_match.get("vulnerable", False):
+                    continue
+                cpe_uri = cpe_match.get("criteria", "")
+                parts = cpe_uri.split(":")
+                # CPE 2.3: cpe:2.3:a:vendor:product:version:...
+                if len(parts) >= 6:
+                    product = parts[4] if len(parts) > 4 else "unknown"
+                    version = parts[5] if len(parts) > 5 else "*"
+                    ver_start_inc = cpe_match.get("versionStartIncluding", "")
+                    ver_end_exc = cpe_match.get("versionEndExcluding", "")
+                    ver_end_inc = cpe_match.get("versionEndIncluding", "")
+
+                    if ver_start_inc or ver_end_exc or ver_end_inc:
+                        ver_range = ""
+                        if ver_start_inc:
+                            ver_range += f">={ver_start_inc}"
+                        if ver_end_exc:
+                            ver_range += f"<{ver_end_exc}" if not ver_range else f", <{ver_end_exc}"
+                        elif ver_end_inc:
+                            ver_range += f"<={ver_end_inc}" if not ver_range else f", <={ver_end_inc}"
+                    else:
+                        ver_range = version if version != "*" else "all versions"
+
+                    result.append({
+                        "name": product,
+                        "version_range": ver_range,
+                        "ecosystem": "unknown",
+                        "source": "nvd",
+                    })
+
+    # Deduplicate by name
+    seen: set[str] = set()
+    deduped = []
+    for r in result:
+        if r["name"] not in seen:
+            seen.add(r["name"])
+            deduped.append(r)
+    return deduped
+
+
+# ---------------------------------------------------------------------------
+# Source 2: OSV.dev — CVE → affected packages with ecosystem tags
+# ---------------------------------------------------------------------------
+
+
+def _fetch_osv_affected(cve_id: str) -> list[dict[str, str]]:
+    """Query OSV for the CVE and return affected package records."""
+    try:
+        data = _post(_OSV_QUERY_URL, {"id": cve_id})
+    except Exception as exc:
+        logger.debug("OSV query failed: %s", exc)
+        return []
+
+    result: list[dict[str, str]] = []
+    for vuln in data.get("vulns", []):
+        vuln_id = vuln.get("id", "")
+        # Fetch the full record to get affected packages
+        try:
+            full = _get(_OSV_VULN_URL.format(vuln_id))
+        except Exception:
+            continue
+
+        for affected in full.get("affected", []):
+            pkg = affected.get("package", {})
+            name = pkg.get("name", "")
+            ecosystem = pkg.get("ecosystem", "")
+            if not name:
+                continue
+
+            # Extract version range summary
+            ranges = affected.get("ranges", [])
+            ver_range = _summarise_osv_ranges(ranges, affected.get("versions", []))
+
+            result.append({
+                "name": name,
+                "ecosystem": ecosystem,
+                "version_range": ver_range,
+                "source": "osv",
+            })
+
+    return result
+
+
+def _summarise_osv_ranges(ranges: list[dict], versions: list[str]) -> str:
+    """Produce a short human-readable version range from OSV range data."""
+    summaries: list[str] = []
+    for rng in ranges:
+        if rng.get("type") == "SEMVER" or rng.get("type") == "ECOSYSTEM":
+            events = rng.get("events", [])
+            introduced = None
+            fixed = None
+            for ev in events:
+                if "introduced" in ev and ev["introduced"] != "0":
+                    introduced = ev["introduced"]
+                if "fixed" in ev:
+                    fixed = ev["fixed"]
+            if introduced and fixed:
+                summaries.append(f">={introduced}, <{fixed}")
+            elif introduced:
+                summaries.append(f">={introduced}")
+            elif fixed:
+                summaries.append(f"<{fixed}")
+
+    if summaries:
+        return "; ".join(summaries)
+    if versions:
+        sample = versions[:5]
+        suffix = f" (+{len(versions) - 5} more)" if len(versions) > 5 else ""
+        return ", ".join(sample) + suffix
+    return "unspecified"
+
+
+# ---------------------------------------------------------------------------
+# Source 3: GitHub Advisory API
+# ---------------------------------------------------------------------------
+
+
+def _fetch_ghsa_affected(cve_id: str) -> list[dict[str, str]]:
+    """Return affected packages from GitHub Security Advisory DB."""
+    try:
+        data = _get(_GHSA_URL, params={"cve_id": cve_id, "per_page": 10})
+    except Exception as exc:
+        logger.debug("GHSA fetch failed: %s", exc)
+        return []
+
+    result: list[dict[str, str]] = []
+    for advisory in data if isinstance(data, list) else []:
+        for vuln in advisory.get("vulnerabilities", []):
+            pkg = vuln.get("package", {})
+            name = pkg.get("name", "")
+            ecosystem = pkg.get("ecosystem", "")
+            if not name:
+                continue
+            vulnerable_range = vuln.get("vulnerable_version_range", "")
+            patched = vuln.get("first_patched_version", {})
+            patched_ver = patched.get("identifier", "") if isinstance(patched, dict) else ""
+            ver_range = vulnerable_range or (f"<{patched_ver}" if patched_ver else "unspecified")
+            result.append({
+                "name": name,
+                "ecosystem": ecosystem,
+                "version_range": ver_range,
+                "source": "ghsa",
+            })
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Package-level enrichment: download/dependent stats
+# ---------------------------------------------------------------------------
+
+
+def _enrich_npm(name: str) -> dict[str, Any]:
+    """Fetch npm dependent count + weekly downloads."""
+    result: dict[str, Any] = {"ecosystem": "npm", "package_name": name}
+    try:
+        # Search returns dependents count
+        search_data = _get(_NPM_SEARCH_URL, params={"text": name, "size": 5})
+        for obj in search_data.get("objects", []):
+            if obj.get("package", {}).get("name", "").lower() == name.lower():
+                result["dependent_packages_count"] = int(obj.get("dependents", 0))
+                dls = obj.get("downloads", {})
+                result["weekly_downloads"] = dls.get("weekly", 0)
+                result["monthly_downloads"] = dls.get("monthly", 0)
+                break
+        # Fallback: direct downloads API
+        if "weekly_downloads" not in result:
+            dl_data = _get(_NPM_DOWNLOADS_URL.format(name))
+            result["weekly_downloads"] = dl_data.get("downloads", 0)
+    except Exception as exc:
+        logger.debug("npm enrich failed for %s: %s", name, exc)
+    return result
+
+
+def _enrich_pypi(name: str) -> dict[str, Any]:
+    """Fetch PyPI package metadata."""
+    result: dict[str, Any] = {"ecosystem": "PyPI", "package_name": name}
+    try:
+        pypi_data = _get(_PYPI_JSON_URL.format(name))
+        info = pypi_data.get("info", {})
+        result["description"] = info.get("summary", "")[:120]
+        result["latest_version"] = info.get("version", "")
+        result["home_page"] = info.get("project_url", info.get("home_page", ""))
+        # Total release count as a proxy for maturity
+        result["release_count"] = len(pypi_data.get("releases", {}))
+        # Try pypistats for download counts (rate-limited; degrade gracefully)
+        try:
+            stats = _get(_PYPISTATS_URL.format(name))
+            data = stats.get("data", {})
+            result["weekly_downloads"] = data.get("last_week", 0)
+            result["monthly_downloads"] = data.get("last_month", 0)
+        except Exception:
+            result["weekly_downloads"] = None
+            result["monthly_downloads"] = None
+    except Exception as exc:
+        logger.debug("PyPI enrich failed for %s: %s", name, exc)
+    return result
+
+
+def _enrich_maven(name: str) -> dict[str, Any]:
+    """Fetch Maven Central artifact metadata."""
+    result: dict[str, Any] = {"ecosystem": "Maven", "package_name": name}
+    try:
+        # Accept both 'groupId:artifactId' and plain 'artifactId' forms
+        if ":" in name:
+            g, a = name.split(":", 1)
+            query = f"g:{g} AND a:{a}"
+        else:
+            query = f"a:{name}"
+        data = _get(_MAVEN_SEARCH_URL, params={"q": query, "rows": 5, "wt": "json"})
+        docs = data.get("response", {}).get("docs", [])
+        if docs:
+            doc = docs[0]
+            result["latest_version"] = doc.get("latestVersion", "")
+            result["version_count"] = doc.get("versionCount", 0)
+            result["group_id"] = doc.get("g", "")
+            result["artifact_id"] = doc.get("a", "")
+            result["full_id"] = doc.get("id", name)
+        result["total_artifacts_found"] = data.get("response", {}).get("numFound", 0)
+    except Exception as exc:
+        logger.debug("Maven enrich failed for %s: %s", name, exc)
+    return result
+
+
+def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
+    """Dispatch to the right enrichment function based on ecosystem."""
+    eco_lower = (ecosystem or "").lower()
+    if eco_lower in ("npm", "javascript", "node"):
+        return _enrich_npm(name)
+    elif eco_lower in ("pypi", "python", "pip"):
+        return _enrich_pypi(name)
+    elif eco_lower in ("maven", "java", "gradle"):
+        return _enrich_maven(name)
+    # Unknown ecosystem — return minimal record
+    return {"ecosystem": ecosystem, "package_name": name}
+
+
+# ---------------------------------------------------------------------------
+# Blast radius scoring
+# ---------------------------------------------------------------------------
+
+
+def _blast_score(stats: dict[str, Any]) -> str:
+    """
+    Produce a qualitative blast-radius label based on download/dependent counts.
+
+    Returns one of: critical / high / medium / low / unknown
+    """
+    weekly = stats.get("weekly_downloads") or 0
+    dependents = stats.get("dependent_packages_count") or 0
+
+    if weekly >= 5_000_000 or dependents >= 50_000:
+        return "CRITICAL"
+    elif weekly >= 500_000 or dependents >= 5_000:
+        return "HIGH"
+    elif weekly >= 50_000 or dependents >= 500:
+        return "MEDIUM"
+    elif weekly > 0 or dependents > 0:
+        return "LOW"
+    return "UNKNOWN"
+
+
+# ---------------------------------------------------------------------------
+# Main tool function
+# ---------------------------------------------------------------------------
+
+
+@tool
+def get_dependency_blast_radius(  # noqa: C901
+    package_or_cve: str,
+    max_packages: int = 10,
+) -> str:
+    """
+    Estimate the downstream blast radius of a vulnerable package or CVE.
+
+    Given a package specification (e.g. ``requests@2.28.0``) or a CVE ID
+    (e.g. ``CVE-2021-44228``), this tool:
+
+    1. Identifies the affected package(s) and version range(s) from NVD,
+       OSV.dev, and the GitHub Advisory Database.
+    2. For each affected package, fetches downstream exposure metrics:
+       - **npm**: dependent package count + weekly/monthly download stats
+       - **PyPI**: package metadata + download stats (when pypistats is available)
+       - **Maven**: artifact metadata from Maven Central
+    3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
+
+    Use after ``get_nvd_data`` to understand *how many projects are exposed*
+    to a vulnerability — the answer is often orders of magnitude larger than
+    the single vulnerable package.
+
+    Args:
+        package_or_cve: Package spec (``name@version``, ``ecosystem:name@version``)
+                        or CVE ID (``CVE-YYYY-NNNN``).
+        max_packages:   Maximum number of packages to enrich with stats (default 10).
+
+    Returns:
+        A structured text report with per-package exposure stats and a
+        summary blast-radius label.
+    """
+    try:
+        parsed = _parse_input(package_or_cve)
+    except ValueError as e:
+        return f"Error: {e}"
+
+    sections: list[str] = []
+    all_packages: list[dict[str, Any]] = []
+
+    if parsed["kind"] == "cve":
+        cve_id = parsed["cve_id"]
+        sections.append(f"Dependency Blast Radius — {cve_id}\n{'='*50}")
+
+        # Gather affected packages from multiple sources
+        nvd_pkgs = _fetch_nvd_affected(cve_id)
+        osv_pkgs = _fetch_osv_affected(cve_id)
+        ghsa_pkgs = _fetch_ghsa_affected(cve_id)
+
+        # Merge: OSV and GHSA have ecosystem tags; NVD often does not
+        # Prefer OSV/GHSA records since they include ecosystem
+        seen_names: dict[str, dict] = {}
+        for pkg in osv_pkgs + ghsa_pkgs + nvd_pkgs:
+            key = (pkg["name"].lower(), (pkg.get("ecosystem") or "").lower())
+            if key not in seen_names:
+                seen_names[key] = pkg
+
+        merged = list(seen_names.values())
+        if not merged:
+            return (
+                f"No affected package records found for {cve_id} in NVD, OSV, or GHSA.\n"
+                "The CVE may be too recent, use a product/version CPE rather than a named package,\n"
+                "or may not yet be indexed."
+            )
+
+        sections.append(f"Affected packages found: {len(merged)}")
+        all_packages = merged[:max_packages]
+
+    else:
+        # Direct package query
+        name = parsed["name"]
+        version = parsed["version"]
+        ecosystem = parsed["ecosystem"] or ""
+        label = f"{ecosystem}:{name}" if ecosystem else name
+        ver_label = f"@{version}" if version else " (all versions)"
+        sections.append(f"Dependency Blast Radius — {label}{ver_label}\n{'='*50}")
+        all_packages = [{
+            "name": name,
+            "ecosystem": ecosystem,
+            "version_range": version or "all",
+            "source": "direct",
+        }]
+
+    # Enrich each package with stats
+    enriched_results: list[dict[str, Any]] = []
+    for pkg in all_packages:
+        eco = pkg.get("ecosystem", "")
+        name = pkg["name"]
+        stats = _enrich_package(name, eco)
+        stats["version_range"] = pkg.get("version_range", "")
+        stats["source"] = pkg.get("source", "")
+        blast = _blast_score(stats)
+        stats["blast_radius"] = blast
+        enriched_results.append(stats)
+
+    # Sort by blast severity
+    _severity_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2, "LOW": 3, "UNKNOWN": 4}
+    enriched_results.sort(key=lambda r: _severity_order.get(r.get("blast_radius", "UNKNOWN"), 4))
+
+    # Build output
+    for i, r in enumerate(enriched_results):
+        eco = r.get("ecosystem") or "Unknown"
+        eco_label = _ECOSYSTEM_LABEL.get(eco, eco)
+        pkg_name = r.get("package_name") or r.get("name", "unknown")
+        blast = r.get("blast_radius", "UNKNOWN")
+        ver_range = r.get("version_range", "")
+        source = r.get("source", "")
+
+        lines: list[str] = [
+            f"\n[{i + 1}] {pkg_name}  ({eco_label})",
+            f"    Blast radius:     {blast}",
+        ]
+        if ver_range:
+            lines.append(f"    Vulnerable range: {ver_range}")
+
+        # npm-specific stats
+        if "dependent_packages_count" in r:
+            lines.append(f"    npm dependents:   {r['dependent_packages_count']:,}")
+        if r.get("weekly_downloads") is not None:
+            lines.append(f"    Weekly downloads: {r['weekly_downloads']:,}")
+        if r.get("monthly_downloads") is not None:
+            lines.append(f"    Monthly downloads:{r['monthly_downloads']:,}")
+
+        # PyPI-specific stats
+        if eco.lower() in ("pypi", "python"):
+            if r.get("latest_version"):
+                lines.append(f"    Latest version:   {r['latest_version']}")
+            if r.get("release_count"):
+                lines.append(f"    Total releases:   {r['release_count']}")
+            if r.get("description"):
+                lines.append(f"    Description:      {r['description'][:80]}")
+
+        # Maven-specific stats
+        if eco.lower() in ("maven", "java"):
+            if r.get("full_id"):
+                lines.append(f"    Maven artifact:   {r['full_id']}")
+            if r.get("latest_version"):
+                lines.append(f"    Latest version:   {r['latest_version']}")
+            if r.get("version_count"):
+                lines.append(f"    Version count:    {r['version_count']}")
+
+        if source:
+            lines.append(f"    Data sources:     {source}")
+
+        sections.extend(lines)
+
+    # Summary line
+    if enriched_results:
+        top = enriched_results[0]
+        max_blast = top.get("blast_radius", "UNKNOWN")
+        max_pkg = top.get("package_name", "")
+        sections.append(f"\nSummary: highest blast radius is {max_blast} ({max_pkg})")
+        total_weekly = sum(
+            r.get("weekly_downloads") or 0
+            for r in enriched_results
+            if r.get("weekly_downloads") is not None
+        )
+        total_dependents = sum(
+            r.get("dependent_packages_count") or 0
+            for r in enriched_results
+        )
+        if total_weekly:
+            sections.append(f"         Total weekly downloads across all packages: {total_weekly:,}")
+        if total_dependents:
+            sections.append(f"         Total npm dependent packages: {total_dependents:,}")
+
+    return "\n".join(sections)

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -16,8 +16,8 @@ from manus_use.tools.get_dependency_blast_radius import (
     _blast_score,
     _enrich_maven,
     _enrich_npm,
-    _enrich_pypi,
     _enrich_package,
+    _enrich_pypi,
     _fetch_ghsa_affected,
     _fetch_nvd_affected,
     _fetch_osv_affected,
@@ -25,7 +25,6 @@ from manus_use.tools.get_dependency_blast_radius import (
     _summarise_osv_ranges,
     get_dependency_blast_radius,
 )
-
 
 # ===========================================================================
 # _parse_input
@@ -363,9 +362,7 @@ class TestFetchOsvAffected:
     def test_returns_packages_from_osv(self):
         with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
             mock_post.return_value.status_code = 200
-            mock_post.return_value.json.return_value = _make_osv_query_response(
-                ["GHSA-xxxx-yyyy-zzzz"]
-            )
+            mock_post.return_value.json.return_value = _make_osv_query_response(["GHSA-xxxx-yyyy-zzzz"])
             mock_get.return_value.status_code = 200
             mock_get.return_value.json.return_value = _make_osv_full_response()
             result = _fetch_osv_affected("CVE-2021-44228")
@@ -610,9 +607,7 @@ class TestEnrichMaven:
 
     def test_returns_artifact_metadata(self):
         mock_resp = MagicMock()
-        mock_resp.json.return_value = self._make_maven_response(
-            "org.apache.logging.log4j", "log4j-core", "2.20.0"
-        )
+        mock_resp.json.return_value = self._make_maven_response("org.apache.logging.log4j", "log4j-core", "2.20.0")
         with patch("requests.get", return_value=mock_resp):
             result = _enrich_maven("org.apache.logging.log4j:log4j-core")
         assert result["ecosystem"] == "Maven"
@@ -648,43 +643,33 @@ class TestEnrichMaven:
 
 class TestEnrichPackageDispatch:
     def test_npm_ecosystem(self):
-        with patch(
-            "manus_use.tools.get_dependency_blast_radius._enrich_npm"
-        ) as mock_npm:
+        with patch("manus_use.tools.get_dependency_blast_radius._enrich_npm") as mock_npm:
             mock_npm.return_value = {"ecosystem": "npm", "package_name": "axios"}
-            result = _enrich_package("axios", "npm")
+            _enrich_package("axios", "npm")
         mock_npm.assert_called_once_with("axios")
 
     def test_javascript_ecosystem_routes_to_npm(self):
-        with patch(
-            "manus_use.tools.get_dependency_blast_radius._enrich_npm"
-        ) as mock_npm:
+        with patch("manus_use.tools.get_dependency_blast_radius._enrich_npm") as mock_npm:
             mock_npm.return_value = {"ecosystem": "npm", "package_name": "react"}
-            result = _enrich_package("react", "javascript")
+            _enrich_package("react", "javascript")
         mock_npm.assert_called_once_with("react")
 
     def test_pypi_ecosystem(self):
-        with patch(
-            "manus_use.tools.get_dependency_blast_radius._enrich_pypi"
-        ) as mock_pypi:
+        with patch("manus_use.tools.get_dependency_blast_radius._enrich_pypi") as mock_pypi:
             mock_pypi.return_value = {"ecosystem": "PyPI", "package_name": "requests"}
-            result = _enrich_package("requests", "PyPI")
+            _enrich_package("requests", "PyPI")
         mock_pypi.assert_called_once_with("requests")
 
     def test_python_ecosystem_routes_to_pypi(self):
-        with patch(
-            "manus_use.tools.get_dependency_blast_radius._enrich_pypi"
-        ) as mock_pypi:
+        with patch("manus_use.tools.get_dependency_blast_radius._enrich_pypi") as mock_pypi:
             mock_pypi.return_value = {"ecosystem": "PyPI", "package_name": "flask"}
-            result = _enrich_package("flask", "python")
+            _enrich_package("flask", "python")
         mock_pypi.assert_called_once_with("flask")
 
     def test_maven_ecosystem(self):
-        with patch(
-            "manus_use.tools.get_dependency_blast_radius._enrich_maven"
-        ) as mock_maven:
+        with patch("manus_use.tools.get_dependency_blast_radius._enrich_maven") as mock_maven:
             mock_maven.return_value = {"ecosystem": "Maven", "package_name": "log4j-core"}
-            result = _enrich_package("log4j-core", "Maven")
+            _enrich_package("log4j-core", "Maven")
         mock_maven.assert_called_once_with("log4j-core")
 
     def test_unknown_ecosystem_returns_minimal_record(self):
@@ -808,7 +793,7 @@ class TestGetDependencyBlastRadius:
                 return_value=pypi_stats,
             ) as mock_enrich,
         ):
-            result = get_dependency_blast_radius("CVE-2023-32681")
+            _result = get_dependency_blast_radius("CVE-2023-32681")
         # _enrich_package should be called exactly once (deduplicated)
         mock_enrich.assert_called_once()
 
@@ -860,8 +845,7 @@ class TestGetDependencyBlastRadius:
     def test_max_packages_respected(self):
         # Create 15 packages
         many_pkgs = [
-            {"name": f"lib-{i}", "ecosystem": "npm", "version_range": "1.0", "source": "osv"}
-            for i in range(15)
+            {"name": f"lib-{i}", "ecosystem": "npm", "version_range": "1.0", "source": "osv"} for i in range(15)
         ]
         call_count = {"n": 0}
 
@@ -878,7 +862,7 @@ class TestGetDependencyBlastRadius:
                 side_effect=enrich_counter,
             ),
         ):
-            result = get_dependency_blast_radius("CVE-2021-00001", max_packages=5)
+            _result = get_dependency_blast_radius("CVE-2021-00001", max_packages=5)
         assert call_count["n"] == 5
 
     def test_ecosystem_label_in_output(self):

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -1,0 +1,951 @@
+"""
+Tests for src/manus_use/tools/get_dependency_blast_radius.py
+
+All external HTTP calls are mocked — no real network I/O.
+100% mocked: NVD, OSV, GHSA, npm, PyPI, pypistats, Maven Central.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_use.tools.get_dependency_blast_radius import (
+    _blast_score,
+    _enrich_maven,
+    _enrich_npm,
+    _enrich_pypi,
+    _enrich_package,
+    _fetch_ghsa_affected,
+    _fetch_nvd_affected,
+    _fetch_osv_affected,
+    _parse_input,
+    _summarise_osv_ranges,
+    get_dependency_blast_radius,
+)
+
+
+# ===========================================================================
+# _parse_input
+# ===========================================================================
+
+
+class TestParseInput:
+    def test_cve_id_uppercase(self):
+        result = _parse_input("CVE-2021-44228")
+        assert result["kind"] == "cve"
+        assert result["cve_id"] == "CVE-2021-44228"
+
+    def test_cve_id_lowercase(self):
+        result = _parse_input("cve-2021-44228")
+        assert result["kind"] == "cve"
+        assert result["cve_id"] == "CVE-2021-44228"
+
+    def test_cve_id_with_spaces(self):
+        result = _parse_input("  CVE-2024-3094  ")
+        assert result["kind"] == "cve"
+        assert result["cve_id"] == "CVE-2024-3094"
+
+    def test_package_with_version(self):
+        result = _parse_input("requests@2.28.0")
+        assert result["kind"] == "package"
+        assert result["name"] == "requests"
+        assert result["version"] == "2.28.0"
+        assert result["ecosystem"] is None
+
+    def test_package_without_version(self):
+        result = _parse_input("requests")
+        assert result["kind"] == "package"
+        assert result["name"] == "requests"
+        assert result["version"] is None
+
+    def test_ecosystem_qualified_package(self):
+        result = _parse_input("pypi:requests@2.28.0")
+        assert result["kind"] == "package"
+        assert result["ecosystem"] == "pypi"
+        assert result["name"] == "requests"
+        assert result["version"] == "2.28.0"
+
+    def test_npm_ecosystem(self):
+        result = _parse_input("npm:lodash@4.17.20")
+        assert result["kind"] == "package"
+        assert result["ecosystem"] == "npm"
+        assert result["name"] == "lodash"
+        assert result["version"] == "4.17.20"
+
+    def test_maven_ecosystem(self):
+        result = _parse_input("maven:log4j-core@2.14.1")
+        assert result["kind"] == "package"
+        assert result["ecosystem"] == "maven"
+        assert result["name"] == "log4j-core"
+
+    def test_url_not_treated_as_ecosystem(self):
+        # http: should not strip the protocol
+        result = _parse_input("https://example.com")
+        assert result["kind"] == "package"
+        # name should include the full string (no ecosystem stripping)
+
+    def test_cve_id_extracted_correctly(self):
+        result = _parse_input("CVE-2023-12345")
+        assert result["cve_id"] == "CVE-2023-12345"
+        assert result["name"] is None
+
+
+# ===========================================================================
+# _summarise_osv_ranges
+# ===========================================================================
+
+
+class TestSummariseOsvRanges:
+    def test_semver_introduced_fixed(self):
+        ranges = [
+            {
+                "type": "SEMVER",
+                "events": [{"introduced": "2.0.0"}, {"fixed": "2.3.1"}],
+            }
+        ]
+        result = _summarise_osv_ranges(ranges, [])
+        assert "2.0.0" in result
+        assert "2.3.1" in result
+
+    def test_ecosystem_range(self):
+        ranges = [
+            {
+                "type": "ECOSYSTEM",
+                "events": [{"introduced": "1.0.0"}, {"fixed": "1.5.0"}],
+            }
+        ]
+        result = _summarise_osv_ranges(ranges, [])
+        assert ">=1.0.0" in result
+        assert "<1.5.0" in result
+
+    def test_falls_back_to_versions_list(self):
+        result = _summarise_osv_ranges([], ["2.0.0", "2.1.0", "2.2.0"])
+        assert "2.0.0" in result
+        assert "2.1.0" in result
+
+    def test_versions_list_truncated_beyond_five(self):
+        versions = ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6"]
+        result = _summarise_osv_ranges([], versions)
+        assert "+2 more" in result
+
+    def test_empty_input(self):
+        result = _summarise_osv_ranges([], [])
+        assert result == "unspecified"
+
+    def test_introduced_only(self):
+        ranges = [{"type": "SEMVER", "events": [{"introduced": "1.0.0"}]}]
+        result = _summarise_osv_ranges(ranges, [])
+        assert ">=1.0.0" in result
+
+    def test_git_range_skipped(self):
+        ranges = [{"type": "GIT", "events": [{"introduced": "abc123"}, {"fixed": "def456"}]}]
+        result = _summarise_osv_ranges(ranges, ["2.0.0"])
+        # GIT ranges are skipped; should fall back to versions list
+        assert "2.0.0" in result
+
+
+# ===========================================================================
+# _blast_score
+# ===========================================================================
+
+
+class TestBlastScore:
+    def test_critical_by_downloads(self):
+        assert _blast_score({"weekly_downloads": 10_000_000}) == "CRITICAL"
+
+    def test_critical_by_dependents(self):
+        assert _blast_score({"dependent_packages_count": 100_000}) == "CRITICAL"
+
+    def test_high_by_downloads(self):
+        assert _blast_score({"weekly_downloads": 1_000_000}) == "HIGH"
+
+    def test_high_by_dependents(self):
+        assert _blast_score({"dependent_packages_count": 10_000}) == "HIGH"
+
+    def test_medium_by_downloads(self):
+        assert _blast_score({"weekly_downloads": 100_000}) == "MEDIUM"
+
+    def test_medium_by_dependents(self):
+        assert _blast_score({"dependent_packages_count": 1_000}) == "MEDIUM"
+
+    def test_low_small_downloads(self):
+        assert _blast_score({"weekly_downloads": 5_000}) == "LOW"
+
+    def test_low_small_dependents(self):
+        assert _blast_score({"dependent_packages_count": 10}) == "LOW"
+
+    def test_unknown_no_data(self):
+        assert _blast_score({}) == "UNKNOWN"
+
+    def test_unknown_zero_values(self):
+        assert _blast_score({"weekly_downloads": 0, "dependent_packages_count": 0}) == "UNKNOWN"
+
+    def test_none_values_treated_as_zero(self):
+        assert _blast_score({"weekly_downloads": None, "dependent_packages_count": None}) == "UNKNOWN"
+
+    def test_critical_threshold_boundary(self):
+        assert _blast_score({"weekly_downloads": 5_000_000}) == "CRITICAL"
+        assert _blast_score({"weekly_downloads": 4_999_999}) == "HIGH"
+
+
+# ===========================================================================
+# _fetch_nvd_affected
+# ===========================================================================
+
+
+def _make_nvd_cve_response(
+    cve_id: str = "CVE-2021-44228",
+    product: str = "log4j-core",
+    version_start: str = "2.0.0",
+    version_end: str = "2.15.0",
+) -> dict[str, Any]:
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": cve_id,
+                    "configurations": [
+                        {
+                            "nodes": [
+                                {
+                                    "cpeMatch": [
+                                        {
+                                            "vulnerable": True,
+                                            "criteria": f"cpe:2.3:a:apache:{product}:*:*:*:*:*:*:*:*",
+                                            "versionStartIncluding": version_start,
+                                            "versionEndExcluding": version_end,
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+class TestFetchNvdAffected:
+    def test_extracts_package_and_range(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _make_nvd_cve_response()
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_nvd_affected("CVE-2021-44228")
+        assert len(result) >= 1
+        assert result[0]["name"] == "log4j-core"
+        assert "2.0.0" in result[0]["version_range"]
+        assert "2.15.0" in result[0]["version_range"]
+
+    def test_returns_empty_on_http_error(self):
+        with patch("requests.get", side_effect=Exception("network error")):
+            result = _fetch_nvd_affected("CVE-2021-44228")
+        assert result == []
+
+    def test_returns_empty_when_no_vulnerabilities(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_nvd_affected("CVE-2021-44228")
+        assert result == []
+
+    def test_skips_non_vulnerable_cpe(self):
+        data = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "CVE-2021-44228",
+                        "configurations": [
+                            {
+                                "nodes": [
+                                    {
+                                        "cpeMatch": [
+                                            {
+                                                "vulnerable": False,
+                                                "criteria": "cpe:2.3:a:apache:log4j-core:2.0:*:*:*:*:*:*:*",
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = data
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_nvd_affected("CVE-2021-44228")
+        assert result == []
+
+    def test_deduplication_by_name(self):
+        # Multiple CPEs for the same product → should deduplicate
+        data = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": "CVE-2021-44228",
+                        "configurations": [
+                            {
+                                "nodes": [
+                                    {
+                                        "cpeMatch": [
+                                            {
+                                                "vulnerable": True,
+                                                "criteria": "cpe:2.3:a:apache:log4j-core:2.0:*:*:*:*:*:*:*",
+                                                "versionStartIncluding": "2.0",
+                                                "versionEndExcluding": "2.15.0",
+                                            },
+                                            {
+                                                "vulnerable": True,
+                                                "criteria": "cpe:2.3:a:apache:log4j-core:2.0:*:*:*:*:*:*:*",
+                                                "versionStartIncluding": "2.16.0",
+                                                "versionEndExcluding": "2.17.0",
+                                            },
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                }
+            ]
+        }
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = data
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_nvd_affected("CVE-2021-44228")
+        names = [r["name"] for r in result]
+        assert names.count("log4j-core") == 1
+
+
+# ===========================================================================
+# _fetch_osv_affected
+# ===========================================================================
+
+
+def _make_osv_query_response(vuln_ids: list[str]) -> dict:
+    return {"vulns": [{"id": vid} for vid in vuln_ids]}
+
+
+def _make_osv_full_response(
+    name: str = "log4j-core",
+    ecosystem: str = "Maven",
+    introduced: str = "2.0.0",
+    fixed: str = "2.15.0",
+) -> dict:
+    return {
+        "id": "GHSA-xxxx-yyyy-zzzz",
+        "affected": [
+            {
+                "package": {"name": name, "ecosystem": ecosystem},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": introduced}, {"fixed": fixed}],
+                    }
+                ],
+                "versions": [],
+            }
+        ],
+    }
+
+
+class TestFetchOsvAffected:
+    def test_returns_packages_from_osv(self):
+        with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = _make_osv_query_response(
+                ["GHSA-xxxx-yyyy-zzzz"]
+            )
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = _make_osv_full_response()
+            result = _fetch_osv_affected("CVE-2021-44228")
+        assert any(r["name"] == "log4j-core" for r in result)
+        assert any(r["ecosystem"] == "Maven" for r in result)
+
+    def test_returns_empty_on_post_failure(self):
+        with patch("requests.post", side_effect=Exception("timeout")):
+            result = _fetch_osv_affected("CVE-2021-44228")
+        assert result == []
+
+    def test_skips_packages_without_name(self):
+        osv_full = {
+            "id": "OSV-001",
+            "affected": [{"package": {"name": "", "ecosystem": "PyPI"}, "ranges": [], "versions": []}],
+        }
+        with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
+            mock_post.return_value.json.return_value = _make_osv_query_response(["OSV-001"])
+            mock_get.return_value.json.return_value = osv_full
+            result = _fetch_osv_affected("CVE-2023-0001")
+        assert result == []
+
+    def test_continues_when_individual_vuln_fetch_fails(self):
+        with patch("requests.post") as mock_post, patch("requests.get") as mock_get:
+            mock_post.return_value.json.return_value = _make_osv_query_response(
+                ["GHSA-aaa-bbb-ccc", "GHSA-xxx-yyy-zzz"]
+            )
+            # First call fails, second succeeds
+            mock_get.side_effect = [
+                Exception("connection refused"),
+                MagicMock(
+                    status_code=200,
+                    json=MagicMock(return_value=_make_osv_full_response(name="requests")),
+                ),
+            ]
+            result = _fetch_osv_affected("CVE-2023-0001")
+        # Should contain the one that succeeded
+        assert any(r["name"] == "requests" for r in result)
+
+
+# ===========================================================================
+# _fetch_ghsa_affected
+# ===========================================================================
+
+
+def _make_ghsa_response(
+    pkg_name: str = "log4j-core",
+    ecosystem: str = "maven",
+    vuln_range: str = ">=2.0.0, <2.15.0",
+    patched: str = "2.15.0",
+) -> list[dict]:
+    return [
+        {
+            "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+            "vulnerabilities": [
+                {
+                    "package": {"name": pkg_name, "ecosystem": ecosystem},
+                    "vulnerable_version_range": vuln_range,
+                    "first_patched_version": {"identifier": patched},
+                }
+            ],
+        }
+    ]
+
+
+class TestFetchGhsaAffected:
+    def test_returns_packages_from_ghsa(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = _make_ghsa_response()
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_ghsa_affected("CVE-2021-44228")
+        assert any(r["name"] == "log4j-core" for r in result)
+        assert any(r["ecosystem"] == "maven" for r in result)
+
+    def test_uses_patched_version_when_range_absent(self):
+        response = [
+            {
+                "ghsa_id": "GHSA-test",
+                "vulnerabilities": [
+                    {
+                        "package": {"name": "example-lib", "ecosystem": "PyPI"},
+                        "vulnerable_version_range": "",
+                        "first_patched_version": {"identifier": "3.0.0"},
+                    }
+                ],
+            }
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = response
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_ghsa_affected("CVE-2023-0001")
+        assert any(r["name"] == "example-lib" for r in result)
+        assert any("<3.0.0" in r["version_range"] for r in result)
+
+    def test_returns_empty_on_http_error(self):
+        with patch("requests.get", side_effect=Exception("503")):
+            result = _fetch_ghsa_affected("CVE-2021-44228")
+        assert result == []
+
+    def test_skips_packages_without_name(self):
+        response = [
+            {
+                "ghsa_id": "GHSA-test",
+                "vulnerabilities": [
+                    {
+                        "package": {"name": "", "ecosystem": "npm"},
+                        "vulnerable_version_range": ">=1.0",
+                        "first_patched_version": {"identifier": "2.0.0"},
+                    }
+                ],
+            }
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = response
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_ghsa_affected("CVE-2023-0001")
+        assert result == []
+
+
+# ===========================================================================
+# _enrich_npm
+# ===========================================================================
+
+
+class TestEnrichNpm:
+    def _make_search_response(self, name: str, dependents: int, weekly: int, monthly: int) -> dict:
+        return {
+            "objects": [
+                {
+                    "package": {"name": name},
+                    "dependents": str(dependents),
+                    "downloads": {"weekly": weekly, "monthly": monthly},
+                }
+            ]
+        }
+
+    def test_returns_dependent_and_download_counts(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_search_response("lodash", 200000, 130000000, 520000000)
+        with patch("requests.get", return_value=mock_resp):
+            result = _enrich_npm("lodash")
+        assert result["ecosystem"] == "npm"
+        assert result["dependent_packages_count"] == 200000
+        assert result["weekly_downloads"] == 130000000
+
+    def test_falls_back_to_downloads_api(self):
+        # Search response has no matching package name
+        search_resp = MagicMock()
+        search_resp.json.return_value = {"objects": [{"package": {"name": "something-else"}, "dependents": "0"}]}
+        dl_resp = MagicMock()
+        dl_resp.json.return_value = {"downloads": 5000000, "package": "axios"}
+        with patch("requests.get", side_effect=[search_resp, dl_resp]):
+            result = _enrich_npm("axios")
+        assert result["weekly_downloads"] == 5000000
+
+    def test_graceful_degradation_on_error(self):
+        with patch("requests.get", side_effect=Exception("timeout")):
+            result = _enrich_npm("axios")
+        assert result["ecosystem"] == "npm"
+        assert result["package_name"] == "axios"
+        # No crash — just missing keys
+        assert "dependent_packages_count" not in result
+
+    def test_package_name_case_insensitive_match(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_search_response("Lodash", 100, 1000, 4000)
+        with patch("requests.get", return_value=mock_resp):
+            result = _enrich_npm("lodash")
+        assert result.get("dependent_packages_count") == 100
+
+
+# ===========================================================================
+# _enrich_pypi
+# ===========================================================================
+
+
+class TestEnrichPypi:
+    def _make_pypi_response(self, name: str, version: str, summary: str) -> dict:
+        return {
+            "info": {
+                "name": name,
+                "version": version,
+                "summary": summary,
+                "project_url": f"https://pypi.org/project/{name}/",
+            },
+            "releases": {"1.0.0": [], "2.0.0": [], version: []},
+        }
+
+    def test_returns_package_metadata(self):
+        pypi_resp = MagicMock()
+        pypi_resp.json.return_value = self._make_pypi_response("requests", "2.28.0", "HTTP for Humans")
+        pypi_resp.raise_for_status.return_value = None
+        stats_resp = MagicMock()
+        stats_resp.json.return_value = {"data": {"last_week": 50000000, "last_month": 200000000}}
+        stats_resp.raise_for_status.return_value = None
+        with patch("requests.get", side_effect=[pypi_resp, stats_resp]):
+            result = _enrich_pypi("requests")
+        assert result["ecosystem"] == "PyPI"
+        assert result["latest_version"] == "2.28.0"
+        assert result["weekly_downloads"] == 50000000
+        assert "HTTP for Humans" in result.get("description", "")
+
+    def test_download_stats_none_on_rate_limit(self):
+        pypi_resp = MagicMock()
+        pypi_resp.json.return_value = self._make_pypi_response("requests", "2.28.0", "HTTP for Humans")
+        pypi_resp.raise_for_status.return_value = None
+        stats_resp = MagicMock()
+        stats_resp.raise_for_status.side_effect = Exception("429 Too Many Requests")
+        with patch("requests.get", side_effect=[pypi_resp, stats_resp]):
+            result = _enrich_pypi("requests")
+        assert result["weekly_downloads"] is None
+
+    def test_graceful_degradation_on_pypi_error(self):
+        with patch("requests.get", side_effect=Exception("connection refused")):
+            result = _enrich_pypi("requests")
+        assert result["ecosystem"] == "PyPI"
+        assert result["package_name"] == "requests"
+
+
+# ===========================================================================
+# _enrich_maven
+# ===========================================================================
+
+
+class TestEnrichMaven:
+    def _make_maven_response(self, group_id: str, artifact_id: str, version: str) -> dict:
+        return {
+            "response": {
+                "numFound": 1,
+                "docs": [
+                    {
+                        "id": f"{group_id}:{artifact_id}",
+                        "g": group_id,
+                        "a": artifact_id,
+                        "latestVersion": version,
+                        "versionCount": 42,
+                    }
+                ],
+            }
+        }
+
+    def test_returns_artifact_metadata(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_maven_response(
+            "org.apache.logging.log4j", "log4j-core", "2.20.0"
+        )
+        with patch("requests.get", return_value=mock_resp):
+            result = _enrich_maven("org.apache.logging.log4j:log4j-core")
+        assert result["ecosystem"] == "Maven"
+        assert result["latest_version"] == "2.20.0"
+        assert result["version_count"] == 42
+        assert result["full_id"] == "org.apache.logging.log4j:log4j-core"
+
+    def test_plain_artifact_id(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_maven_response("org.example", "mylib", "1.0.0")
+        with patch("requests.get", return_value=mock_resp):
+            result = _enrich_maven("mylib")
+        assert result["ecosystem"] == "Maven"
+
+    def test_graceful_degradation_on_error(self):
+        with patch("requests.get", side_effect=Exception("403 Forbidden")):
+            result = _enrich_maven("log4j-core")
+        assert result["ecosystem"] == "Maven"
+        assert result["package_name"] == "log4j-core"
+
+    def test_no_docs_returns_minimal_record(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"response": {"numFound": 0, "docs": []}}
+        with patch("requests.get", return_value=mock_resp):
+            result = _enrich_maven("nonexistent-lib")
+        assert result["total_artifacts_found"] == 0
+
+
+# ===========================================================================
+# _enrich_package dispatch
+# ===========================================================================
+
+
+class TestEnrichPackageDispatch:
+    def test_npm_ecosystem(self):
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_npm"
+        ) as mock_npm:
+            mock_npm.return_value = {"ecosystem": "npm", "package_name": "axios"}
+            result = _enrich_package("axios", "npm")
+        mock_npm.assert_called_once_with("axios")
+
+    def test_javascript_ecosystem_routes_to_npm(self):
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_npm"
+        ) as mock_npm:
+            mock_npm.return_value = {"ecosystem": "npm", "package_name": "react"}
+            result = _enrich_package("react", "javascript")
+        mock_npm.assert_called_once_with("react")
+
+    def test_pypi_ecosystem(self):
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_pypi"
+        ) as mock_pypi:
+            mock_pypi.return_value = {"ecosystem": "PyPI", "package_name": "requests"}
+            result = _enrich_package("requests", "PyPI")
+        mock_pypi.assert_called_once_with("requests")
+
+    def test_python_ecosystem_routes_to_pypi(self):
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_pypi"
+        ) as mock_pypi:
+            mock_pypi.return_value = {"ecosystem": "PyPI", "package_name": "flask"}
+            result = _enrich_package("flask", "python")
+        mock_pypi.assert_called_once_with("flask")
+
+    def test_maven_ecosystem(self):
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_maven"
+        ) as mock_maven:
+            mock_maven.return_value = {"ecosystem": "Maven", "package_name": "log4j-core"}
+            result = _enrich_package("log4j-core", "Maven")
+        mock_maven.assert_called_once_with("log4j-core")
+
+    def test_unknown_ecosystem_returns_minimal_record(self):
+        result = _enrich_package("unknown-pkg", "SomeExoticEcosystem")
+        assert result["ecosystem"] == "SomeExoticEcosystem"
+        assert result["package_name"] == "unknown-pkg"
+
+
+# ===========================================================================
+# get_dependency_blast_radius (integration tests with full stack mocked)
+# ===========================================================================
+
+
+class TestGetDependencyBlastRadius:
+    def _mock_all_sources(
+        self,
+        nvd_pkgs=None,
+        osv_pkgs=None,
+        ghsa_pkgs=None,
+        npm_stats=None,
+    ):
+        """Return context managers that mock all external calls."""
+        nvd_pkgs = nvd_pkgs or []
+        osv_pkgs = osv_pkgs or []
+        ghsa_pkgs = ghsa_pkgs or []
+        npm_stats = npm_stats or {
+            "ecosystem": "npm",
+            "package_name": "lodash",
+            "dependent_packages_count": 200000,
+            "weekly_downloads": 130000000,
+            "monthly_downloads": 520000000,
+        }
+
+        patches = [
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected",
+                return_value=nvd_pkgs,
+            ),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._fetch_osv_affected",
+                return_value=osv_pkgs,
+            ),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected",
+                return_value=ghsa_pkgs,
+            ),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+        ]
+        return patches
+
+    def test_cve_no_packages_found_returns_message(self):
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+        ):
+            result = get_dependency_blast_radius("CVE-2021-44228")
+        assert "No affected package records found" in result
+
+    def test_cve_with_packages_returns_blast_radius_info(self):
+        pkgs = [{"name": "lodash", "ecosystem": "npm", "version_range": ">=4.0.0, <4.17.21", "source": "osv"}]
+        npm_stats = {
+            "ecosystem": "npm",
+            "package_name": "lodash",
+            "dependent_packages_count": 200000,
+            "weekly_downloads": 130000000,
+        }
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=pkgs),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2021-44228")
+        assert "CRITICAL" in result
+        assert "lodash" in result
+        assert "130,000,000" in result or "Weekly downloads" in result
+
+    def test_package_spec_direct(self):
+        npm_stats = {
+            "ecosystem": "npm",
+            "package_name": "lodash",
+            "dependent_packages_count": 200000,
+            "weekly_downloads": 130000000,
+        }
+        with patch(
+            "manus_use.tools.get_dependency_blast_radius._enrich_package",
+            return_value=npm_stats,
+        ):
+            result = get_dependency_blast_radius("lodash@4.17.20")
+        assert "lodash" in result
+        assert "CRITICAL" in result
+
+    def test_invalid_spec_returns_error(self):
+        # A completely empty string
+        result = get_dependency_blast_radius("")
+        # Should return an error or empty packages message (graceful)
+        assert isinstance(result, str)
+
+    def test_cve_deduplication_across_sources(self):
+        # Same package appears in both OSV and GHSA
+        osv_pkgs = [{"name": "requests", "ecosystem": "PyPI", "version_range": ">=2.0, <2.29", "source": "osv"}]
+        ghsa_pkgs = [{"name": "requests", "ecosystem": "PyPI", "version_range": ">=2.0, <2.29", "source": "ghsa"}]
+        pypi_stats = {
+            "ecosystem": "PyPI",
+            "package_name": "requests",
+            "weekly_downloads": 60000000,
+        }
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=osv_pkgs),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=ghsa_pkgs),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ) as mock_enrich,
+        ):
+            result = get_dependency_blast_radius("CVE-2023-32681")
+        # _enrich_package should be called exactly once (deduplicated)
+        mock_enrich.assert_called_once()
+
+    def test_packages_sorted_by_blast_severity(self):
+        osv_pkgs = [
+            {"name": "small-lib", "ecosystem": "npm", "version_range": "1.0.0", "source": "osv"},
+            {"name": "big-lib", "ecosystem": "npm", "version_range": "2.0.0", "source": "osv"},
+        ]
+
+        def enrich_side_effect(name, ecosystem):
+            if name == "small-lib":
+                return {"ecosystem": "npm", "package_name": "small-lib", "weekly_downloads": 1000}
+            else:
+                return {"ecosystem": "npm", "package_name": "big-lib", "weekly_downloads": 10_000_000}
+
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=osv_pkgs),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                side_effect=enrich_side_effect,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2021-00001")
+        # CRITICAL (big-lib) should appear before LOW (small-lib)
+        assert result.index("big-lib") < result.index("small-lib")
+
+    def test_summary_line_present(self):
+        pkgs = [{"name": "axios", "ecosystem": "npm", "version_range": ">=1.0.0, <1.7.0", "source": "ghsa"}]
+        npm_stats = {
+            "ecosystem": "npm",
+            "package_name": "axios",
+            "dependent_packages_count": 180000,
+            "weekly_downloads": 120000000,
+        }
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=pkgs),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2023-45857")
+        assert "Summary" in result
+
+    def test_max_packages_respected(self):
+        # Create 15 packages
+        many_pkgs = [
+            {"name": f"lib-{i}", "ecosystem": "npm", "version_range": "1.0", "source": "osv"}
+            for i in range(15)
+        ]
+        call_count = {"n": 0}
+
+        def enrich_counter(name, ecosystem):
+            call_count["n"] += 1
+            return {"ecosystem": "npm", "package_name": name, "weekly_downloads": 100}
+
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=many_pkgs),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                side_effect=enrich_counter,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2021-00001", max_packages=5)
+        assert call_count["n"] == 5
+
+    def test_ecosystem_label_in_output(self):
+        pkgs = [{"name": "requests", "ecosystem": "PyPI", "version_range": "2.28.0", "source": "osv"}]
+        pypi_stats = {
+            "ecosystem": "PyPI",
+            "package_name": "requests",
+            "weekly_downloads": 60000000,
+            "latest_version": "2.34.0",
+            "description": "Python HTTP for Humans",
+            "release_count": 163,
+        }
+        with (
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=pkgs),
+            patch("manus_use.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_use.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2023-32681")
+        assert "Python" in result or "PyPI" in result
+
+
+# ===========================================================================
+# CLI integration: _build_blast_radius_parser
+# ===========================================================================
+
+
+class TestCliParser:
+    def test_spec_argument_required(self):
+        from manus_use.cli import _build_blast_radius_parser
+
+        parser = _build_blast_radius_parser()
+        with pytest.raises(SystemExit):
+            parser.parse_args([])
+
+    def test_default_output_text(self):
+        from manus_use.cli import _build_blast_radius_parser
+
+        parser = _build_blast_radius_parser()
+        args = parser.parse_args(["CVE-2021-44228"])
+        assert args.output == "text"
+
+    def test_output_json(self):
+        from manus_use.cli import _build_blast_radius_parser
+
+        parser = _build_blast_radius_parser()
+        args = parser.parse_args(["CVE-2021-44228", "--output", "json"])
+        assert args.output == "json"
+
+    def test_max_packages_default(self):
+        from manus_use.cli import _build_blast_radius_parser
+
+        parser = _build_blast_radius_parser()
+        args = parser.parse_args(["requests@2.28.0"])
+        assert args.max_packages == 10
+
+    def test_max_packages_custom(self):
+        from manus_use.cli import _build_blast_radius_parser
+
+        parser = _build_blast_radius_parser()
+        args = parser.parse_args(["requests@2.28.0", "--max-packages", "20"])
+        assert args.max_packages == 20
+
+    def test_blast_radius_in_subcommands_set(self):
+        from manus_use.cli import _SUBCOMMANDS
+
+        assert "blast-radius" in _SUBCOMMANDS


### PR DESCRIPTION
## Summary

Adds `get_dependency_blast_radius` — a new tool that answers *"how many downstream projects are actually exposed to this vulnerability?"*

Given a CVE or `package@version` spec, it:

1. **Resolves affected packages** from three public sources in parallel:
   - NVD CPE configurations
   - OSV.dev query + full vulnerability fetch
   - GitHub Advisory Database (GHSA)
2. **Deduplicates** across sources by (name, ecosystem)
3. **Enriches** each package with real download/dependent stats:
   - **npm** → npm registry search API (dependent count) + npm downloads API (weekly/monthly)
   - **PyPI** → PyPI JSON API (metadata) + pypistats.org (weekly/monthly downloads)
   - **Maven** → Maven Central Solr search (artifact metadata, version count)
4. **Labels blast radius** per package:
   | Label | Weekly downloads or npm dependents |
   |---|---|
   | CRITICAL | ≥ 5 M downloads or ≥ 50 K dependents |
   | HIGH | ≥ 500 K downloads or ≥ 5 K dependents |
   | MEDIUM | ≥ 50 K downloads or ≥ 500 dependents |
   | LOW | any measurable signal |
   | UNKNOWN | no data available |

## CLI

```bash
manus-use blast-radius CVE-2021-44228
manus-use blast-radius requests@2.28.0
manus-use blast-radius npm:lodash@4.17.20
manus-use blast-radius CVE-2021-44228 --output json | jq .summary
manus-use blast-radius CVE-2021-44228 --output json | jq '.packages[0].blast_radius'
```

## Files changed

| File | Change |
|---|---|
| `src/manus_use/tools/get_dependency_blast_radius.py` | ✨ new tool (22 KB) |
| `src/manus_use/cli.py` | ✨ `blast-radius` subcommand + dispatch |
| `src/manus_use/agents/vi_agent.py` | ✨ import + tool list + Step 6c in system prompt |
| `tests/test_dependency_blast_radius.py` | ✨ 74 new tests (all HTTP mocked) |
| `README.md` | 📝 full subcommand docs + examples |

## APIs used (all free, no keys required)

- NVD CVE API (`services.nvd.nist.gov`)
- OSV.dev query API (`api.osv.dev`)
- GitHub Advisory REST API (`api.github.com/advisories`)
- npm registry search + downloads API
- PyPI JSON API + pypistats.org
- Maven Central Solr search (`search.maven.org`)

## Tests

74 new tests, all passing. Full suite: **845 passed**.

```
tests/test_dependency_blast_radius.py  74 passed in 1.39s
full suite                            845 passed, 3 deselected, 2 warnings
```

Closes #(new)