### PR TITLE
feat(tools): temporal priority scorer — score_temporal_priority + manus-use temporal-priority CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,46 @@ Use this alongside `epss-trend` and `compare` to answer: *"this CVE is CVSS 9.8
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Output format; `json` includes per-dimension scores and metadata |
 
+### `manus-use temporal-priority <CVE-ID>` — Time-aware urgency score
+
+```bash
+# Score how urgently you need to act on a CVE right now (0-100)
+manus-use temporal-priority CVE-2021-44228
+
+# Machine-readable output
+manus-use temporal-priority CVE-2021-44228 --output json | jq '{score: .urgency_score, label: .label}'
+```
+
+Computes a composite 0–100 urgency score by combining six signals, each weighted
+to reflect real-world exploitation risk:
+
+| Component | Max pts | What it captures |
+|-----------|---------|------------------|
+| CVSS base score | 25 | Theoretical severity |
+| EPSS current score | 20 | ML-predicted exploitation probability |
+| EPSS spike recency | 15 | How recently the EPSS score surged (exponential decay — a spike last week outweighs a spike six months ago) |
+| CISA KEV membership | 20 | Actively exploited in the wild |
+| Patch unavailability | 10 | No patch signals in NVD references |
+| CVE age pressure | 10 | How long an unpatched window has been open |
+
+Score bands:
+
+| Score | Label | Suggested action |
+|-------|-------|------------------|
+| 80–100 | 🔴 CRITICAL | Act immediately — patch, isolate, or mitigate within hours |
+| 60–79 | 🟠 HIGH | Prioritise patching within 1–3 days |
+| 40–59 | 🟡 MEDIUM | Schedule for next maintenance window |
+| 0–39 | 🟢 LOW | Monitor; patch on standard cycle |
+
+Use alongside `exploit-complexity` (how hard to weaponise) and `compare`
+(which of two CVEs is more urgent) to build a full triage picture.
+
+**Options:**
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format; `json` includes per-component breakdown and all raw signals |
+
 ### `manus-use discover` — CVE discovery
 
 ```bash
@@ -606,6 +646,10 @@ manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priori
 # Score how hard it is for an attacker to exploit a CVE (1=trivial, 5=very hard)
 manus-use exploit-complexity CVE-2024-3094
 manus-use exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
+
+# Score time-aware urgency: CVSS + EPSS trajectory + KEV + patch status + age (0-100)
+manus-use temporal-priority CVE-2021-44228
+manus-use temporal-priority CVE-2021-44228 --output json | jq '{score: .urgency_score, label: .label}'
 
 # Discover new high-EPSS CVEs from the last 2 weeks
 manus-use discover --since 2025-06-12 --min-epss 0.6

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -111,6 +111,14 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   - Whether the score was derived from PoC code analysis or NVD CVSS vector only.
   This score contextualises raw CVSS severity: a CVSS 9.8 with complexity_score=1.5 is far more urgent than the same CVSS with complexity_score=4.5.
 
+**Step 6c: Temporal Priority Scoring**
+- Call `score_temporal_priority` with the CVE ID. Include in the report:
+  - The `urgency_score` (0–100) and label (CRITICAL / HIGH / MEDIUM / LOW).
+  - The top-scoring component(s) driving the urgency (e.g. KEV membership, recent EPSS spike).
+  - `days_since_spike` if a spike was detected — a spike in the last 7 days is a strong "act now" signal.
+  This score synthesises CVSS, EPSS trajectory, KEV status, patch availability, and CVE age into a single
+  time-aware urgency number, answering "how urgently must I act *today*?".
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -208,6 +216,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_use.tools.get_trickest_pocs import get_trickest_pocs
             from manus_use.tools.get_vulncheck_data import get_vulncheck_data
             from manus_use.tools.score_exploit_complexity import score_exploit_complexity
+            from manus_use.tools.score_temporal_priority import score_temporal_priority
             from manus_use.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
@@ -261,6 +270,7 @@ class VulnerabilityIntelligenceAgent:
             get_epss_trend,
             get_patch_diff,
             score_exploit_complexity,
+            score_temporal_priority,
             get_vulncheck_data,
             search_poc_sources,
         ]

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -1053,6 +1053,7 @@ _SUBCOMMANDS = {
     "patch-diff",
     "compare",
     "exploit-complexity",
+    "temporal-priority",
     "poc-search",
 }
 
@@ -1343,7 +1344,78 @@ def _run_exploit_complexity(argv: list[str]) -> int:
 
 
 # ---------------------------------------------------------------------------
-# poc-search subcommand
+# temporal-priority subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_temporal_priority_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="manus-use temporal-priority",
+        description=(
+            "Compute a time-aware composite urgency score (0-100) for a CVE.\n"
+            "Combines CVSS severity, EPSS exploitation probability (with spike-recency\n"
+            "decay), CISA KEV membership, patch availability, and CVE age.\n"
+            "Score bands: CRITICAL 80-100 | HIGH 60-79 | MEDIUM 40-59 | LOW 0-39."
+        ),
+    )
+    parser.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier (e.g. CVE-2021-44228)")
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return parser
+
+
+def _run_temporal_priority(argv: list[str]) -> int:
+    parser = _build_temporal_priority_parser()
+    args = parser.parse_args(argv)
+
+    cve_id: str = args.cve_id.strip()
+    import re as _re
+
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id, _re.IGNORECASE):
+        parser.error(f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN")
+
+    try:
+        from manus_use.tools.score_temporal_priority import (
+            _compute_score,
+            _fetch_epss,
+            _fetch_kev,
+            _fetch_nvd,
+            _render_text,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: failed to import score_temporal_priority: {exc}", file=__import__("sys").stderr)
+        return 1
+
+    import concurrent.futures as _cf
+
+    with _cf.ThreadPoolExecutor(max_workers=3) as executor:
+        f_nvd = executor.submit(_fetch_nvd, cve_id)
+        f_epss = executor.submit(_fetch_epss, cve_id)
+        f_kev = executor.submit(_fetch_kev, cve_id)
+        nvd = f_nvd.result()
+        epss = f_epss.result()
+        kev = f_kev.result()
+
+    if nvd.get("error"):
+        print(f"Error: NVD lookup failed for {cve_id}: {nvd['error']}", file=__import__("sys").stderr)
+        return 1
+
+    scored = _compute_score(nvd, epss, kev)
+
+    if args.output == "json":
+        import json as _json
+
+        print(_json.dumps(scored, indent=2))
+        return 0
+
+    print(_render_text(scored))
+    return 0
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -1761,6 +1833,10 @@ def main() -> None:
     if first_positional == "exploit-complexity":
         idx = argv.index("exploit-complexity")
         sys.exit(_run_exploit_complexity(argv[idx + 1 :]))
+
+    if first_positional == "temporal-priority":
+        idx = argv.index("temporal-priority")
+        sys.exit(_run_temporal_priority(argv[idx + 1 :]))
 
     if first_positional == "poc-search":
         idx = argv.index("poc-search")

--- a/src/manus_use/tools/score_temporal_priority.py
+++ b/src/manus_use/tools/score_temporal_priority.py
@@ -1,0 +1,541 @@
+"""
+Tool for computing a time-aware, composite vulnerability urgency score.
+
+Combines CVSS base severity, EPSS exploitation probability (with spike-recency
+decay), CISA KEV membership, patch availability, and CVE age into a single
+0-100 urgency score.  Answers the practical question:
+
+    "Of everything I know about this CVE *right now*, how urgently should I act?"
+
+Score bands
+-----------
+  CRITICAL  80-100  Act immediately.  High CVSS + actively exploited/spiking.
+  HIGH      60-79   Patch/mitigate in days.  Strong exploitation signal.
+  MEDIUM    40-59   Schedule for next maintenance window.
+  LOW        0-39   Monitor; standard patch cycle.
+
+Scoring formula (max 100 points)
+---------------------------------
+Component                      Max pts  Notes
+─────────────────────────────  ───────  ──────────────────────────────────────
+CVSS base score                   25    linear scale (score/10 * 25)
+EPSS current score                20    linear scale (epss * 20)
+EPSS spike recency                15    spike_score * decay(days_since_spike)
+CISA KEV membership               20    in-KEV = 20, not-in-KEV = 0
+Patch unavailability              10    no-patch/unknown = 10, patch = 0
+CVE age pressure                  10    rises from 0→10 over 0-365 days
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import math
+from datetime import date, datetime, timezone
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_use.tools.tool_output_logger import log_tool_output_size
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+_SPIKE_THRESHOLD = 0.10  # same threshold as get_epss_trend
+_SPIKE_HALF_LIFE_DAYS = 30.0  # urgency from a spike halves every 30 days
+_AGE_MAX_DAYS = 365  # beyond this age, age-pressure is capped at 10
+_EPSS_HISTORY_DAYS = 90  # how far back to look for spike recency
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tool spec
+# ──────────────────────────────────────────────────────────────────────────────
+
+TOOL_SPEC = {
+    "name": "score_temporal_priority",
+    "description": (
+        "Computes a time-aware, composite urgency score (0-100) for a CVE by combining "
+        "CVSS severity, current EPSS exploitation probability, EPSS spike recency (with "
+        "exponential decay so a 3-day-old spike counts more than a 6-month-old one), "
+        "CISA KEV membership (actively exploited in the wild), patch availability, and "
+        "CVE publication age. "
+        "Returns the urgency score, a CRITICAL/HIGH/MEDIUM/LOW label, and a ranked "
+        "breakdown of every scoring component so analysts understand exactly what is "
+        "driving the number. Use after get_nvd_data to decide *how urgently* to act. "
+        "Pairs naturally with compare_cves (which CVE is worse) and "
+        "score_exploit_complexity (how hard to weaponise)."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier (e.g., 'CVE-2021-44228').",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "description": "Return format.  'text' (default) returns a human-readable report; 'json' returns raw data.",
+                    "default": "text",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Data-fetch helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _today() -> date:
+    return datetime.now(tz=timezone.utc).date()
+
+
+def _fetch_nvd(cve_id: str) -> dict[str, Any]:
+    """Fetch NVD data for *cve_id* and return a normalised subset."""
+    url = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+    try:
+        resp = requests.get(url, params={"cveId": cve_id.upper()}, timeout=20)
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return {"error": f"CVE {cve_id} not found in NVD"}
+
+    cve = vulns[0].get("cve", {})
+    published_str = cve.get("published", "")
+
+    # CVSS — prefer v3.1, then v3.0, then v2
+    metrics = cve.get("metrics", {})
+    cvss_score: float | None = None
+    cvss_severity: str | None = None
+    cvss_version: str | None = None
+    attack_vector: str | None = None
+
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        if key in metrics and metrics[key]:
+            m = metrics[key][0].get("cvssData", {})
+            cvss_score = m.get("baseScore")
+            cvss_severity = m.get("baseSeverity")
+            cvss_version = m.get("version")
+            attack_vector = m.get("attackVector")
+            break
+    if cvss_score is None and "cvssMetricV2" in metrics and metrics["cvssMetricV2"]:
+        m = metrics["cvssMetricV2"][0].get("cvssData", {})
+        cvss_score = m.get("baseScore")
+        cvss_severity = metrics["cvssMetricV2"][0].get("baseSeverity")
+        cvss_version = "2.0"
+
+    # Patch availability: scan NVD references for commit / advisory / patch signals
+    refs = cve.get("references", [])
+    patch_signals = 0
+    for ref in refs:
+        url_lower = (ref.get("url") or "").lower()
+        tags = [t.lower() for t in ref.get("tags", [])]
+        if any(kw in url_lower for kw in ("/commit/", "/releases/tag/", "/compare/", "/advisory/", "patch", "fix")):
+            patch_signals += 1
+        if any(t in tags for t in ("patch", "release", "fix", "vendor-advisory")):
+            patch_signals += 1
+
+    # Parse published date
+    published_date: date | None = None
+    if published_str:
+        try:
+            published_date = datetime.fromisoformat(published_str.rstrip("Z")).date()
+        except ValueError:
+            pass
+
+    return {
+        "cve_id": cve_id.upper(),
+        "published_date": published_date.isoformat() if published_date else None,
+        "cvss_score": cvss_score,
+        "cvss_severity": cvss_severity,
+        "cvss_version": cvss_version,
+        "attack_vector": attack_vector,
+        "patch_signals": patch_signals,
+        "description": (cve.get("descriptions") or [{}])[0].get("value", "")[:200],
+    }
+
+
+def _fetch_epss(cve_id: str, days: int = _EPSS_HISTORY_DAYS) -> dict[str, Any]:
+    """Fetch EPSS current score and time-series spike analysis."""
+    url = "https://api.first.org/data/v1/epss"
+    try:
+        resp = requests.get(
+            url,
+            params={"cve": cve_id.upper(), "scope": "time-series", "limit": days},
+            timeout=20,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+    except Exception as exc:
+        return {"error": str(exc)}
+
+    entries = data.get("data", [])
+    if not entries:
+        return {"error": "no EPSS data"}
+
+    entry = entries[0]
+    current_epss = float(entry.get("epss", 0))
+    current_percentile = float(entry.get("percentile", 0))
+    current_date_str = entry.get("date", "")
+
+    # Merge current point into series
+    series = list(entry.get("time-series", []))
+    if current_date_str and not any(p.get("date") == current_date_str for p in series):
+        series.insert(0, {"date": current_date_str, "epss": str(current_epss), "percentile": str(current_percentile)})
+
+    # Find the most recent spike (7-day jump ≥ threshold)
+    pts_sorted = sorted(series, key=lambda x: x["date"])
+    scores = [(p["date"], float(p["epss"])) for p in pts_sorted]
+
+    spike_date: str | None = None
+    max_spike_magnitude: float = 0.0
+    for i in range(len(scores) - 1):
+        for j in range(i + 1, min(i + 8, len(scores))):
+            delta = scores[j][1] - scores[i][1]
+            if delta >= _SPIKE_THRESHOLD and delta > max_spike_magnitude:
+                max_spike_magnitude = delta
+                spike_date = scores[j][0]
+
+    days_since_spike: int | None = None
+    if spike_date:
+        try:
+            spike_dt = datetime.fromisoformat(spike_date).date()
+            days_since_spike = (_today() - spike_dt).days
+        except ValueError:
+            pass
+
+    return {
+        "current_epss": current_epss,
+        "current_percentile": current_percentile,
+        "spike_detected": spike_date is not None,
+        "spike_magnitude": round(max_spike_magnitude, 6),
+        "spike_date": spike_date,
+        "days_since_spike": days_since_spike,
+    }
+
+
+def _fetch_kev(cve_id: str) -> dict[str, Any]:
+    """Check CISA KEV for *cve_id*."""
+    url = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    try:
+        resp = requests.get(url, timeout=20)
+        resp.raise_for_status()
+        catalog = resp.json()
+    except Exception as exc:
+        return {"error": str(exc), "in_kev": False}
+
+    target = cve_id.upper()
+    for vuln in catalog.get("vulnerabilities", []):
+        if vuln.get("cveID", "").upper() == target:
+            return {
+                "in_kev": True,
+                "date_added": vuln.get("dateAdded"),
+                "due_date": vuln.get("dueDate"),
+                "required_action": vuln.get("requiredAction"),
+                "vendor_project": vuln.get("vendorProject"),
+                "product": vuln.get("product"),
+            }
+    return {"in_kev": False}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scoring engine
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _spike_decay(days_since: int) -> float:
+    """Exponential decay: halves every *_SPIKE_HALF_LIFE_DAYS* days. Returns 0-1."""
+    return math.exp(-math.log(2) * days_since / _SPIKE_HALF_LIFE_DAYS)
+
+
+def _compute_score(
+    nvd: dict[str, Any],
+    epss: dict[str, Any],
+    kev: dict[str, Any],
+) -> dict[str, Any]:
+    """
+    Return a dict with per-component scores, totals, and explanations.
+
+    All sub-scores are floats; urgency_score is rounded to 1 decimal place.
+    """
+    components: list[dict[str, Any]] = []
+
+    # ── 1. CVSS base score (max 25) ──────────────────────────────────────────
+    cvss_raw = nvd.get("cvss_score")
+    if cvss_raw is not None:
+        cvss_pts = round((float(cvss_raw) / 10.0) * 25.0, 2)
+        sev = nvd.get("cvss_severity") or "?"
+        av_note = f", attack-vector={nvd['attack_vector']}" if nvd.get("attack_vector") else ""
+        components.append(
+            {
+                "name": "CVSS base score",
+                "score": cvss_pts,
+                "max": 25,
+                "detail": f"CVSS {cvss_raw} ({sev}){av_note}",
+            }
+        )
+    else:
+        components.append(
+            {
+                "name": "CVSS base score",
+                "score": 0.0,
+                "max": 25,
+                "detail": "Not available",
+            }
+        )
+
+    # ── 2. EPSS current (max 20) ──────────────────────────────────────────────
+    current_epss = epss.get("current_epss", 0.0) if not epss.get("error") else 0.0
+    epss_pts = round(current_epss * 20.0, 2)
+    pct = epss.get("current_percentile", 0.0) or 0.0
+    components.append(
+        {
+            "name": "EPSS current score",
+            "score": epss_pts,
+            "max": 20,
+            "detail": f"EPSS={current_epss:.4f} ({float(pct):.1%} percentile)"
+            if not epss.get("error")
+            else "Not available",
+        }
+    )
+
+    # ── 3. EPSS spike recency (max 15) ────────────────────────────────────────
+    spike_pts = 0.0
+    spike_detail = "No significant spike detected"
+    if not epss.get("error") and epss.get("spike_detected"):
+        days_since = epss.get("days_since_spike")
+        magnitude = epss.get("spike_magnitude", 0.0)
+        if days_since is not None:
+            decay = _spike_decay(days_since)
+            # Raw spike score: magnitude relative to threshold, capped at 1.0
+            raw = min(magnitude / _SPIKE_THRESHOLD, 2.0) / 2.0  # 0→1 scale
+            spike_pts = round(raw * decay * 15.0, 2)
+            spike_detail = (
+                f"Spike +{magnitude:.4f} detected {days_since}d ago (decay factor {decay:.2f} → {spike_pts:.1f} pts)"
+            )
+        else:
+            # spike date unknown; use full weight
+            spike_pts = round(min(magnitude / _SPIKE_THRESHOLD, 2.0) / 2.0 * 15.0, 2)
+            spike_detail = f"Spike +{magnitude:.4f} detected (date unknown)"
+
+    components.append(
+        {
+            "name": "EPSS spike recency",
+            "score": spike_pts,
+            "max": 15,
+            "detail": spike_detail,
+        }
+    )
+
+    # ── 4. CISA KEV (max 20) ─────────────────────────────────────────────────
+    in_kev = kev.get("in_kev", False)
+    kev_pts = 20.0 if in_kev else 0.0
+    if in_kev:
+        kev_detail = f"In CISA KEV — added {kev.get('date_added', '?')}, due {kev.get('due_date', '?')}"
+    elif kev.get("error"):
+        kev_detail = f"KEV lookup failed: {kev['error']}"
+    else:
+        kev_detail = "Not in CISA KEV"
+    components.append(
+        {
+            "name": "CISA KEV membership",
+            "score": kev_pts,
+            "max": 20,
+            "detail": kev_detail,
+        }
+    )
+
+    # ── 5. Patch unavailability (max 10) ─────────────────────────────────────
+    patch_signals = nvd.get("patch_signals", 0)
+    if patch_signals >= 2:
+        patch_pts = 0.0
+        patch_detail = f"Patch likely available ({patch_signals} NVD patch signals)"
+    elif patch_signals == 1:
+        patch_pts = 5.0
+        patch_detail = "Patch status uncertain (1 NVD patch signal)"
+    else:
+        patch_pts = 10.0
+        patch_detail = "No patch signals in NVD references"
+    components.append(
+        {
+            "name": "Patch unavailability",
+            "score": patch_pts,
+            "max": 10,
+            "detail": patch_detail,
+        }
+    )
+
+    # ── 6. CVE age pressure (max 10) ─────────────────────────────────────────
+    age_pts = 0.0
+    age_detail = "Publication date unavailable"
+    published_str = nvd.get("published_date")
+    if published_str:
+        try:
+            pub_date = date.fromisoformat(published_str)
+            age_days = (_today() - pub_date).days
+            # Linear ramp from 0→10 over 0-365 days
+            age_pts = round(min(age_days / _AGE_MAX_DAYS, 1.0) * 10.0, 2)
+            age_detail = f"Published {pub_date} ({age_days}d ago)"
+        except ValueError:
+            pass
+    components.append(
+        {
+            "name": "CVE age pressure",
+            "score": age_pts,
+            "max": 10,
+            "detail": age_detail,
+        }
+    )
+
+    # ── Totals ────────────────────────────────────────────────────────────────
+    total = round(sum(c["score"] for c in components), 1)
+    total = min(total, 100.0)
+
+    if total >= 80:
+        label = "CRITICAL"
+    elif total >= 60:
+        label = "HIGH"
+    elif total >= 40:
+        label = "MEDIUM"
+    else:
+        label = "LOW"
+
+    return {
+        "cve_id": nvd.get("cve_id", ""),
+        "urgency_score": total,
+        "label": label,
+        "components": sorted(components, key=lambda c: c["score"], reverse=True),
+        "description": nvd.get("description", ""),
+        "cvss_score": nvd.get("cvss_score"),
+        "cvss_severity": nvd.get("cvss_severity"),
+        "current_epss": current_epss,
+        "in_kev": in_kev,
+        "spike_detected": epss.get("spike_detected", False),
+        "days_since_spike": epss.get("days_since_spike"),
+        "published_date": nvd.get("published_date"),
+        "patch_signals": nvd.get("patch_signals", 0),
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Text renderer
+# ──────────────────────────────────────────────────────────────────────────────
+
+_LABEL_ICON = {
+    "CRITICAL": "🔴",
+    "HIGH": "🟠",
+    "MEDIUM": "🟡",
+    "LOW": "🟢",
+}
+
+_ADVICE = {
+    "CRITICAL": "Act immediately — patch, isolate, or mitigate within hours.",
+    "HIGH": "Prioritise patching within 1-3 days.",
+    "MEDIUM": "Schedule for next maintenance window.",
+    "LOW": "Monitor; patch on standard cycle.",
+}
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    cve = result["cve_id"]
+    score = result["urgency_score"]
+    label = result["label"]
+    icon = _LABEL_ICON.get(label, "")
+    advice = _ADVICE.get(label, "")
+
+    sep = "─" * 72
+    lines: list[str] = [
+        "",
+        sep,
+        f"  Temporal Priority Score  —  {cve}",
+        sep,
+        f"  Urgency Score : {score:>5.1f} / 100  {icon} {label}",
+        f"  Advice        : {advice}",
+        "",
+        f"  {'COMPONENT':<28}  {'PTS':>6}  {'MAX':>4}  DETAIL",
+        f"  {'─' * 28}  {'─' * 6}  {'─' * 4}  {'─' * 28}",
+    ]
+    for comp in result["components"]:
+        lines.append(f"  {comp['name']:<28}  {comp['score']:>6.1f}  {comp['max']:>4}  {comp['detail']}")
+
+    lines += [
+        sep,
+    ]
+
+    if result.get("description"):
+        lines.append(f"\n  Description: {result['description']}")
+
+    return "\n".join(lines) + "\n"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Strands tool entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def score_temporal_priority(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Compute a time-aware composite urgency score for a CVE."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+
+    cve_id = str(tool_input.get("cve_id", "")).strip().upper()
+    output_fmt = str(tool_input.get("output", "text")).lower()
+
+    if not cve_id.startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Invalid CVE ID '{cve_id}'. Must be like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("score_temporal_priority", result)
+        return result
+
+    # Fan-out: fetch all three sources in parallel
+    with concurrent.futures.ThreadPoolExecutor(max_workers=3) as executor:
+        future_nvd = executor.submit(_fetch_nvd, cve_id)
+        future_epss = executor.submit(_fetch_epss, cve_id)
+        future_kev = executor.submit(_fetch_kev, cve_id)
+        nvd = future_nvd.result()
+        epss = future_epss.result()
+        kev = future_kev.result()
+
+    if nvd.get("error"):
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"NVD lookup failed for {cve_id}: {nvd['error']}"}],
+        }
+        log_tool_output_size("score_temporal_priority", result)
+        return result
+
+    scored = _compute_score(nvd, epss, kev)
+
+    if output_fmt == "json":
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"json": scored}],
+        }
+    else:
+        text_report = _render_text(scored)
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [
+                {"text": text_report},
+                {"json": scored},
+            ],
+        }
+
+    log_tool_output_size("score_temporal_priority", result)
+    return result

--- a/tests/test_readme_cli.py
+++ b/tests/test_readme_cli.py
@@ -446,3 +446,156 @@ class TestModeFlag:
 
         args = cli._build_run_parser().parse_args(["task"])
         assert args.mode == "auto"
+
+
+# ---------------------------------------------------------------------------
+# temporal-priority subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestTemporalPrioritySubcommand:
+    def test_parser_has_cve_id_positional(self):
+        """temporal-priority parser requires a CVE-ID positional argument."""
+        from manus_use import cli  # noqa: PLC0415
+
+        parser = cli._build_temporal_priority_parser()
+        args = parser.parse_args(["CVE-2021-44228"])
+        assert args.cve_id == "CVE-2021-44228"
+
+    def test_parser_output_default_is_text(self):
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_temporal_priority_parser().parse_args(["CVE-2021-44228"])
+        assert args.output == "text"
+
+    def test_parser_output_json_accepted(self):
+        from manus_use import cli  # noqa: PLC0415
+
+        args = cli._build_temporal_priority_parser().parse_args(["CVE-2021-44228", "--output", "json"])
+        assert args.output == "json"
+
+    def test_routing_in_main(self):
+        """main() should route 'temporal-priority' to _run_temporal_priority."""
+        import sys
+        from unittest.mock import patch
+
+        from manus_use import cli  # noqa: PLC0415
+
+        with patch.object(cli, "_run_temporal_priority", return_value=0) as mock_run:
+            with patch.object(sys, "argv", ["manus-use", "temporal-priority", "CVE-2021-44228"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+            assert exc_info.value.code == 0
+            mock_run.assert_called_once_with(["CVE-2021-44228"])
+
+    def test_temporal_priority_in_known_subcommands(self):
+        """temporal-priority must be listed in KNOWN_SUBCOMMANDS."""
+        from manus_use import cli  # noqa: PLC0415
+
+        assert "temporal-priority" in cli._SUBCOMMANDS
+
+    def test_run_temporal_priority_invalid_cve(self, capsys):
+        """_run_temporal_priority should exit non-zero for bad CVE IDs."""
+        from manus_use import cli  # noqa: PLC0415
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli._run_temporal_priority(["NOT-A-CVE"])
+        assert exc_info.value.code != 0
+
+    def test_run_temporal_priority_text_output(self, capsys):
+        """_run_temporal_priority text mode should print score to stdout."""
+        from datetime import date
+        from unittest.mock import patch
+
+        from manus_use import cli  # noqa: PLC0415
+
+        mock_nvd = {
+            "cve_id": "CVE-2021-44228",
+            "cvss_score": 9.8,
+            "cvss_severity": "CRITICAL",
+            "cvss_version": "3.1",
+            "attack_vector": "NETWORK",
+            "patch_signals": 2,
+            "published_date": "2021-12-10",
+            "description": "Log4Shell RCE",
+        }
+        mock_epss = {
+            "current_epss": 0.90,
+            "current_percentile": 0.97,
+            "spike_detected": True,
+            "spike_magnitude": 0.30,
+            "spike_date": "2021-12-11",
+            "days_since_spike": 5,
+        }
+        mock_kev = {"in_kev": True, "date_added": "2021-12-11", "due_date": "2022-01-03"}
+
+        with (
+            patch("manus_use.tools.score_temporal_priority._fetch_nvd", return_value=mock_nvd),
+            patch("manus_use.tools.score_temporal_priority._fetch_epss", return_value=mock_epss),
+            patch("manus_use.tools.score_temporal_priority._fetch_kev", return_value=mock_kev),
+            patch("manus_use.tools.score_temporal_priority._today", return_value=date(2026, 6, 29)),
+        ):
+            exit_code = cli._run_temporal_priority(["CVE-2021-44228"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "CVE-2021-44228" in captured.out
+        assert "Urgency Score" in captured.out
+
+    def test_run_temporal_priority_json_output(self, capsys):
+        """_run_temporal_priority --output json should produce valid JSON."""
+        import json
+        from datetime import date
+        from unittest.mock import patch
+
+        from manus_use import cli  # noqa: PLC0415
+
+        mock_nvd = {
+            "cve_id": "CVE-2021-44228",
+            "cvss_score": 9.8,
+            "cvss_severity": "CRITICAL",
+            "cvss_version": "3.1",
+            "attack_vector": "NETWORK",
+            "patch_signals": 2,
+            "published_date": "2021-12-10",
+            "description": "Log4Shell",
+        }
+        mock_epss = {
+            "current_epss": 0.90,
+            "current_percentile": 0.97,
+            "spike_detected": False,
+            "spike_magnitude": 0.0,
+            "spike_date": None,
+            "days_since_spike": None,
+        }
+        mock_kev = {"in_kev": False}
+
+        with (
+            patch("manus_use.tools.score_temporal_priority._fetch_nvd", return_value=mock_nvd),
+            patch("manus_use.tools.score_temporal_priority._fetch_epss", return_value=mock_epss),
+            patch("manus_use.tools.score_temporal_priority._fetch_kev", return_value=mock_kev),
+            patch("manus_use.tools.score_temporal_priority._today", return_value=date(2026, 6, 29)),
+        ):
+            exit_code = cli._run_temporal_priority(["CVE-2021-44228", "--output", "json"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cve_id"] == "CVE-2021-44228"
+        assert "urgency_score" in data
+        assert "label" in data
+
+    def test_run_temporal_priority_nvd_error(self, capsys):
+        """_run_temporal_priority should return non-zero when NVD lookup fails."""
+        from unittest.mock import patch
+
+        from manus_use import cli  # noqa: PLC0415
+
+        with (
+            patch("manus_use.tools.score_temporal_priority._fetch_nvd", return_value={"error": "not found"}),
+            patch("manus_use.tools.score_temporal_priority._fetch_epss", return_value={"error": "not found"}),
+            patch("manus_use.tools.score_temporal_priority._fetch_kev", return_value={"in_kev": False}),
+        ):
+            exit_code = cli._run_temporal_priority(["CVE-9999-9999"])
+
+        assert exit_code != 0

--- a/tests/test_temporal_priority.py
+++ b/tests/test_temporal_priority.py
@@ -1,0 +1,784 @@
+"""
+Tests for score_temporal_priority.
+
+All HTTP calls are mocked — no real network access.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_use.tools.score_temporal_priority import (
+    TOOL_SPEC,
+    _compute_score,
+    _fetch_epss,
+    _fetch_kev,
+    _fetch_nvd,
+    _render_text,
+    _spike_decay,
+    score_temporal_priority,
+)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures / helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+TODAY = date(2026, 6, 29)
+TODAY_STR = TODAY.isoformat()
+
+
+def _tool(cve_id: str, output: str = "text") -> dict:
+    return {
+        "toolUseId": "tu-001",
+        "input": {"cve_id": cve_id, "output": output},
+    }
+
+
+def _nvd_response(cve_id: str, score: float = 9.8, published: str = "2021-12-10T00:00:00.000") -> dict:
+    """Minimal NVD API JSON for one CVE."""
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": cve_id,
+                    "published": published,
+                    "descriptions": [{"lang": "en", "value": f"Critical vuln in {cve_id}"}],
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "cvssData": {
+                                    "version": "3.1",
+                                    "baseScore": score,
+                                    "baseSeverity": "CRITICAL",
+                                    "attackVector": "NETWORK",
+                                }
+                            }
+                        ]
+                    },
+                    "references": [
+                        {"url": "https://github.com/org/repo/commit/abc123", "tags": ["patch"]},
+                        {"url": "https://github.com/org/repo/releases/tag/v2.0", "tags": ["release"]},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _nvd_response_no_patch(cve_id: str, score: float = 9.8) -> dict:
+    """NVD response with no patch references."""
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": cve_id,
+                    "published": "2024-01-15T00:00:00.000",
+                    "descriptions": [{"lang": "en", "value": "RCE vulnerability"}],
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "cvssData": {
+                                    "version": "3.1",
+                                    "baseScore": score,
+                                    "baseSeverity": "CRITICAL",
+                                    "attackVector": "NETWORK",
+                                }
+                            }
+                        ]
+                    },
+                    "references": [
+                        {"url": "https://example.com/advisory", "tags": []},
+                    ],
+                }
+            }
+        ]
+    }
+
+
+def _epss_response(cve_id: str, current: float = 0.85, spike: bool = True, spike_days_ago: int = 10) -> dict:
+    """FIRST.org EPSS time-series response."""
+    today = TODAY
+    pts = []
+    # Build a series: stable low, then spike, then current
+    for i in range(30, 0, -1):
+        d = today - timedelta(days=i)
+        if i == spike_days_ago and spike:
+            pts.append({"date": d.isoformat(), "epss": str(round(current - 0.20, 4)), "percentile": "0.90"})
+        elif i < spike_days_ago and spike:
+            pts.append({"date": d.isoformat(), "epss": str(current), "percentile": "0.97"})
+        else:
+            pts.append({"date": d.isoformat(), "epss": "0.05", "percentile": "0.70"})
+
+    return {
+        "data": [
+            {
+                "cve": cve_id,
+                "epss": str(current),
+                "percentile": "0.97",
+                "date": TODAY_STR,
+                "time-series": pts,
+            }
+        ]
+    }
+
+
+def _epss_response_no_spike(cve_id: str, current: float = 0.03) -> dict:
+    today = TODAY
+    pts = [
+        {"date": (today - timedelta(days=i)).isoformat(), "epss": str(current), "percentile": "0.50"}
+        for i in range(30, 0, -1)
+    ]
+    return {
+        "data": [
+            {
+                "cve": cve_id,
+                "epss": str(current),
+                "percentile": "0.50",
+                "date": TODAY_STR,
+                "time-series": pts,
+            }
+        ]
+    }
+
+
+def _kev_response(cve_id: str, in_kev: bool = True) -> dict:
+    vulns = []
+    if in_kev:
+        vulns.append(
+            {
+                "cveID": cve_id,
+                "dateAdded": "2021-12-11",
+                "dueDate": "2022-01-03",
+                "requiredAction": "Apply updates",
+                "vendorProject": "Apache",
+                "product": "Log4j",
+            }
+        )
+    return {"vulnerabilities": vulns}
+
+
+def _mock_requests_get(url, params=None, timeout=None):
+    """Route URLs to canned responses."""
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    cve_id = (params or {}).get("cveId") or (params or {}).get("cve") or "CVE-2021-44228"
+    if "nvd.nist.gov" in url:
+        resp.json.return_value = _nvd_response(cve_id)
+    elif "first.org" in url:
+        resp.json.return_value = _epss_response(cve_id)
+    elif "cisa.gov" in url:
+        resp.json.return_value = _kev_response(cve_id)
+    else:
+        resp.json.return_value = {}
+    return resp
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _spike_decay
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_spike_decay_zero_days():
+    """Decay at day 0 should be 1.0 (no attenuation)."""
+    assert _spike_decay(0) == pytest.approx(1.0)
+
+
+def test_spike_decay_half_life():
+    """Decay at _SPIKE_HALF_LIFE_DAYS (30) should be ~0.5."""
+    from manus_use.tools.score_temporal_priority import _SPIKE_HALF_LIFE_DAYS
+
+    assert _spike_decay(_SPIKE_HALF_LIFE_DAYS) == pytest.approx(0.5, abs=0.01)
+
+
+def test_spike_decay_one_year():
+    """Decay at 365 days should be very small."""
+    assert _spike_decay(365) < 0.05
+
+
+def test_spike_decay_monotone():
+    """Decay should be monotonically decreasing."""
+    values = [_spike_decay(d) for d in range(0, 200, 10)]
+    assert all(values[i] > values[i + 1] for i in range(len(values) - 1))
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _fetch_nvd
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_nvd_success():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _nvd_response("CVE-2021-44228")
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd("CVE-2021-44228")
+
+    assert result["cve_id"] == "CVE-2021-44228"
+    assert result["cvss_score"] == 9.8
+    assert result["cvss_severity"] == "CRITICAL"
+    assert result["attack_vector"] == "NETWORK"
+    assert result["patch_signals"] >= 2
+
+
+def test_fetch_nvd_not_found():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd("CVE-9999-0000")
+
+    assert "error" in result
+
+
+def test_fetch_nvd_request_error():
+    import requests
+
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("timeout")):
+        result = _fetch_nvd("CVE-2021-44228")
+    assert "error" in result
+
+
+def test_fetch_nvd_cvss_v2_fallback():
+    """Should use CVSSv2 when no v3 present."""
+    nvd_data = {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2017-0001",
+                    "published": "2017-03-17T00:00:00.000",
+                    "descriptions": [{"lang": "en", "value": "Old vuln"}],
+                    "metrics": {
+                        "cvssMetricV2": [
+                            {
+                                "cvssData": {"version": "2.0", "baseScore": 7.8},
+                                "baseSeverity": "HIGH",
+                            }
+                        ]
+                    },
+                    "references": [],
+                }
+            }
+        ]
+    }
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = nvd_data
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd("CVE-2017-0001")
+
+    assert result["cvss_score"] == 7.8
+    assert result["cvss_version"] == "2.0"
+
+
+def test_fetch_nvd_no_patch_signals():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _nvd_response_no_patch("CVE-2024-1234")
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd("CVE-2024-1234")
+
+    assert result["patch_signals"] == 0
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _fetch_epss
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_epss_with_spike():
+    with patch("requests.get") as mock_get, patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _epss_response("CVE-2021-44228", current=0.85, spike=True, spike_days_ago=10)
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss("CVE-2021-44228")
+
+    assert result["current_epss"] == pytest.approx(0.85)
+    assert result["spike_detected"] is True
+    assert result["spike_magnitude"] > 0.10
+    assert result["days_since_spike"] is not None
+
+
+def test_fetch_epss_no_spike():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _epss_response_no_spike("CVE-2021-44228", current=0.03)
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss("CVE-2021-44228")
+
+    assert result["current_epss"] == pytest.approx(0.03)
+    assert result["spike_detected"] is False
+
+
+def test_fetch_epss_not_found():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss("CVE-9999-0000")
+
+    assert "error" in result
+
+
+def test_fetch_epss_request_error():
+    import requests
+
+    with patch("requests.get", side_effect=requests.exceptions.Timeout("timeout")):
+        result = _fetch_epss("CVE-2021-44228")
+    assert "error" in result
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _fetch_kev
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_fetch_kev_in_catalog():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _kev_response("CVE-2021-44228", in_kev=True)
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev("CVE-2021-44228")
+
+    assert result["in_kev"] is True
+    assert result["date_added"] == "2021-12-11"
+
+
+def test_fetch_kev_not_in_catalog():
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _kev_response("CVE-2021-44228", in_kev=False)
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev("CVE-9999-0000")
+
+    assert result["in_kev"] is False
+
+
+def test_fetch_kev_request_error():
+    import requests
+
+    with patch("requests.get", side_effect=requests.exceptions.ConnectionError("refused")):
+        result = _fetch_kev("CVE-2021-44228")
+    assert result["in_kev"] is False
+    assert "error" in result
+
+
+def test_fetch_kev_case_insensitive():
+    """KEV lookup should be case-insensitive."""
+    with patch("requests.get") as mock_get:
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _kev_response("CVE-2021-44228", in_kev=True)
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev("cve-2021-44228")
+
+    assert result["in_kev"] is True
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _compute_score
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_nvd(score=9.8, published_days_ago=500, patch_signals=2):
+    pub = (TODAY - timedelta(days=published_days_ago)).isoformat()
+    return {
+        "cve_id": "CVE-2021-44228",
+        "cvss_score": score,
+        "cvss_severity": "CRITICAL",
+        "cvss_version": "3.1",
+        "attack_vector": "NETWORK",
+        "patch_signals": patch_signals,
+        "published_date": pub,
+        "description": "Remote code execution via JNDI lookup.",
+    }
+
+
+def _make_epss(current=0.85, spike=True, days_since=10, magnitude=0.20):
+    return {
+        "current_epss": current,
+        "current_percentile": 0.97,
+        "spike_detected": spike,
+        "spike_magnitude": magnitude,
+        "spike_date": (TODAY - timedelta(days=days_since)).isoformat() if spike else None,
+        "days_since_spike": days_since if spike else None,
+    }
+
+
+def _make_kev(in_kev=True):
+    if in_kev:
+        return {"in_kev": True, "date_added": "2021-12-11", "due_date": "2022-01-03"}
+    return {"in_kev": False}
+
+
+def test_compute_score_critical_all_factors():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        result = _compute_score(_make_nvd(), _make_epss(), _make_kev(True))
+    assert result["urgency_score"] >= 80
+    assert result["label"] == "CRITICAL"
+    assert result["in_kev"] is True
+    assert result["spike_detected"] is True
+
+
+def test_compute_score_low_all_factors_minimal():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd = _make_nvd(score=2.0, published_days_ago=5, patch_signals=3)
+        epss = _make_epss(current=0.001, spike=False)
+        kev = _make_kev(False)
+        result = _compute_score(nvd, epss, kev)
+    assert result["urgency_score"] < 40
+    assert result["label"] == "LOW"
+
+
+def test_compute_score_capped_at_100():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd = _make_nvd(score=10.0, published_days_ago=1000, patch_signals=0)
+        epss = _make_epss(current=1.0, spike=True, days_since=0, magnitude=1.0)
+        kev = _make_kev(True)
+        result = _compute_score(nvd, epss, kev)
+    assert result["urgency_score"] <= 100.0
+
+
+def test_compute_score_has_all_components():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        result = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+    names = {c["name"] for c in result["components"]}
+    assert "CVSS base score" in names
+    assert "EPSS current score" in names
+    assert "EPSS spike recency" in names
+    assert "CISA KEV membership" in names
+    assert "Patch unavailability" in names
+    assert "CVE age pressure" in names
+
+
+def test_compute_score_no_cvss():
+    """Missing CVSS should score 0 for that component, not error."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd = _make_nvd()
+        nvd["cvss_score"] = None
+        result = _compute_score(nvd, _make_epss(current=0.1, spike=False), _make_kev(False))
+    cvss_comp = next(c for c in result["components"] if c["name"] == "CVSS base score")
+    assert cvss_comp["score"] == 0.0
+
+
+def test_compute_score_no_patch_signals_adds_pts():
+    """No patch signal should add 10 pts."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd_no_patch = _make_nvd(patch_signals=0)
+        nvd_with_patch = _make_nvd(patch_signals=3)
+        r_no = _compute_score(nvd_no_patch, _make_epss(spike=False), _make_kev(False))
+        r_yes = _compute_score(nvd_with_patch, _make_epss(spike=False), _make_kev(False))
+    patch_no = next(c for c in r_no["components"] if c["name"] == "Patch unavailability")
+    patch_yes = next(c for c in r_yes["components"] if c["name"] == "Patch unavailability")
+    assert patch_no["score"] == 10.0
+    assert patch_yes["score"] == 0.0
+
+
+def test_compute_score_kev_adds_20():
+    """KEV membership should add exactly 20 pts."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd = _make_nvd(score=5.0, patch_signals=2)
+        epss = _make_epss(current=0.1, spike=False)
+        r_kev = _compute_score(nvd, epss, _make_kev(True))
+        r_no_kev = _compute_score(nvd, epss, _make_kev(False))
+    kev_comp = next(c for c in r_kev["components"] if c["name"] == "CISA KEV membership")
+    no_kev_comp = next(c for c in r_no_kev["components"] if c["name"] == "CISA KEV membership")
+    assert kev_comp["score"] == 20.0
+    assert no_kev_comp["score"] == 0.0
+
+
+def test_compute_score_spike_recency_old_spike_less_than_fresh():
+    """A 200-day-old spike should score less than a 5-day-old spike."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd = _make_nvd()
+        epss_fresh = _make_epss(spike=True, days_since=5, magnitude=0.20)
+        epss_old = _make_epss(spike=True, days_since=200, magnitude=0.20)
+        r_fresh = _compute_score(nvd, epss_fresh, _make_kev(False))
+        r_old = _compute_score(nvd, epss_old, _make_kev(False))
+    spike_fresh = next(c for c in r_fresh["components"] if c["name"] == "EPSS spike recency")
+    spike_old = next(c for c in r_old["components"] if c["name"] == "EPSS spike recency")
+    assert spike_fresh["score"] > spike_old["score"]
+
+
+def test_compute_score_age_pressure_increases():
+    """Older CVEs should have higher age pressure score."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        nvd_old = _make_nvd(published_days_ago=365)
+        nvd_new = _make_nvd(published_days_ago=10)
+        epss = _make_epss(spike=False)
+        r_old = _compute_score(nvd_old, epss, _make_kev(False))
+        r_new = _compute_score(nvd_new, epss, _make_kev(False))
+    age_old = next(c for c in r_old["components"] if c["name"] == "CVE age pressure")
+    age_new = next(c for c in r_new["components"] if c["name"] == "CVE age pressure")
+    assert age_old["score"] > age_new["score"]
+
+
+def test_compute_score_components_sorted_descending():
+    """Components should be sorted by score descending."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        result = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+    scores = [c["score"] for c in result["components"]]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_compute_score_epss_error_graceful():
+    """If EPSS fetch errored, scores should default gracefully (no exception)."""
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        result = _compute_score(_make_nvd(), {"error": "network down"}, _make_kev(False))
+    assert isinstance(result["urgency_score"], float)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests: _render_text
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_render_text_contains_cve_id():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        scored = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+    text = _render_text(scored)
+    assert "CVE-2021-44228" in text
+
+
+def test_render_text_contains_score():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        scored = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+    text = _render_text(scored)
+    assert str(int(scored["urgency_score"])) in text
+
+
+def test_render_text_contains_label():
+    with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+        scored = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+    text = _render_text(scored)
+    assert scored["label"] in text
+
+
+def test_render_text_all_labels():
+    """All four label tiers should render without error."""
+    for forced_score, expected_label in [(90, "CRITICAL"), (65, "HIGH"), (50, "MEDIUM"), (20, "LOW")]:
+        with patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY):
+            scored = _compute_score(_make_nvd(), _make_epss(), _make_kev())
+        scored["urgency_score"] = forced_score
+        scored["label"] = expected_label
+        text = _render_text(scored)
+        assert expected_label in text
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Integration tests: score_temporal_priority (mocked HTTP)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _make_mock_get(cve_id: str, nvd_score: float = 9.8, epss_current: float = 0.85, in_kev: bool = True):
+    def mock_get(url, params=None, timeout=None):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            resp.json.return_value = _nvd_response(cve_id, score=nvd_score)
+        elif "first.org" in url:
+            resp.json.return_value = _epss_response(cve_id, current=epss_current, spike=True, spike_days_ago=5)
+        elif "cisa.gov" in url:
+            resp.json.return_value = _kev_response(cve_id, in_kev=in_kev)
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    return mock_get
+
+
+def test_tool_text_output_success():
+    cve = "CVE-2021-44228"
+    with (
+        patch("requests.get", side_effect=_make_mock_get(cve)),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool(cve, "text"))
+
+    assert result["status"] == "success"
+    texts = [c["text"] for c in result["content"] if "text" in c]
+    assert texts
+    assert cve in texts[0]
+
+
+def test_tool_json_output_success():
+    cve = "CVE-2021-44228"
+    with (
+        patch("requests.get", side_effect=_make_mock_get(cve)),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool(cve, "json"))
+
+    assert result["status"] == "success"
+    jsons = [c["json"] for c in result["content"] if "json" in c]
+    assert jsons
+    assert jsons[0]["cve_id"] == cve
+    assert "urgency_score" in jsons[0]
+    assert "label" in jsons[0]
+    assert "components" in jsons[0]
+
+
+def test_tool_invalid_cve_id():
+    result = score_temporal_priority(_tool("NOT-A-CVE"))
+    assert result["status"] == "error"
+    assert "Invalid" in result["content"][0]["text"]
+
+
+def test_tool_invalid_cve_id_lowercase():
+    result = score_temporal_priority(_tool("cve2024-1234"))
+    assert result["status"] == "error"
+
+
+def test_tool_nvd_not_found():
+    def mock_get(url, params=None, timeout=None):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            resp.json.return_value = {"vulnerabilities": []}
+        elif "first.org" in url:
+            resp.json.return_value = _epss_response("CVE-9999-9999")
+        elif "cisa.gov" in url:
+            resp.json.return_value = _kev_response("CVE-9999-9999", in_kev=False)
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    with patch("requests.get", side_effect=mock_get):
+        result = score_temporal_priority(_tool("CVE-9999-9999"))
+    assert result["status"] == "error"
+    assert "NVD lookup failed" in result["content"][0]["text"]
+
+
+def test_tool_epss_error_does_not_crash():
+    """EPSS failure should degrade gracefully, not crash."""
+    import requests
+
+    def mock_get(url, params=None, timeout=None):
+        if "first.org" in url:
+            raise requests.exceptions.ConnectionError("no network")
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            resp.json.return_value = _nvd_response("CVE-2021-44228")
+        elif "cisa.gov" in url:
+            resp.json.return_value = _kev_response("CVE-2021-44228", in_kev=False)
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    with (
+        patch("requests.get", side_effect=mock_get),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool("CVE-2021-44228"))
+    assert result["status"] == "success"
+
+
+def test_tool_kev_error_does_not_crash():
+    """KEV failure should degrade gracefully."""
+    import requests
+
+    def mock_get(url, params=None, timeout=None):
+        if "cisa.gov" in url:
+            raise requests.exceptions.Timeout("timeout")
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            resp.json.return_value = _nvd_response("CVE-2021-44228")
+        elif "first.org" in url:
+            resp.json.return_value = _epss_response("CVE-2021-44228")
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    with (
+        patch("requests.get", side_effect=mock_get),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool("CVE-2021-44228"))
+    assert result["status"] == "success"
+
+
+def test_tool_low_epss_no_kev_no_spike():
+    """Low-risk CVE should score LOW."""
+    cve = "CVE-2024-0001"
+
+    def mock_get(url, params=None, timeout=None):
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        if "nvd.nist.gov" in url:
+            resp.json.return_value = _nvd_response(cve, score=3.5, published="2024-01-01T00:00:00.000")
+        elif "first.org" in url:
+            resp.json.return_value = _epss_response_no_spike(cve, current=0.005)
+        elif "cisa.gov" in url:
+            resp.json.return_value = _kev_response(cve, in_kev=False)
+        else:
+            resp.json.return_value = {}
+        return resp
+
+    with (
+        patch("requests.get", side_effect=mock_get),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool(cve, "json"))
+
+    jsons = [c["json"] for c in result["content"] if "json" in c]
+    assert jsons[0]["label"] in ("LOW", "MEDIUM")
+
+
+def test_tool_critical_all_signals():
+    """High CVSS + KEV + fresh spike + no patch = CRITICAL."""
+    cve = "CVE-2021-44228"
+    with (
+        patch("requests.get", side_effect=_make_mock_get(cve, nvd_score=9.8, epss_current=0.90, in_kev=True)),
+        patch("manus_use.tools.score_temporal_priority._today", return_value=TODAY),
+    ):
+        result = score_temporal_priority(_tool(cve, "json"))
+
+    jsons = [c["json"] for c in result["content"] if "json" in c]
+    # Log4Shell with all signals should be CRITICAL
+    assert jsons[0]["label"] == "CRITICAL"
+    assert jsons[0]["urgency_score"] >= 80
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tool spec validation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def test_tool_spec_structure():
+    assert TOOL_SPEC["name"] == "score_temporal_priority"
+    assert "description" in TOOL_SPEC
+    assert "inputSchema" in TOOL_SPEC
+    schema = TOOL_SPEC["inputSchema"]["json"]
+    assert "cve_id" in schema["properties"]
+    assert "cve_id" in schema["required"]
+
+
+def test_tool_spec_output_enum():
+    schema = TOOL_SPEC["inputSchema"]["json"]
+    output_prop = schema["properties"].get("output", {})
+    assert "enum" in output_prop
+    assert "text" in output_prop["enum"]
+    assert "json" in output_prop["enum"]


### PR DESCRIPTION
Adds a **time-aware composite urgency score (0–100)** for CVE triage. Answers: *"of everything I know about this CVE right now, how urgently must I act today?"*

## Scoring formula (max 100 pts)

| Component | Max pts | Signal captured |
|-----------|---------|-----------------|
| CVSS base score | 25 | Theoretical severity |
| EPSS current score | 20 | ML-predicted exploitation probability |
| EPSS spike recency | 15 | Exponential decay — spike last week >>> spike 6 months ago |
| CISA KEV membership | 20 | Actively exploited in the wild |
| Patch unavailability | 10 | No patch signals in NVD references |
| CVE age pressure | 10 | How long the unpatched window has been open |

Score bands: **CRITICAL** 80–100 | **HIGH** 60–79 | **MEDIUM** 40–59 | **LOW** 0–39

## Files changed

- `src/manus_use/tools/score_temporal_priority.py` — new tool (541 lines)
- `src/manus_use/agents/vi_agent.py` — registered in tool list + Step 6c in system prompt
- `src/manus_use/cli.py` — `temporal-priority` subcommand + routing
- `README.md` — full CLI reference section with score-band table and jq examples
- `tests/test_temporal_priority.py` — 43 unit + integration tests (100% mocked)
- `tests/test_readme_cli.py` — 9 CLI routing + parser tests

**823 tests passing, 0 failures.**

## Design decisions

- `_spike_decay(days)` uses exponential decay with a 30-day half-life so a recent EPSS spike dominates over a stale one — matching practitioner intuition
- Three data sources (NVD, FIRST.org EPSS, CISA KEV) fetched in parallel via `ThreadPoolExecutor(max_workers=3)`
- Graceful degradation: EPSS or KEV failures → 0 pts for that component, no crash; NVD failure → explicit error
- Composable with `compare` (which CVE is more urgent?) and `exploit-complexity` (how hard to weaponise?)