### PR TITLE
feat: rename package manus-use → manus-agent and CLI command manus-use → manus-agent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for your interest in contributing! This guide covers everything you ne
 
 ```bash
 git clone https://github.com/manus-use/manus-use.git
-cd manus-use
+cd manus-agent
 
 # Install the package in editable mode with all dev/test extras
 pip install -e ".[dev,browser,search,visualization]"
@@ -27,7 +27,7 @@ pip install -e ".[dev,browser,search,visualization]"
 If you are working inside a git **worktree** (e.g. for a parallel feature branch), make sure you install from the worktree directory, not the main clone:
 
 ```bash
-git -C /path/to/manus-use worktree add /tmp/my-feature -b feat/my-feature origin/main
+git -C /path/to/manus-agent worktree add /tmp/my-feature -b feat/my-feature origin/main
 cd /tmp/my-feature
 pip install -e ".[dev]"
 ```
@@ -101,7 +101,7 @@ manus-use/
 │   ├── multi_agents/    # WorkflowAgent + Orchestrator
 │   ├── tools/           # @tool-decorated functions used by agents
 │   ├── sandbox/         # Docker sandbox helpers
-│   ├── cli.py           # manus-use CLI entry point
+│   ├── cli.py           # manus-agent CLI entry point
 │   └── config.py        # Config model (Pydantic + TOML)
 ├── tests/               # pytest test suite
 ├── config/
@@ -127,7 +127,7 @@ We follow [Conventional Commits](https://www.conventionalcommits.org/):
 ```
 <type>(<scope>): <short description>
 
-feat(cli): add --dry-run flag to manus-use discover
+feat(cli): add --dry-run flag to manus-agent discover
 fix(config): respect aws_region from [agent] section
 docs(readme): add Ollama provider example
 test(vi_agent): cover goal-loop completeness check

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
 
 ```bash
 # Basic installation
-pip install manus-use
+pip install manus-agent
 
 # With browser automation support
-pip install manus-use[browser]
+pip install manus-agent[browser]
 playwright install chromium
 
 # Full installation with all optional features
-pip install manus-use[browser,search,visualization]
+pip install manus-agent[browser,search,visualization]
 ```
 
 ---
@@ -62,13 +62,13 @@ pip install manus-use[browser,search,visualization]
 
 ```bash
 # 1. Set up credentials
-manus-use init
+manus-agent init
 
 # 2. Verify your environment
-manus-use doctor
+manus-agent doctor
 
 # 3. Run a task
-manus-use "Write a Python script that fetches the current Bitcoin price"
+manus-agent "Write a Python script that fetches the current Bitcoin price"
 
 # Or start the interactive REPL
 manus-use
@@ -78,27 +78,27 @@ manus-use
 
 ## CLI Reference
 
-### `manus-use [task]` — Run a task
+### `manus-agent [task]` — Run a task
 
 ```bash
 # Single-shot (prints result, then exits)
-manus-use "Create a factorial function in Python"
+manus-agent "Create a factorial function in Python"
 
 # Use a specific agent type
-manus-use --agent browser "Find the top 5 trending GitHub repos today"
+manus-agent --agent browser "Find the top 5 trending GitHub repos today"
 
 # Force multi-agent orchestration
-manus-use --mode multi "Research quantum computing and create a presentation"
+manus-agent --mode multi "Research quantum computing and create a presentation"
 
 # JSON output for piping
-manus-use --format json "List the first 10 prime numbers" | jq .result
+manus-agent --format json "List the first 10 prime numbers" | jq .result
 
 # Stream output tokens in real time
-manus-use --stream "Write a short story about a robot"
+manus-agent --stream "Write a short story about a robot"
 
 # Interactive REPL
 manus-use
-manus-use --mode multi
+manus-agent --mode multi
 ```
 
 | Flag | Default | Description |
@@ -115,44 +115,44 @@ manus-use --mode multi
 
 ---
 
-### `manus-use init` — Configure credentials
+### `manus-agent init` — Configure credentials
 
 ```bash
-manus-use init                        # write to ~/.manus-use/config.toml
-manus-use init --output ./my.toml    # write to a custom path
-manus-use init --force                # overwrite without prompting
+manus-agent init                        # write to ~/.manus-use/config.toml
+manus-agent init --output ./my.toml    # write to a custom path
+manus-agent init --force                # overwrite without prompting
 ```
 
-### `manus-use doctor` — Diagnose your environment
+### `manus-agent doctor` — Diagnose your environment
 
 ```bash
-manus-use doctor
-manus-use doctor --config ./custom.toml
+manus-agent doctor
+manus-agent doctor --config ./custom.toml
 ```
 
 Checks Python packages, config file validity, and API key accessibility.
 
-### `manus-use history` — Browse past runs
+### `manus-agent history` — Browse past runs
 
 ```bash
-manus-use history                        # last 20 runs
-manus-use history --limit 50            # last 50 runs
-manus-use history --grep "bitcoin"      # filter by task text
-manus-use history --format json | jq .  # all history as JSON
-manus-use history --clear               # delete all history
+manus-agent history                        # last 20 runs
+manus-agent history --limit 50            # last 50 runs
+manus-agent history --grep "bitcoin"      # filter by task text
+manus-agent history --format json | jq .  # all history as JSON
+manus-agent history --clear               # delete all history
 ```
 
 History is stored at `~/.manus-use/history.jsonl`.
 
 ---
 
-### `manus-use analyze <CVE-ID>` — Vulnerability intelligence
+### `manus-agent analyze <CVE-ID>` — Vulnerability intelligence
 
 ```bash
-manus-use analyze CVE-2025-6554
-manus-use analyze CVE-2024-3094 --verify
-manus-use analyze CVE-2025-6554 --output json
-manus-use analyze CVE-2025-6554 --output lark
+manus-agent analyze CVE-2025-6554
+manus-agent analyze CVE-2024-3094 --verify
+manus-agent analyze CVE-2025-6554 --output json
+manus-agent analyze CVE-2025-6554 --output lark
 ```
 
 Runs an 8-step intelligence pipeline — see [Security & Vulnerability Intelligence](#security--vulnerability-intelligence) for full details.
@@ -165,11 +165,11 @@ Runs an 8-step intelligence pipeline — see [Security & Vulnerability Intellige
 
 ---
 
-### `manus-use remediate <CVE-ID>` — Remediation guidance
+### `manus-agent remediate <CVE-ID>` — Remediation guidance
 
 ```bash
-manus-use remediate CVE-2024-3094
-manus-use remediate CVE-2024-3094 --output json
+manus-agent remediate CVE-2024-3094
+manus-agent remediate CVE-2024-3094 --output json
 ```
 
 | Flag | Default | Description |
@@ -179,13 +179,13 @@ manus-use remediate CVE-2024-3094 --output json
 
 ---
 
-### `manus-use discover` — CVE discovery
+### `manus-agent discover` — CVE discovery
 
 ```bash
-manus-use discover
-manus-use discover --since 2025-06-01 --min-epss 0.7
-manus-use discover --dry-run
-manus-use discover --output json
+manus-agent discover
+manus-agent discover --since 2025-06-01 --min-epss 0.7
+manus-agent discover --dry-run
+manus-agent discover --output json
 ```
 
 | Flag | Default | Description |
@@ -198,12 +198,12 @@ manus-use discover --output json
 
 ---
 
-### `manus-use epss-trend <CVE-ID>` — EPSS score history
+### `manus-agent epss-trend <CVE-ID>` — EPSS score history
 
 ```bash
-manus-use epss-trend CVE-2024-3094
-manus-use epss-trend CVE-2024-3094 --days 90
-manus-use epss-trend CVE-2024-3094 --output json | jq .analysis.spike_detected
+manus-agent epss-trend CVE-2024-3094
+manus-agent epss-trend CVE-2024-3094 --days 90
+manus-agent epss-trend CVE-2024-3094 --output json | jq .analysis.spike_detected
 ```
 
 Fetches daily EPSS scores from the [FIRST.org API](https://www.first.org/epss/) and detects exploitation spikes (≥ 0.10 jump in a 7-day window).
@@ -215,11 +215,11 @@ Fetches daily EPSS scores from the [FIRST.org API](https://www.first.org/epss/) 
 
 ---
 
-### `manus-use patch-diff <CVE-ID>` — Patch diff summariser
+### `manus-agent patch-diff <CVE-ID>` — Patch diff summariser
 
 ```bash
-manus-use patch-diff CVE-2024-3094
-manus-use patch-diff CVE-2024-3094 --output json | jq .commit_summaries
+manus-agent patch-diff CVE-2024-3094
+manus-agent patch-diff CVE-2024-3094 --output json | jq .commit_summaries
 ```
 
 Finds the fixing commit(s) via GHSA + NVD, fetches the raw unified diff, and produces a structured summary: files/functions changed, bug class (14 categories), reproduction condition hints, and commit URL.
@@ -230,11 +230,11 @@ Finds the fixing commit(s) via GHSA + NVD, fetches the raw unified diff, and pro
 
 ---
 
-### `manus-use variants <CVE-ID>` — Variant analysis
+### `manus-agent variants <CVE-ID>` — Variant analysis
 
 ```bash
-manus-use variants CVE-2024-3094
-manus-use variants CVE-2024-3094 --output json
+manus-agent variants CVE-2024-3094
+manus-agent variants CVE-2024-3094 --output json
 ```
 
 | Flag | Default | Description |
@@ -243,11 +243,11 @@ manus-use variants CVE-2024-3094 --output json
 
 ---
 
-### `manus-use compare <CVE-A> <CVE-B>` — Side-by-side comparison
+### `manus-agent compare <CVE-A> <CVE-B>` — Side-by-side comparison
 
 ```bash
-manus-use compare CVE-2024-3094 CVE-2021-44228
-manus-use compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
+manus-agent compare CVE-2024-3094 CVE-2021-44228
+manus-agent compare CVE-2024-3094 CVE-2021-44228 --output json | jq .higher_priority
 ```
 
 Fetches NVD, EPSS, and CISA KEV data for both CVEs in parallel and produces a side-by-side comparison across CVSS, EPSS, KEV membership, CWE, and exploitability factors. Outputs a prioritisation recommendation with confidence level (*strong / moderate / weak*).
@@ -258,11 +258,11 @@ Fetches NVD, EPSS, and CISA KEV data for both CVEs in parallel and produces a si
 
 ---
 
-### `manus-use exploit-complexity <CVE-ID>` — Exploit complexity scorer
+### `manus-agent exploit-complexity <CVE-ID>` — Exploit complexity scorer
 
 ```bash
-manus-use exploit-complexity CVE-2024-3094
-manus-use exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
+manus-agent exploit-complexity CVE-2024-3094
+manus-agent exploit-complexity CVE-2024-3094 --output json | jq .attacker_friendly
 ```
 
 Scores practical attacker effort on a 1–5 scale across five dimensions:
@@ -283,12 +283,12 @@ Outputs a `complexity_score` (1–5), a label (*trivial / low / moderate / high 
 
 ---
 
-### `manus-use poc-search <CVE-ID>` — Multi-source PoC aggregator
+### `manus-agent poc-search <CVE-ID>` — Multi-source PoC aggregator
 
 ```bash
-manus-use poc-search CVE-2024-3094
-manus-use poc-search CVE-2024-3094 --sources trickest,exploitdb,github
-manus-use poc-search CVE-2024-3094 --output json | jq .exploited_in_wild
+manus-agent poc-search CVE-2024-3094
+manus-agent poc-search CVE-2024-3094 --sources trickest,exploitdb,github
+manus-agent poc-search CVE-2024-3094 --output json | jq .exploited_in_wild
 ```
 
 Queries five PoC sources **in parallel**, deduplicates results, and sorts by exploited-in-wild status and publication date:
@@ -308,14 +308,14 @@ Queries five PoC sources **in parallel**, deduplicates results, and sorts by exp
 
 ---
 
-### `manus-use blast-radius <SPEC>` — Dependency blast radius
+### `manus-agent blast-radius <SPEC>` — Dependency blast radius
 
 ```bash
-manus-use blast-radius requests@2.28.0
-manus-use blast-radius pypi:urllib3@1.26.5
-manus-use blast-radius npm:lodash@4.17.20
-manus-use blast-radius CVE-2021-44228
-manus-use blast-radius CVE-2021-44228 --output json | jq .summary
+manus-agent blast-radius requests@2.28.0
+manus-agent blast-radius pypi:urllib3@1.26.5
+manus-agent blast-radius npm:lodash@4.17.20
+manus-agent blast-radius CVE-2021-44228
+manus-agent blast-radius CVE-2021-44228 --output json | jq .summary
 ```
 
 Estimates how broadly a vulnerability propagates downstream. Resolves affected packages from NVD CPE + OSV.dev + GHSA, then enriches each with real download/dependent stats:
@@ -344,12 +344,12 @@ Blast-radius labels per package:
 
 ---
 
-### `manus-use silent-patches <owner/repo>` — Silent patch detector
+### `manus-agent silent-patches <owner/repo>` — Silent patch detector
 
 ```bash
-manus-use silent-patches torvalds/linux
-manus-use silent-patches torvalds/linux --since 2025-01-01
-manus-use silent-patches torvalds/linux --output json | jq .[].classification
+manus-agent silent-patches torvalds/linux
+manus-agent silent-patches torvalds/linux --since 2025-01-01
+manus-agent silent-patches torvalds/linux --output json | jq .[].classification
 ```
 
 Scans a repository's commit history for security fixes that were never assigned a CVE. Uses two-stage heuristic scoring: commit message keywords then diff keywords. Each candidate commit is labelled with one of 14 bug classes (e.g. `auth_bypass`, `buffer_overflow`, `use_after_free`).
@@ -364,11 +364,11 @@ Scans a repository's commit history for security fixes that were never assigned 
 
 ---
 
-### `manus-use cve-timeline <CVE-ID>` — CVE timeline
+### `manus-agent cve-timeline <CVE-ID>` — CVE timeline
 
 ```bash
-manus-use cve-timeline CVE-2021-44228
-manus-use cve-timeline CVE-2021-44228 --output json
+manus-agent cve-timeline CVE-2021-44228
+manus-agent cve-timeline CVE-2021-44228 --output json
 ```
 
 Reconstructs the full event timeline for a CVE: NVD publish date → EPSS history → CISA KEV add date → patch release date. Useful for understanding how quickly a vulnerability was weaponised and fixed.
@@ -379,12 +379,12 @@ Reconstructs the full event timeline for a CVE: NVD publish date → EPSS histor
 
 ---
 
-### `manus-use version-range <CVE-ID>` — Affected version ranges
+### `manus-agent version-range <CVE-ID>` — Affected version ranges
 
 ```bash
-manus-use version-range CVE-2021-44228
-manus-use version-range CVE-2021-44228 --ecosystem pypi
-manus-use version-range CVE-2021-44228 --output json | jq .first_patched_version
+manus-agent version-range CVE-2021-44228
+manus-agent version-range CVE-2021-44228 --ecosystem pypi
+manus-agent version-range CVE-2021-44228 --output json | jq .first_patched_version
 ```
 
 Walks NVD CPE configurations and cross-references PyPI / npm / Maven to produce structured vulnerable semver ranges, a list of affected releases, and the first patched release.
@@ -396,11 +396,11 @@ Walks NVD CPE configurations and cross-references PyPI / npm / Maven to produce 
 
 ---
 
-### `manus-use vendor-response <CVE-ID>` — Vendor response tracker
+### `manus-agent vendor-response <CVE-ID>` — Vendor response tracker
 
 ```bash
-manus-use vendor-response CVE-2024-3094
-manus-use vendor-response CVE-2024-3094 --output json | jq .classification
+manus-agent vendor-response CVE-2024-3094
+manus-agent vendor-response CVE-2024-3094 --output json | jq .classification
 ```
 
 Queries four sources (NVD reference URL patterns, GHSA published state + patched_versions, CISA KEV required-action + due-date, repo-level GitHub security advisories) and outputs a 6-state patch-status classification:
@@ -415,11 +415,11 @@ Confidence is rated `high / moderate / low`. A VulnCheck KEV hit upgrades confid
 
 ---
 
-### `manus-use poc-freshness <CVE-ID>` — PoC freshness checker
+### `manus-agent poc-freshness <CVE-ID>` — PoC freshness checker
 
 ```bash
-manus-use poc-freshness CVE-2024-3094
-manus-use poc-freshness CVE-2024-3094 --output json | jq .freshness_score
+manus-agent poc-freshness CVE-2024-3094
+manus-agent poc-freshness CVE-2024-3094 --output json | jq .freshness_score
 ```
 
 Measures how recently PoC activity occurred: last commit recency in known PoC repos, recently-starred repositories, new Exploit-DB entries. A high freshness score means attacker interest is ongoing.
@@ -430,11 +430,11 @@ Measures how recently PoC activity occurred: last commit recency in known PoC re
 
 ---
 
-### `manus-use sbom-scan <bom-file>` — SBOM scanner
+### `manus-agent sbom-scan <bom-file>` — SBOM scanner
 
 ```bash
-manus-use sbom-scan bom.json
-manus-use sbom-scan sbom.spdx.json --output json | jq .critical_count
+manus-agent sbom-scan bom.json
+manus-agent sbom-scan sbom.spdx.json --output json | jq .critical_count
 ```
 
 Parses CycloneDX or SPDX SBOMs, queries OSV.dev in batch for all components, enriches each finding with EPSS and CISA KEV status, and ranks results by KEV membership then EPSS score.
@@ -445,11 +445,11 @@ Parses CycloneDX or SPDX SBOMs, queries OSV.dev in batch for all components, enr
 
 ---
 
-### `manus-use temporal-priority <CVE-ID>` — Temporal priority scorer
+### `manus-agent temporal-priority <CVE-ID>` — Temporal priority scorer
 
 ```bash
-manus-use temporal-priority CVE-2024-3094
-manus-use temporal-priority CVE-2024-3094 --output json | jq .score
+manus-agent temporal-priority CVE-2024-3094
+manus-agent temporal-priority CVE-2024-3094 --output json | jq .score
 ```
 
 Produces a 0–100 urgency score combining CVSS base score, current EPSS, EPSS spike recency, CISA KEV membership, patch availability, and CVE age. Designed to answer: *"given everything I know today, how urgent is this?"*
@@ -460,11 +460,11 @@ Produces a 0–100 urgency score combining CVSS base score, current EPSS, EPSS s
 
 ---
 
-### `manus-use cluster-variants <CVE-ID>` — CVE variant clustering
+### `manus-agent cluster-variants <CVE-ID>` — CVE variant clustering
 
 ```bash
-manus-use cluster-variants CVE-2021-44228
-manus-use cluster-variants CVE-2021-44228 --output json | jq .clusters
+manus-agent cluster-variants CVE-2021-44228
+manus-agent cluster-variants CVE-2021-44228 --output json | jq .clusters
 ```
 
 Groups CVEs related to the input across three cluster dimensions: same component/vendor, same CWE weakness class, and same researcher/disclosure domain. Useful for finding the full attack surface when one CVE is confirmed exploited.
@@ -475,13 +475,13 @@ Groups CVEs related to the input across three cluster dimensions: same component
 
 ---
 
-### `manus-use changelog` — Manage project changelog
+### `manus-agent changelog` — Manage project changelog
 
 ```bash
-manus-use changelog                       # show full CHANGELOG.md
-manus-use changelog --version 0.1.0      # show section for a specific version
-manus-use changelog --generate           # preview next release notes from commits
-manus-use changelog --generate --output json
+manus-agent changelog                       # show full CHANGELOG.md
+manus-agent changelog --version 0.1.0      # show section for a specific version
+manus-agent changelog --generate           # preview next release notes from commits
+manus-agent changelog --generate --output json
 ```
 
 Parses [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, etc.) and groups them into `Added`, `Fixed`, and `Changed` sections.
@@ -496,7 +496,7 @@ Parses [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `f
 
 ## Configuration
 
-Create `~/.manus-use/config.toml` (or run `manus-use init`):
+Create `~/.manus-use/config.toml` (or run `manus-agent init`):
 
 ```toml
 [llm]
@@ -593,7 +593,7 @@ result = agent.handle_request("Analyse CVE-2025-6554")
 
 ### Pipeline
 
-The `manus-use analyze` command runs an 8-step pipeline:
+The `manus-agent analyze` command runs an 8-step pipeline:
 
 1. **NVD + GHSA** — official CVE metadata, CVSS, CWE
 2. **CISA KEV** — known-exploited-vulnerabilities catalogue; **VulnCheck KEV** when `VULNCHECK_API_KEY` is set (100+ intel sources, ransomware flag)
@@ -608,27 +608,27 @@ The `manus-use analyze` command runs an 8-step pipeline:
 
 ```bash
 # Full intelligence report
-manus-use analyze CVE-2024-3094
+manus-agent analyze CVE-2024-3094
 
 # How exploitable is it right now?
-manus-use exploit-complexity CVE-2024-3094
-manus-use epss-trend CVE-2024-3094
+manus-agent exploit-complexity CVE-2024-3094
+manus-agent epss-trend CVE-2024-3094
 
 # What changed in the fix?
-manus-use patch-diff CVE-2024-3094
+manus-agent patch-diff CVE-2024-3094
 
 # Am I affected?
-manus-use version-range CVE-2024-3094
-manus-use sbom-scan bom.json
+manus-agent version-range CVE-2024-3094
+manus-agent sbom-scan bom.json
 
 # Triage two CVEs
-manus-use compare CVE-2024-3094 CVE-2021-44228
-manus-use temporal-priority CVE-2024-3094
+manus-agent compare CVE-2024-3094 CVE-2021-44228
+manus-agent temporal-priority CVE-2024-3094
 
 # Find related exposure
-manus-use blast-radius CVE-2021-44228
-manus-use cluster-variants CVE-2021-44228
-manus-use silent-patches apache/log4j
+manus-agent blast-radius CVE-2021-44228
+manus-agent cluster-variants CVE-2021-44228
+manus-agent silent-patches apache/log4j
 ```
 
 ### VulnCheck enrichment (optional)
@@ -720,7 +720,7 @@ manus-agent/
 │   ├── multi_agents/
 │   │   └── workflow_agent.py
 │   ├── tools/           # Strands tool implementations (one file per tool)
-│   ├── cli.py           # manus-use CLI entry point
+│   ├── cli.py           # manus-agent CLI entry point
 │   ├── config.py
 │   └── __init__.py
 ├── tests/               # pytest test suite (900+ tests, all mocked)

--- a/README.md
+++ b/README.md
@@ -14,27 +14,27 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [CLI Reference](#cli-reference)
-  - [Run a task](#manus-use-task--run-a-task)
-  - [init / doctor / history](#manus-use-init--configure-credentials)
-  - [analyze](#manus-use-analyze-cve-id--vulnerability-intelligence)
-  - [remediate](#manus-use-remediate-cve-id--remediation-guidance)
-  - [discover](#manus-use-discover--cve-discovery)
-  - [epss-trend](#manus-use-epss-trend-cve-id--epss-score-history)
-  - [patch-diff](#manus-use-patch-diff-cve-id--patch-diff-summariser)
-  - [variants](#manus-use-variants-cve-id--variant-analysis)
-  - [compare](#manus-use-compare-cve-a-cve-b--side-by-side-comparison)
-  - [exploit-complexity](#manus-use-exploit-complexity-cve-id--exploit-complexity-scorer)
-  - [poc-search](#manus-use-poc-search-cve-id--multi-source-poc-aggregator)
-  - [blast-radius](#manus-use-blast-radius-spec--dependency-blast-radius)
-  - [silent-patches](#manus-use-silent-patches-ownerrepo--silent-patch-detector)
-  - [cve-timeline](#manus-use-cve-timeline-cve-id--cve-timeline)
-  - [version-range](#manus-use-version-range-cve-id--affected-version-ranges)
-  - [vendor-response](#manus-use-vendor-response-cve-id--vendor-response-tracker)
-  - [poc-freshness](#manus-use-poc-freshness-cve-id--poc-freshness-checker)
-  - [sbom-scan](#manus-use-sbom-scan-bomfile--sbom-scanner)
-  - [temporal-priority](#manus-use-temporal-priority-cve-id--temporal-priority-scorer)
-  - [cluster-variants](#manus-use-cluster-variants-cve-id--cve-variant-clustering)
-  - [changelog](#manus-use-changelog--manage-project-changelog)
+  - [Run a task](#manus-agent-task--run-a-task)
+  - [init / doctor / history](#manus-agent-init--configure-credentials)
+  - [analyze](#manus-agent-analyze-cve-id--vulnerability-intelligence)
+  - [remediate](#manus-agent-remediate-cve-id--remediation-guidance)
+  - [discover](#manus-agent-discover--cve-discovery)
+  - [epss-trend](#manus-agent-epss-trend-cve-id--epss-score-history)
+  - [patch-diff](#manus-agent-patch-diff-cve-id--patch-diff-summariser)
+  - [variants](#manus-agent-variants-cve-id--variant-analysis)
+  - [compare](#manus-agent-compare-cve-a-cve-b--side-by-side-comparison)
+  - [exploit-complexity](#manus-agent-exploit-complexity-cve-id--exploit-complexity-scorer)
+  - [poc-search](#manus-agent-poc-search-cve-id--multi-source-poc-aggregator)
+  - [blast-radius](#manus-agent-blast-radius-spec--dependency-blast-radius)
+  - [silent-patches](#manus-agent-silent-patches-ownerrepo--silent-patch-detector)
+  - [cve-timeline](#manus-agent-cve-timeline-cve-id--cve-timeline)
+  - [version-range](#manus-agent-version-range-cve-id--affected-version-ranges)
+  - [vendor-response](#manus-agent-vendor-response-cve-id--vendor-response-tracker)
+  - [poc-freshness](#manus-agent-poc-freshness-cve-id--poc-freshness-checker)
+  - [sbom-scan](#manus-agent-sbom-scan-bomfile--sbom-scanner)
+  - [temporal-priority](#manus-agent-temporal-priority-cve-id--temporal-priority-scorer)
+  - [cluster-variants](#manus-agent-cluster-variants-cve-id--cve-variant-clustering)
+  - [changelog](#manus-agent-changelog--manage-project-changelog)
 - [Configuration](#configuration)
 - [Python API](#python-api)
 - [Security & Vulnerability Intelligence](#security--vulnerability-intelligence)
@@ -71,7 +71,7 @@ manus-agent doctor
 manus-agent "Write a Python script that fetches the current Bitcoin price"
 
 # Or start the interactive REPL
-manus-use
+manus-agent
 ```
 
 ---
@@ -97,7 +97,7 @@ manus-agent --format json "List the first 10 prime numbers" | jq .result
 manus-agent --stream "Write a short story about a robot"
 
 # Interactive REPL
-manus-use
+manus-agent
 manus-agent --mode multi
 ```
 
@@ -118,7 +118,7 @@ manus-agent --mode multi
 ### `manus-agent init` — Configure credentials
 
 ```bash
-manus-agent init                        # write to ~/.manus-use/config.toml
+manus-agent init                        # write to ~/.manus-agent/config.toml
 manus-agent init --output ./my.toml    # write to a custom path
 manus-agent init --force                # overwrite without prompting
 ```
@@ -142,7 +142,7 @@ manus-agent history --format json | jq .  # all history as JSON
 manus-agent history --clear               # delete all history
 ```
 
-History is stored at `~/.manus-use/history.jsonl`.
+History is stored at `~/.manus-agent/history.jsonl`.
 
 ---
 
@@ -496,7 +496,7 @@ Parses [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `f
 
 ## Configuration
 
-Create `~/.manus-use/config.toml` (or run `manus-agent init`):
+Create `~/.manus-agent/config.toml` (or run `manus-agent init`):
 
 ```toml
 [llm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "manus-use"
+name = "manus-agent"
 version = "0.1.0"
 description = "A powerful framework for building advanced AI agents with comprehensive tool support and orchestration capabilities"
 readme = "README.md"
@@ -49,8 +49,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/manus-use/manus-use"
-"Bug Tracker" = "https://github.com/manus-use/manus-use/issues"
+Homepage = "https://github.com/manus-use/manus-agent"
+"Bug Tracker" = "https://github.com/manus-use/manus-agent/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/manus_use"]
@@ -89,7 +89,7 @@ cli = [
 ]
 
 [project.scripts]
-manus-use = "manus_use.cli:main"
+manus-agent = "manus_use.cli:main"
 
 [tool.hatch.envs.default]
 features = ["dev", "browser", "search", "visualization"]

--- a/src/manus_use/__init__.py
+++ b/src/manus_use/__init__.py
@@ -1,4 +1,4 @@
-"""manus-use: A powerful framework for building advanced AI agents."""
+"""manus-agent: A powerful framework for building advanced AI agents."""
 
 from manus_use.agents import (
     BrowserUseAgent,

--- a/src/manus_use/agents/remediation_agent.py
+++ b/src/manus_use/agents/remediation_agent.py
@@ -25,7 +25,7 @@ __all__ = ["RemediationAgent", "DEFAULT_MODEL_ID"]
 # Sensible default used only when no model can be resolved from ``Config``.
 DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
-# Repository root (…/manus-use) — used to locate bundled skills.
+# Repository root (…/manus-agent) — used to locate bundled skills.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 _SYSTEM_PROMPT = """
@@ -210,7 +210,7 @@ class RemediationAgent:
 def _main() -> None:
     """CLI entry-point kept for backwards compatibility.
 
-    Prefer ``manus-use remediate <CVE-ID>`` instead.
+    Prefer ``manus-agent remediate <CVE-ID>`` instead.
     """
     import sys
 

--- a/src/manus_use/agents/vi_agent.py
+++ b/src/manus_use/agents/vi_agent.py
@@ -27,7 +27,7 @@ __all__ = ["VulnerabilityIntelligenceAgent", "DEFAULT_MODEL_ID"]
 # Kept as a single named constant rather than scattered literals.
 DEFAULT_MODEL_ID = "us.anthropic.claude-sonnet-4-20250514-v1:0"
 
-# Repository root (â¦/manus-use) â used to locate bundled skills.
+# Repository root (â¦/manus-agent) â used to locate bundled skills.
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 SYSTEM_PROMPT = """

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -246,10 +246,10 @@ def _append_history(
 
 
 # ---------------------------------------------------------------------------
-# manus-use discover
+# manus-agent discover
 # ---------------------------------------------------------------------------
 
-# manus-use discover
+# manus-agent discover
 # ---------------------------------------------------------------------------
 
 
@@ -368,7 +368,7 @@ def _run_discover(
 
 
 # ---------------------------------------------------------------------------
-# manus-use remediate
+# manus-agent remediate
 # ---------------------------------------------------------------------------
 
 
@@ -700,7 +700,7 @@ def _run_interactive(
 
 
 # ---------------------------------------------------------------------------
-# manus-use init
+# manus-agent init
 # ---------------------------------------------------------------------------
 
 # Provider metadata: (display_name, default_model, env_var_for_api_key, needs_api_key)
@@ -718,7 +718,7 @@ def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
     """Guided interactive config generator."""
     console.print(
         Panel(
-            "[bold]Welcome to [cyan]manus-use init[/cyan]![/bold]\n"
+            "[bold]Welcome to [cyan]manus-agent init[/cyan]![/bold]\n"
             "This wizard will create a [yellow]config.toml[/yellow] for you.",
             border_style="blue",
         )
@@ -814,7 +814,7 @@ def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
     console.print(
         Panel(
             f"[green]✓ Config written to[/green] [bold]{dest}[/bold]\n\n"
-            f"Run [cyan]manus-use doctor[/cyan] to verify your setup.",
+            f"Run [cyan]manus-agent doctor[/cyan] to verify your setup.",
             border_style="green",
             title="[bold green]Done![/bold green]",
         )
@@ -823,7 +823,7 @@ def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
 
 
 # ---------------------------------------------------------------------------
-# manus-use doctor
+# manus-agent doctor
 # ---------------------------------------------------------------------------
 
 # (package_import, pip_extra, description)
@@ -857,7 +857,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
     """Check packages, config, and environment variables."""
     console.print(
         Panel(
-            "[bold cyan]manus-use doctor[/bold cyan] – environment diagnostics",
+            "[bold cyan]manus-agent doctor[/bold cyan] – environment diagnostics",
             border_style="blue",
         )
     )
@@ -902,7 +902,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
             issues.append(f"Config parse error: {exc}")
             config = Config()
     else:
-        console.print("  [yellow]![/yellow] No config file found (run [cyan]manus-use init[/cyan] to create one)")
+        console.print("  [yellow]![/yellow] No config file found (run [cyan]manus-agent init[/cyan] to create one)")
         config = Config()
 
     # ------------------------------------------------------------------
@@ -1470,10 +1470,10 @@ def _build_changelog_parser() -> argparse.ArgumentParser:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Examples:\n"
-            "  manus-use changelog                       # show full CHANGELOG.md\n"
-            "  manus-use changelog --version 0.1.0       # show section for v0.1.0\n"
-            "  manus-use changelog --generate            # preview next release notes\n"
-            "  manus-use changelog --generate --output json\n"
+            "  manus-agent changelog                       # show full CHANGELOG.md\n"
+            "  manus-agent changelog --version 0.1.0       # show section for v0.1.0\n"
+            "  manus-agent changelog --generate            # preview next release notes\n"
+            "  manus-agent changelog --generate --output json\n"
         ),
     )
     p.add_argument(
@@ -1868,45 +1868,45 @@ def _build_run_parser() -> argparse.ArgumentParser:
         epilog=(
             "Examples:\n"
             "  # Single-shot (non-interactive)\n"
-            '  manus-use "Create a factorial function in Python"\n'
-            '  manus-use --agent browser "Find the top 5 trending GitHub repos today"\n'
-            '  manus-use --output result.txt "Summarise the latest AI news"\n'
-            '  manus-use --format json "List prime numbers up to 50"\n'
-            '  manus-use --format json "task" | jq .result\n\n'
+            '  manus-agent "Create a factorial function in Python"\n'
+            '  manus-agent --agent browser "Find the top 5 trending GitHub repos today"\n'
+            '  manus-agent --output result.txt "Summarise the latest AI news"\n'
+            '  manus-agent --format json "List prime numbers up to 50"\n'
+            '  manus-agent --format json "task" | jq .result\n\n'
             "  # Interactive REPL\n"
-            "  manus-use\n"
-            "  manus-use --mode multi\n\n"
+            "  manus-agent\n"
+            "  manus-agent --mode multi\n\n"
             "  # Setup helpers\n"
-            "  manus-use init           # create ~/.manus-use/config.toml interactively\n"
-            "  manus-use doctor         # check packages, config, and API keys\n"
-            "  manus-use history        # show recent runs (use --help for filters)\n"
+            "  manus-agent init           # create ~/.manus-use/config.toml interactively\n"
+            "  manus-agent doctor         # check packages, config, and API keys\n"
+            "  manus-agent history        # show recent runs (use --help for filters)\n"
             "\n"
             "  # EPSS trend analysis\n"
-            "  manus-use epss-trend CVE-2024-3094\n"
-            "  manus-use epss-trend CVE-2024-3094 --days 90 --output json\n"
+            "  manus-agent epss-trend CVE-2024-3094\n"
+            "  manus-agent epss-trend CVE-2024-3094 --days 90 --output json\n"
             "\n"
             "  # Patch diff summariser (fixing-commit analysis)\n"
-            "  manus-use patch-diff CVE-2024-3094\n"
-            "  manus-use patch-diff CVE-2024-3094 --output json\n"
+            "  manus-agent patch-diff CVE-2024-3094\n"
+            "  manus-agent patch-diff CVE-2024-3094 --output json\n"
             "\n"
             "  # Vulnerability intelligence analysis\n"
-            "  manus-use analyze CVE-2025-6554\n"
-            "  manus-use analyze CVE-2024-3094 --verify --output json\n"
+            "  manus-agent analyze CVE-2025-6554\n"
+            "  manus-agent analyze CVE-2024-3094 --verify --output json\n"
             "  \n"
             "  # CVE discovery\n"
-            "  manus-use discover\n"
-            "  manus-use discover --since 2025-06-01 --min-epss 0.7 --output json\n"
-            "  manus-use discover --dry-run\n"
+            "  manus-agent discover\n"
+            "  manus-agent discover --since 2025-06-01 --min-epss 0.7 --output json\n"
+            "  manus-agent discover --dry-run\n"
             "  \n"
             "  # CVE remediation guidance\n"
-            "  manus-use remediate CVE-2024-3094\n"
-            "  manus-use remediate CVE-2024-3094 --output json\n"
+            "  manus-agent remediate CVE-2024-3094\n"
+            "  manus-agent remediate CVE-2024-3094 --output json\n"
             "\n"
             "  # Changelog and release notes\n"
-            "  manus-use changelog                           # show full CHANGELOG.md\n"
-            "  manus-use changelog --version 0.1.0          # show section for v0.1.0\n"
-            "  manus-use changelog --generate               # preview next release notes\n"
-            "  manus-use changelog --generate --output json\n"
+            "  manus-agent changelog                           # show full CHANGELOG.md\n"
+            "  manus-agent changelog --version 0.1.0          # show section for v0.1.0\n"
+            "  manus-agent changelog --generate               # preview next release notes\n"
+            "  manus-agent changelog --generate --output json\n"
         ),
     )
     parser.add_argument(
@@ -1978,7 +1978,7 @@ def _build_init_parser() -> argparse.ArgumentParser:
     """Build the `init` subcommand parser."""
     parser = argparse.ArgumentParser(
         prog="manus-agent init",
-        description="Guided wizard to create a manus-use configuration file.",
+        description="Guided wizard to create a manus-agent configuration file.",
     )
     parser.add_argument(
         "--output",
@@ -1999,7 +1999,7 @@ def _build_doctor_parser() -> argparse.ArgumentParser:
     """Build the `doctor` subcommand parser."""
     parser = argparse.ArgumentParser(
         prog="manus-agent doctor",
-        description="Diagnose your manus-use installation: packages, config file, API keys.",
+        description="Diagnose your manus-agent installation: packages, config file, API keys.",
     )
     parser.add_argument(
         "--config",
@@ -2054,7 +2054,7 @@ def _cmd_history(args: argparse.Namespace) -> int:
         return 0
 
     if not _HISTORY_PATH.exists():
-        console.print("[dim]No history yet – run a task with [cyan]manus-use 'task...'[/cyan] first.[/dim]")
+        console.print("[dim]No history yet – run a task with [cyan]manus-agent 'task...'[/cyan] first.[/dim]")
         return 0
 
     records = []

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -205,7 +205,7 @@ def _run_analyze(
 # History helpers
 # ---------------------------------------------------------------------------
 
-_HISTORY_PATH = Path.home() / ".manus-use" / "history.jsonl"
+_HISTORY_PATH = Path.home() / ".manus-agent" / "history.jsonl"
 
 
 def _append_history(
@@ -219,7 +219,7 @@ def _append_history(
 ) -> None:
     """Append a single-shot run record to the history log.
 
-    The log lives at ``~/.manus-use/history.jsonl`` (one JSON object per line)
+    The log lives at ``~/.manus-agent/history.jsonl`` (one JSON object per line)
     so it can be streamed/grepped without loading the whole file.
 
     Each record has:
@@ -711,7 +711,7 @@ _PROVIDERS = {
     "ollama": ("Ollama (local)", "llama3.2", None, False),
 }
 
-_DEFAULT_CONFIG_PATH = Path.home() / ".manus-use" / "config.toml"
+_DEFAULT_CONFIG_PATH = Path.home() / ".manus-agent" / "config.toml"
 
 
 def _cmd_init(args: argparse.Namespace) -> int:  # noqa: C901
@@ -1877,7 +1877,7 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  manus-agent\n"
             "  manus-agent --mode multi\n\n"
             "  # Setup helpers\n"
-            "  manus-agent init           # create ~/.manus-use/config.toml interactively\n"
+            "  manus-agent init           # create ~/.manus-agent/config.toml interactively\n"
             "  manus-agent doctor         # check packages, config, and API keys\n"
             "  manus-agent history        # show recent runs (use --help for filters)\n"
             "\n"

--- a/src/manus_use/cli.py
+++ b/src/manus_use/cli.py
@@ -120,7 +120,7 @@ def _make_agent(agent_type: str, config: Config, **agent_kwargs):
 def _build_analyze_parser() -> argparse.ArgumentParser:
     """Build the argument parser for the `analyze` subcommand."""
     parser = argparse.ArgumentParser(
-        prog="manus-use analyze",
+        prog="manus-agent analyze",
         description="Run a vulnerability intelligence analysis for a CVE.",
     )
     parser.add_argument(
@@ -256,7 +256,7 @@ def _append_history(
 def _build_discover_parser() -> argparse.ArgumentParser:
     """Build the argument parser for the `discover` subcommand."""
     parser = argparse.ArgumentParser(
-        prog="manus-use discover",
+        prog="manus-agent discover",
         description="Discover recent high-EPSS CVEs and submit them for tracking.",
     )
     parser.add_argument(
@@ -375,7 +375,7 @@ def _run_discover(
 def _build_remediate_parser() -> argparse.ArgumentParser:
     """Build the argument parser for the ``remediate`` subcommand."""
     parser = argparse.ArgumentParser(
-        prog="manus-use remediate",
+        prog="manus-agent remediate",
         description="Generate actionable remediation guidance for a CVE.",
     )
     parser.add_argument(
@@ -998,7 +998,7 @@ def _cmd_doctor(args: argparse.Namespace) -> int:
 
 def _build_variants_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use variants",
+        prog="manus-agent variants",
         description="CVE variant analysis — find similar bugs in related codebases",
         add_help=True,
     )
@@ -1066,7 +1066,7 @@ _SUBCOMMANDS = {
 
 def _build_epss_trend_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use epss-trend",
+        prog="manus-agent epss-trend",
         description=(
             "Fetch EPSS (Exploit Prediction Scoring System) score history for a CVE \n"
             "and flag significant spikes that indicate new exploitation activity."
@@ -1161,7 +1161,7 @@ def _run_epss_trend(argv: list[str]) -> int:
 
 def _build_patch_diff_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use patch-diff",
+        prog="manus-agent patch-diff",
         description=(
             "Fetch the fixing-commit diff for a CVE from GitHub and produce a\n"
             "structured summary: files changed, functions touched, bug class,\n"
@@ -1229,7 +1229,7 @@ def _run_patch_diff(argv: list[str]) -> int:
 
 def _build_compare_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use compare",
+        prog="manus-agent compare",
         description=(
             "Compare two CVEs side-by-side across CVSS, EPSS, CISA KEV, CWE,\n"
             "attack vector, and other dimensions.  Outputs a prioritisation\n"
@@ -1303,7 +1303,7 @@ def _run_compare(argv: list[str]) -> int:
 
 def _build_exploit_complexity_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        prog="manus-use exploit-complexity",
+        prog="manus-agent exploit-complexity",
         description="Score the practical complexity of exploiting a CVE (1=trivial, 5=very hard).",
     )
     parser.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier (e.g. CVE-2024-3094)")
@@ -1351,7 +1351,7 @@ def _run_exploit_complexity(argv: list[str]) -> int:
 
 def _build_poc_search_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use poc-search",
+        prog="manus-agent poc-search",
         description=(
             "Search multiple public sources for PoC exploits related to a CVE.\n"
             "Sources: trickest/cve, VulnCheck KEV, Exploit-DB, GitHub, NVD refs."
@@ -1459,7 +1459,7 @@ def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
 
 def _build_changelog_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use changelog",
+        prog="manus-agent changelog",
         description=(
             "View CHANGELOG.md or generate release notes from recent git commits.\n"
             "Without --generate, prints the CHANGELOG.md content (or the section\n"
@@ -1694,7 +1694,7 @@ def _run_changelog_generate(args: argparse.Namespace, root: "_Path") -> int:  # 
 
 def _build_blast_radius_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
-        prog="manus-use blast-radius",
+        prog="manus-agent blast-radius",
         description=(
             "Estimate the downstream blast radius of a vulnerable package or CVE.\n"
             "Given a package spec (requests@2.28.0, npm:axios@1.6.0, CVE-2021-44228),\n"
@@ -1862,7 +1862,7 @@ def _run_blast_radius(argv: list[str]) -> int:
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
-        prog="manus-use",
+        prog="manus-agent",
         description="ManusUse – Advanced AI Agent Framework",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
@@ -1912,7 +1912,7 @@ def _build_run_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"manus-use {__version__}",
+        version=f"manus-agent {__version__}",
     )
     parser.add_argument(
         "task",
@@ -1977,7 +1977,7 @@ def _build_run_parser() -> argparse.ArgumentParser:
 def _build_init_parser() -> argparse.ArgumentParser:
     """Build the `init` subcommand parser."""
     parser = argparse.ArgumentParser(
-        prog="manus-use init",
+        prog="manus-agent init",
         description="Guided wizard to create a manus-use configuration file.",
     )
     parser.add_argument(
@@ -1998,7 +1998,7 @@ def _build_init_parser() -> argparse.ArgumentParser:
 def _build_doctor_parser() -> argparse.ArgumentParser:
     """Build the `doctor` subcommand parser."""
     parser = argparse.ArgumentParser(
-        prog="manus-use doctor",
+        prog="manus-agent doctor",
         description="Diagnose your manus-use installation: packages, config file, API keys.",
     )
     parser.add_argument(
@@ -2014,7 +2014,7 @@ def _build_doctor_parser() -> argparse.ArgumentParser:
 def _build_history_parser() -> argparse.ArgumentParser:
     """Build the `history` subcommand parser."""
     parser = argparse.ArgumentParser(
-        prog="manus-use history",
+        prog="manus-agent history",
         description="Show past single-shot task runs recorded in the history log.",
     )
     parser.add_argument(

--- a/src/manus_use/config.py
+++ b/src/manus_use/config.py
@@ -50,7 +50,7 @@ def _load_dotenv() -> None:
     search_paths = [
         Path(".env"),
         Path("config/.env"),
-        Path.home() / ".manus-use" / ".env",
+        Path.home() / ".manus-agent" / ".env",
     ]
     for p in search_paths:
         if p.exists():
@@ -305,7 +305,7 @@ class Config(BaseModel):
 
             .env              (current working directory)
             config/.env
-            ~/.manus-use/.env
+            ~/.manus-agent/.env
         """
         # Load .env into os.environ (does not overwrite vars already set in shell)
         _load_dotenv()
@@ -315,7 +315,7 @@ class Config(BaseModel):
             search_paths = [
                 Path("config.toml"),
                 Path("config/config.toml"),
-                Path.home() / ".manus-use" / "config.toml",
+                Path.home() / ".manus-agent" / "config.toml",
             ]
             for p in search_paths:
                 if p.exists():

--- a/src/manus_use/tools/get_dependency_blast_radius.py
+++ b/src/manus_use/tools/get_dependency_blast_radius.py
@@ -18,8 +18,8 @@ Data sources (all free, no API key required):
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
 
-CLI: ``manus-use blast-radius requests@2.28.0``
-     ``manus-use blast-radius CVE-2021-44228``
+CLI: ``manus-agent blast-radius requests@2.28.0``
+     ``manus-agent blast-radius CVE-2021-44228``
 """
 
 from __future__ import annotations

--- a/src/manus_use/tools/search_poc_sources.py
+++ b/src/manus_use/tools/search_poc_sources.py
@@ -13,7 +13,7 @@ parallel and returns a unified, deduplicated, and ranked result set:
 The tool is deliberately source-agnostic: all results share a common schema
 so consumers can sort, filter, and display them uniformly.
 
-CLI: ``manus-use poc-search CVE-XXXX-YYYY``
+CLI: ``manus-agent poc-search CVE-XXXX-YYYY``
 """
 
 from __future__ import annotations
@@ -194,7 +194,7 @@ def _ensure_exploitdb_cache() -> str | None:
         pass
 
     try:
-        req = urllib.request.Request(_EXPLOITDB_CSV_URL, headers={"User-Agent": "manus-use"})
+        req = urllib.request.Request(_EXPLOITDB_CSV_URL, headers={"User-Agent": "manus-agent"})
         with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
             data = resp.read()
         with open(cache_path, "wb") as fh:

--- a/src/manus_use/utils/__init__.py
+++ b/src/manus_use/utils/__init__.py
@@ -1,1 +1,1 @@
-"""Utility modules for manus-use."""
+"""Utility modules for manus-agent."""

--- a/tests/test_changelog_cli.py
+++ b/tests/test_changelog_cli.py
@@ -61,7 +61,7 @@ class TestChangelogSubcommandRouting:
         assert callable(cli._run_changelog)
 
     def test_changelog_help_exits_zero(self):
-        """manus-use changelog --help exits 0."""
+        """manus-agent changelog --help exits 0."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit) as exc_info:
@@ -101,7 +101,7 @@ class TestChangelogSubcommandRouting:
         assert exc_info.value.code == 0
 
     def test_top_level_help_mentions_changelog(self, capsys):
-        """manus-use --help output mentions the changelog subcommand."""
+        """manus-agent --help output mentions the changelog subcommand."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):

--- a/tests/test_changelog_cli.py
+++ b/tests/test_changelog_cli.py
@@ -1,4 +1,4 @@
-"""Tests for the `manus-use changelog` subcommand and scripts/release.py.
+"""Tests for the `manus-agent changelog` subcommand and scripts/release.py.
 
 All git operations are fully mocked — no real git calls occur.
 All file I/O uses tmp_path fixtures so the source tree is never touched.
@@ -23,7 +23,7 @@ def _invoke_changelog(argv: list[str]) -> tuple[int, str, str]:
     """Call cli.main() with `changelog <argv>` and return (rc, stdout, stderr)."""
     from manus_use import cli  # noqa: PLC0415
 
-    with mock.patch.object(sys, "argv", ["manus-use", "changelog", *argv]):
+    with mock.patch.object(sys, "argv", ["manus-agent", "changelog", *argv]):
         import io
 
         out_buf, err_buf = io.StringIO(), io.StringIO()
@@ -65,7 +65,7 @@ class TestChangelogSubcommandRouting:
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit) as exc_info:
-            with mock.patch.object(sys, "argv", ["manus-use", "changelog", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "changelog", "--help"]):
                 cli.main()
         assert exc_info.value.code == 0
 
@@ -74,7 +74,7 @@ class TestChangelogSubcommandRouting:
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "changelog", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "changelog", "--help"]):
                 cli.main()
         out = capsys.readouterr().out
         assert "--generate" in out
@@ -84,7 +84,7 @@ class TestChangelogSubcommandRouting:
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "changelog", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "changelog", "--help"]):
                 cli.main()
         out = capsys.readouterr().out
         assert "--version" in out
@@ -95,7 +95,7 @@ class TestChangelogSubcommandRouting:
 
         with mock.patch.object(cli, "_run_changelog", return_value=0) as mock_run:
             with pytest.raises(SystemExit) as exc_info:
-                with mock.patch.object(sys, "argv", ["manus-use", "changelog"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "changelog"]):
                     cli.main()
         mock_run.assert_called_once()
         assert exc_info.value.code == 0
@@ -105,7 +105,7 @@ class TestChangelogSubcommandRouting:
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
         out = capsys.readouterr().out
         assert "changelog" in out

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ def _invoke_main(argv, *, patch_single_shot=True, single_shot_rc=0):
         captured["no_history"] = no_history
         return single_shot_rc
 
-    with mock.patch.object(sys, "argv", ["manus-use"] + argv):
+    with mock.patch.object(sys, "argv", ["manus-agent"] + argv):
         with mock.patch.object(cli, "_run_single_shot", side_effect=fake_single_shot) as m_ss:
             with mock.patch.object(cli, "_run_interactive") as m_int:
                 with mock.patch("manus_use.cli.Config") as m_cfg:
@@ -56,7 +56,7 @@ def test_version_flag():
     """--version prints version string and exits 0."""
     from manus_use import cli
 
-    with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+    with mock.patch.object(sys, "argv", ["manus-agent", "--version"]):
         with pytest.raises(SystemExit) as exc_info:
             cli.main()
     assert exc_info.value.code == 0
@@ -68,7 +68,7 @@ def test_version_flag():
 
 
 def test_single_shot_dispatches_task():
-    """`manus-use 'do X'` routes to _run_single_shot with correct task."""
+    """`manus-agent 'do X'` routes to _run_single_shot with correct task."""
     captured = _invoke_main(["do X"])
     assert captured["task"] == "do X"
     assert captured["_run_single_shot"].called
@@ -143,7 +143,7 @@ def test_output_without_task_is_error():
     """--output without a task argument should produce an argparse error (exit 2)."""
     from manus_use import cli
 
-    with mock.patch.object(sys, "argv", ["manus-use", "--output", "out.txt"]):
+    with mock.patch.object(sys, "argv", ["manus-agent", "--output", "out.txt"]):
         with mock.patch("manus_use.cli.Config") as m_cfg:
             m_cfg.from_file.return_value = mock.MagicMock()
             with pytest.raises(SystemExit) as exc_info:
@@ -428,7 +428,7 @@ def _invoke_history(argv):
     from manus_use import cli
 
     captured = {}
-    with mock.patch.object(sys, "argv", ["manus-use", "history"] + argv):
+    with mock.patch.object(sys, "argv", ["manus-agent", "history"] + argv):
         with mock.patch.object(cli, "_cmd_history") as m_hist:
             m_hist.return_value = 0
             try:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -319,7 +319,7 @@ def test_append_history_creates_file(tmp_path):
     """_append_history creates the history file and writes a valid JSON record."""
     from manus_use import cli
 
-    hist_path = tmp_path / ".manus-use" / "history.jsonl"
+    hist_path = tmp_path / ".manus-agent" / "history.jsonl"
 
     with mock.patch.object(cli, "_HISTORY_PATH", hist_path):
         cli._append_history(
@@ -419,7 +419,7 @@ def test_history_flag_calls_append(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# manus-use history subcommand
+# manus-agent history subcommand
 # ---------------------------------------------------------------------------
 
 
@@ -440,7 +440,7 @@ def _invoke_history(argv):
 
 
 def test_history_subcommand_dispatches():
-    """manus-use history dispatches to _cmd_history."""
+    """manus-agent history dispatches to _cmd_history."""
     captured = _invoke_history([])
     assert captured["_cmd_history"].called
 

--- a/tests/test_cli_stream.py
+++ b/tests/test_cli_stream.py
@@ -44,7 +44,7 @@ def _invoke_main(argv, *, single_shot_rc=0):
         captured["stream"] = stream
         return single_shot_rc
 
-    with mock.patch.object(sys, "argv", ["manus-use"] + argv):
+    with mock.patch.object(sys, "argv", ["manus-agent"] + argv):
         with mock.patch.object(cli, "_run_single_shot", side_effect=fake_single_shot) as m_ss:
             with mock.patch.object(cli, "_run_interactive"):
                 with mock.patch("manus_use.cli.Config") as m_cfg:

--- a/tests/test_compare_cves.py
+++ b/tests/test_compare_cves.py
@@ -1,5 +1,5 @@
 """
-Tests for compare_cves tool and manus-use compare CLI subcommand.
+Tests for compare_cves tool and manus-agent compare CLI subcommand.
 
 All tests are fully mocked — no real HTTP calls are made.
 """

--- a/tests/test_compare_cves.py
+++ b/tests/test_compare_cves.py
@@ -844,7 +844,7 @@ class TestMainDispatchesCompare:
     def test_main_routes_compare_subcommand(self):
 
         with patch("manus_use.cli._run_compare", return_value=0) as mock_run:
-            with patch("sys.argv", ["manus-use", "compare", "CVE-2021-44228", "CVE-2024-3094"]):
+            with patch("sys.argv", ["manus-agent", "compare", "CVE-2021-44228", "CVE-2024-3094"]):
                 try:
                     from manus_use.cli import main
 
@@ -857,7 +857,7 @@ class TestMainDispatchesCompare:
     def test_main_compare_passes_output_flag(self):
 
         with patch("manus_use.cli._run_compare", return_value=0) as mock_run:
-            with patch("sys.argv", ["manus-use", "compare", "CVE-2021-44228", "CVE-2024-3094", "--output", "json"]):
+            with patch("sys.argv", ["manus-agent", "compare", "CVE-2021-44228", "CVE-2024-3094", "--output", "json"]):
                 try:
                     from manus_use.cli import main
 

--- a/tests/test_epss_trend.py
+++ b/tests/test_epss_trend.py
@@ -438,4 +438,4 @@ def test_readme_epss_trend_example_commands():
 
     readme = Path(__file__).resolve().parents[1] / "README.md"
     content = readme.read_text()
-    assert "manus-use epss-trend CVE-" in content
+    assert "manus-agent epss-trend CVE-" in content

--- a/tests/test_exploit_complexity.py
+++ b/tests/test_exploit_complexity.py
@@ -995,7 +995,7 @@ def test_cli_dispatch_exploit_complexity_in_main(monkeypatch):
         return 0
 
     monkeypatch.setattr(cli, "_run_exploit_complexity", fake_run)
-    monkeypatch.setattr(sys, "argv", ["manus-use", "exploit-complexity", "CVE-2024-3094"])
+    monkeypatch.setattr(sys, "argv", ["manus-agent", "exploit-complexity", "CVE-2024-3094"])
     with pytest.raises(SystemExit) as exc:
         cli.main()
 

--- a/tests/test_init_doctor.py
+++ b/tests/test_init_doctor.py
@@ -1,4 +1,4 @@
-"""Tests for `manus-use init` and `manus-use doctor` subcommands."""
+"""Tests for `manus-agent init` and `manus-agent doctor` subcommands."""
 
 import contextlib
 import os
@@ -23,7 +23,7 @@ def _invoke(argv: list[str], *, inputs: list[str] | None = None):
     exit_code = 0
 
     # Patch Prompt.ask / Confirm.ask so tests don't block on stdin.
-    with mock.patch.object(sys, "argv", ["manus-use"] + argv):
+    with mock.patch.object(sys, "argv", ["manus-agent"] + argv):
         try:
             cli.main()
         except SystemExit as exc:
@@ -63,7 +63,7 @@ class TestInitCommand:
 
         with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_responses)):
             with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_responses)):
-                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest), "--force"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -82,7 +82,7 @@ class TestInitCommand:
         original_mtime = dest.stat().st_mtime
 
         with mock.patch("manus_use.cli.Confirm.ask", return_value=False):
-            with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest)]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest)]):
                 with pytest.raises(SystemExit) as exc_info:
                     cli.main()
 
@@ -101,7 +101,7 @@ class TestInitCommand:
 
         with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
             with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
-                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest), "--force"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -123,7 +123,7 @@ class TestInitCommand:
         with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
             with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
                 with mock.patch.dict(os.environ, env_patch, clear=False):
-                    with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                    with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest), "--force"]):
                         with pytest.raises(SystemExit) as exc_info:
                             cli.main()
 
@@ -149,7 +149,7 @@ class TestInitCommand:
 
         with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
             with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
-                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest), "--force"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -170,7 +170,7 @@ class TestInitCommand:
 
         with mock.patch("manus_use.cli.Prompt.ask", side_effect=lambda *a, **kw: next(prompt_seq)):
             with mock.patch("manus_use.cli.Confirm.ask", side_effect=lambda *a, **kw: next(confirm_seq)):
-                with mock.patch.object(sys, "argv", ["manus-use", "init", "--output", str(dest), "--force"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "init", "--output", str(dest), "--force"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -185,7 +185,7 @@ class TestInitCommand:
 
 class TestDoctorCommand:
     def _run_doctor(self, extra_argv=None, env_patch=None, import_side_effects=None, mock_imports_ok=True):
-        """Helper: run `manus-use doctor` and return exit code.
+        """Helper: run `manus-agent doctor` and return exit code.
 
         Args:
             extra_argv: extra CLI arguments after ``doctor``.
@@ -198,7 +198,7 @@ class TestDoctorCommand:
         """
         from manus_use import cli
 
-        argv = ["manus-use", "doctor"] + (extra_argv or [])
+        argv = ["manus-agent", "doctor"] + (extra_argv or [])
 
         missing = import_side_effects or set()
 
@@ -243,7 +243,7 @@ class TestDoctorCommand:
         # missing API key — env-var config loading could otherwise backfill it.
         env = {k: v for k, v in os.environ.items() if k not in ("OPENAI_API_KEY",) and not k.startswith("MANUS_LLM")}
         with mock.patch.dict(os.environ, env, clear=True):
-            with mock.patch.object(sys, "argv", ["manus-use", "doctor", "--config", str(config_file)]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "doctor", "--config", str(config_file)]):
                 with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
                     with mock.patch("manus_use.cli._check_import", return_value=True):
                         with pytest.raises(SystemExit) as exc_info:
@@ -310,7 +310,7 @@ class TestDoctorCommand:
         # bedrock config with no AWS creds — this should still exit 0.
         env = {k: v for k, v in os.environ.items() if not k.startswith("AWS_") and not k.startswith("MANUS_LLM")}
         with mock.patch.dict(os.environ, env, clear=True):
-            with mock.patch.object(sys, "argv", ["manus-use", "doctor", "--config", str(config_file)]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "doctor", "--config", str(config_file)]):
                 with mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)):
                     with mock.patch("manus_use.cli._check_import", return_value=True):
                         with pytest.raises(SystemExit) as exc_info:
@@ -338,7 +338,7 @@ class TestBackwardCompat:
             captured["task"] = task
             return 0
 
-        with mock.patch.object(sys, "argv", ["manus-use", "hello world"]):
+        with mock.patch.object(sys, "argv", ["manus-agent", "hello world"]):
             with mock.patch.object(cli, "_run_single_shot", side_effect=fake_ss):
                 with mock.patch("manus_use.cli.Config") as m_cfg:
                     m_cfg.from_file.return_value = mock.MagicMock()
@@ -352,7 +352,7 @@ class TestBackwardCompat:
         """No positional task → routes to _run_interactive."""
         from manus_use import cli
 
-        with mock.patch.object(sys, "argv", ["manus-use"]):
+        with mock.patch.object(sys, "argv", ["manus-agent"]):
             with mock.patch.object(cli, "_run_interactive") as m_int:
                 with mock.patch("manus_use.cli.Config") as m_cfg:
                     m_cfg.from_file.return_value = mock.MagicMock()
@@ -364,7 +364,7 @@ class TestBackwardCompat:
         """--version still exits 0 and doesn't need subcommand."""
         from manus_use import cli
 
-        with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+        with mock.patch.object(sys, "argv", ["manus-agent", "--version"]):
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
 

--- a/tests/test_packageability.py
+++ b/tests/test_packageability.py
@@ -2,7 +2,7 @@
 
 These tests guard against ``from src.manus_use.<...>`` imports and module-level
 side-effects (network connections, filesystem mutations) that break the package
-when installed via ``pip install manus-use``.
+when installed via ``pip install manus-agent``.
 
 Background
 ----------

--- a/tests/test_patch_diff.py
+++ b/tests/test_patch_diff.py
@@ -573,7 +573,7 @@ class TestPatchDiffCLI:
 
         with (
             patch("manus_use.tools.get_patch_diff.fetch_and_summarise", return_value=payload),
-            patch("sys.argv", ["manus-use", "patch-diff", "CVE-2024-99999"]),
+            patch("sys.argv", ["manus-agent", "patch-diff", "CVE-2024-99999"]),
             pytest.raises(SystemExit) as exc,
         ):
             cli.main()
@@ -625,4 +625,4 @@ class TestReadmeDocsPatchDiff:
 
     def test_readme_has_patch_diff_example(self):
         readme = self._get_readme()
-        assert "manus-use patch-diff CVE" in readme
+        assert "manus-agent patch-diff CVE" in readme

--- a/tests/test_readme_cli.py
+++ b/tests/test_readme_cli.py
@@ -37,31 +37,31 @@ def _parser_help(build_fn_name: str) -> str:
 
 class TestTopLevelHelp:
     def test_help_exits_zero(self):
-        """`manus-use --help` exits with code 0."""
+        """`manus-agent --help` exits with code 0."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit) as exc_info:
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
         assert exc_info.value.code == 0
 
     def test_help_mentions_task_positional(self, capsys):
-        """`manus-use --help` describes the [task] positional argument."""
+        """`manus-agent --help` describes the [task] positional argument."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
 
         out = capsys.readouterr().out
         assert "task" in out.lower()
 
     def test_help_mentions_subcommands(self, capsys):
-        """`manus-use --help` lists init, doctor, history, and analyze."""
+        """`manus-agent --help` lists init, doctor, history, and analyze."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
 
         out = capsys.readouterr().out
@@ -69,22 +69,22 @@ class TestTopLevelHelp:
             assert sub in out, f"Subcommand '{sub}' not mentioned in --help output"
 
     def test_help_shows_format_flag(self, capsys):
-        """`manus-use --help` documents --format."""
+        """`manus-agent --help` documents --format."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
 
         out = capsys.readouterr().out
         assert "--format" in out
 
     def test_help_shows_no_history_flag(self, capsys):
-        """`manus-use --help` documents --no-history."""
+        """`manus-agent --help` documents --no-history."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--help"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--help"]):
                 cli.main()
 
         out = capsys.readouterr().out
@@ -98,19 +98,19 @@ class TestTopLevelHelp:
 
 class TestInitSubcommand:
     def test_init_parser_has_output_flag(self):
-        """`manus-use init` parser exposes --output."""
+        """`manus-agent init` parser exposes --output."""
         assert "--output" in _parser_help("_build_init_parser")
 
     def test_init_parser_has_force_flag(self):
-        """`manus-use init` parser exposes --force."""
+        """`manus-agent init` parser exposes --force."""
         assert "--force" in _parser_help("_build_init_parser")
 
     def test_init_routing_in_main(self):
-        """`manus-use init` routes to _cmd_init, not the task runner."""
+        """`manus-agent init` routes to _cmd_init, not the task runner."""
         from manus_use import cli  # noqa: PLC0415
 
         with mock.patch.object(cli, "_cmd_init", return_value=0) as m:
-            with mock.patch.object(sys, "argv", ["manus-use", "init"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "init"]):
                 with pytest.raises(SystemExit) as exc_info:
                     cli.main()
 
@@ -118,12 +118,12 @@ class TestInitSubcommand:
         m.assert_called_once()
 
     def test_init_does_not_route_to_single_shot(self):
-        """`manus-use init` must NOT invoke _run_single_shot."""
+        """`manus-agent init` must NOT invoke _run_single_shot."""
         from manus_use import cli  # noqa: PLC0415
 
         with mock.patch.object(cli, "_cmd_init", return_value=0):
             with mock.patch.object(cli, "_run_single_shot") as m_shot:
-                with mock.patch.object(sys, "argv", ["manus-use", "init"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "init"]):
                     with pytest.raises(SystemExit):
                         cli.main()
 
@@ -137,15 +137,15 @@ class TestInitSubcommand:
 
 class TestDoctorSubcommand:
     def test_doctor_parser_has_config_flag(self):
-        """`manus-use doctor` parser exposes --config."""
+        """`manus-agent doctor` parser exposes --config."""
         assert "--config" in _parser_help("_build_doctor_parser")
 
     def test_doctor_routing_in_main(self):
-        """`manus-use doctor` routes to _cmd_doctor."""
+        """`manus-agent doctor` routes to _cmd_doctor."""
         from manus_use import cli  # noqa: PLC0415
 
         with mock.patch.object(cli, "_cmd_doctor", return_value=0) as m:
-            with mock.patch.object(sys, "argv", ["manus-use", "doctor"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "doctor"]):
                 with pytest.raises(SystemExit) as exc_info:
                     cli.main()
 
@@ -153,12 +153,12 @@ class TestDoctorSubcommand:
         m.assert_called_once()
 
     def test_doctor_does_not_route_to_single_shot(self):
-        """`manus-use doctor` must NOT invoke _run_single_shot."""
+        """`manus-agent doctor` must NOT invoke _run_single_shot."""
         from manus_use import cli  # noqa: PLC0415
 
         with mock.patch.object(cli, "_cmd_doctor", return_value=0):
             with mock.patch.object(cli, "_run_single_shot") as m_shot:
-                with mock.patch.object(sys, "argv", ["manus-use", "doctor"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "doctor"]):
                     with pytest.raises(SystemExit):
                         cli.main()
 
@@ -172,19 +172,19 @@ class TestDoctorSubcommand:
 
 class TestAnalyzeSubcommand:
     def test_analyze_parser_has_verify_flag(self):
-        """`manus-use analyze` parser exposes --verify."""
+        """`manus-agent analyze` parser exposes --verify."""
         assert "--verify" in _parser_help("_build_analyze_parser")
 
     def test_analyze_parser_has_output_flag(self):
-        """`manus-use analyze` parser exposes --output."""
+        """`manus-agent analyze` parser exposes --output."""
         assert "--output" in _parser_help("_build_analyze_parser")
 
     def test_analyze_parser_has_config_flag(self):
-        """`manus-use analyze` parser exposes --config."""
+        """`manus-agent analyze` parser exposes --config."""
         assert "--config" in _parser_help("_build_analyze_parser")
 
     def test_analyze_output_choices(self):
-        """`manus-use analyze --output` accepts text, json, and lark."""
+        """`manus-agent analyze --output` accepts text, json, and lark."""
         from manus_use import cli  # noqa: PLC0415
 
         parser = cli._build_analyze_parser()
@@ -193,21 +193,21 @@ class TestAnalyzeSubcommand:
             assert args.output == choice
 
     def test_analyze_verify_defaults_false(self):
-        """`manus-use analyze` has --verify default to False."""
+        """`manus-agent analyze` has --verify default to False."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_analyze_parser().parse_args(["CVE-2025-1234"])
         assert args.verify is False
 
     def test_analyze_output_default_is_text(self):
-        """`manus-use analyze` --output defaults to 'text'."""
+        """`manus-agent analyze` --output defaults to 'text'."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_analyze_parser().parse_args(["CVE-2025-1234"])
         assert args.output == "text"
 
     def test_analyze_cve_id_required(self):
-        """`manus-use analyze` without a CVE-ID exits with code 2."""
+        """`manus-agent analyze` without a CVE-ID exits with code 2."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit) as exc_info:
@@ -215,7 +215,7 @@ class TestAnalyzeSubcommand:
         assert exc_info.value.code == 2
 
     def test_analyze_routing_in_main(self):
-        """`manus-use analyze CVE-...` routes to _run_analyze."""
+        """`manus-agent analyze CVE-...` routes to _run_analyze."""
         from manus_use import cli  # noqa: PLC0415
 
         captured: dict = {}
@@ -227,7 +227,7 @@ class TestAnalyzeSubcommand:
         with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
             with mock.patch("manus_use.cli.Config") as m_cfg:
                 m_cfg.from_file.return_value = mock.MagicMock()
-                with mock.patch.object(sys, "argv", ["manus-use", "analyze", "CVE-2025-6554"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "analyze", "CVE-2025-6554"]):
                     with pytest.raises(SystemExit) as exc_info:
                         cli.main()
 
@@ -236,7 +236,7 @@ class TestAnalyzeSubcommand:
         assert captured["verify"] is False
 
     def test_analyze_verify_flag_forwarded(self):
-        """`manus-use analyze CVE-... --verify` passes verify=True to _run_analyze."""
+        """`manus-agent analyze CVE-... --verify` passes verify=True to _run_analyze."""
         from manus_use import cli  # noqa: PLC0415
 
         captured: dict = {}
@@ -248,14 +248,14 @@ class TestAnalyzeSubcommand:
         with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
             with mock.patch("manus_use.cli.Config") as m_cfg:
                 m_cfg.from_file.return_value = mock.MagicMock()
-                with mock.patch.object(sys, "argv", ["manus-use", "analyze", "CVE-2025-6554", "--verify"]):
+                with mock.patch.object(sys, "argv", ["manus-agent", "analyze", "CVE-2025-6554", "--verify"]):
                     with pytest.raises(SystemExit):
                         cli.main()
 
         assert captured["verify"] is True
 
     def test_analyze_output_json_forwarded(self):
-        """`manus-use analyze CVE-... --output json` passes output='json' to _run_analyze."""
+        """`manus-agent analyze CVE-... --output json` passes output='json' to _run_analyze."""
         from manus_use import cli  # noqa: PLC0415
 
         captured: dict = {}
@@ -270,7 +270,7 @@ class TestAnalyzeSubcommand:
                 with mock.patch.object(
                     sys,
                     "argv",
-                    ["manus-use", "analyze", "CVE-2024-3094", "--output", "json"],
+                    ["manus-agent", "analyze", "CVE-2024-3094", "--output", "json"],
                 ):
                     with pytest.raises(SystemExit):
                         cli.main()
@@ -285,27 +285,27 @@ class TestAnalyzeSubcommand:
 
 class TestHistorySubcommand:
     def test_history_parser_has_limit_flag(self):
-        """`manus-use history` parser exposes --limit."""
+        """`manus-agent history` parser exposes --limit."""
         assert "--limit" in _parser_help("_build_history_parser")
 
     def test_history_parser_has_grep_flag(self):
-        """`manus-use history` parser exposes --grep."""
+        """`manus-agent history` parser exposes --grep."""
         assert "--grep" in _parser_help("_build_history_parser")
 
     def test_history_parser_has_format_flag(self):
-        """`manus-use history` parser exposes --format."""
+        """`manus-agent history` parser exposes --format."""
         assert "--format" in _parser_help("_build_history_parser")
 
     def test_history_parser_has_clear_flag(self):
-        """`manus-use history` parser exposes --clear."""
+        """`manus-agent history` parser exposes --clear."""
         assert "--clear" in _parser_help("_build_history_parser")
 
     def test_history_routing_in_main(self):
-        """`manus-use history` routes to _cmd_history."""
+        """`manus-agent history` routes to _cmd_history."""
         from manus_use import cli  # noqa: PLC0415
 
         with mock.patch.object(cli, "_cmd_history", return_value=0) as m:
-            with mock.patch.object(sys, "argv", ["manus-use", "history"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "history"]):
                 with pytest.raises(SystemExit) as exc_info:
                     cli.main()
 
@@ -313,14 +313,14 @@ class TestHistorySubcommand:
         m.assert_called_once()
 
     def test_history_limit_default(self):
-        """`manus-use history` --limit defaults to 20."""
+        """`manus-agent history` --limit defaults to 20."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_history_parser().parse_args([])
         assert args.limit == 20
 
     def test_history_format_default(self):
-        """`manus-use history` --format defaults to 'text'."""
+        """`manus-agent history` --format defaults to 'text'."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_history_parser().parse_args([])
@@ -334,14 +334,14 @@ class TestHistorySubcommand:
 
 class TestFormatFlag:
     def test_format_json_is_valid(self):
-        """`manus-use task --format json` is accepted by the run parser."""
+        """`manus-agent task --format json` is accepted by the run parser."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_run_parser().parse_args(["some task", "--format", "json"])
         assert args.fmt == "json"
 
     def test_format_text_is_valid(self):
-        """`manus-use task --format text` is accepted by the run parser."""
+        """`manus-agent task --format text` is accepted by the run parser."""
         from manus_use import cli  # noqa: PLC0415
 
         args = cli._build_run_parser().parse_args(["some task", "--format", "text"])
@@ -360,7 +360,7 @@ class TestFormatFlag:
 
         with mock.patch("manus_use.cli.Config") as m_cfg:
             m_cfg.from_file.return_value = mock.MagicMock()
-            with mock.patch.object(sys, "argv", ["manus-use", "--format", "json"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--format", "json"]):
                 with pytest.raises(SystemExit) as exc_info:
                     cli.main()
 
@@ -373,27 +373,27 @@ class TestFormatFlag:
 
 class TestVersionFlag:
     def test_version_exits_zero(self):
-        """`manus-use --version` exits with code 0."""
+        """`manus-agent --version` exits with code 0."""
         from manus_use import cli  # noqa: PLC0415
 
         with pytest.raises(SystemExit) as exc_info:
-            with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--version"]):
                 cli.main()
         assert exc_info.value.code == 0
 
     def test_version_string_matches_package(self, capsys):
-        """`manus-use --version` output contains the installed package version."""
+        """`manus-agent --version` output contains the installed package version."""
         import importlib.metadata  # noqa: PLC0415
 
         from manus_use import cli  # noqa: PLC0415
 
         try:
-            expected = importlib.metadata.version("manus-use")
+            expected = importlib.metadata.version("manus-agent")
         except importlib.metadata.PackageNotFoundError:
             pytest.skip("package not installed in editable mode; skip version check")
 
         with pytest.raises(SystemExit):
-            with mock.patch.object(sys, "argv", ["manus-use", "--version"]):
+            with mock.patch.object(sys, "argv", ["manus-agent", "--version"]):
                 cli.main()
 
         # argparse sends --version to stdout (Python >=3.11) or stderr (<3.11)

--- a/tests/test_remediation_agent.py
+++ b/tests/test_remediation_agent.py
@@ -243,7 +243,7 @@ def test_main_dispatches_remediate_subcommand(monkeypatch):
     """main() routes 'remediate CVE-...' to _run_remediate."""
     from manus_use import cli
 
-    monkeypatch.setattr(sys, "argv", ["manus-use", "remediate", "CVE-2024-3094"])
+    monkeypatch.setattr(sys, "argv", ["manus-agent", "remediate", "CVE-2024-3094"])
 
     with mock.patch("manus_use.cli._run_remediate", return_value=0) as mock_run:
         with pytest.raises(SystemExit) as exc_info:
@@ -260,7 +260,7 @@ def test_main_dispatches_remediate_with_json_flag(monkeypatch):
     """main() passes --output json through to _run_remediate."""
     from manus_use import cli
 
-    monkeypatch.setattr(sys, "argv", ["manus-use", "remediate", "CVE-2024-3094", "--output", "json"])
+    monkeypatch.setattr(sys, "argv", ["manus-agent", "remediate", "CVE-2024-3094", "--output", "json"])
 
     with mock.patch("manus_use.cli._run_remediate", return_value=0) as mock_run:
         with pytest.raises(SystemExit) as exc_info:
@@ -275,7 +275,7 @@ def test_main_remediate_missing_cve_id_exits_nonzero(monkeypatch):
     """main() with 'remediate' but no CVE-ID exits non-zero."""
     from manus_use import cli
 
-    monkeypatch.setattr(sys, "argv", ["manus-use", "remediate"])
+    monkeypatch.setattr(sys, "argv", ["manus-agent", "remediate"])
 
     with pytest.raises(SystemExit) as exc_info:
         cli.main()

--- a/tests/test_search_poc_sources.py
+++ b/tests/test_search_poc_sources.py
@@ -1085,7 +1085,7 @@ class TestCliMainDispatch:
         from manus_use.cli import main
 
         with patch("manus_use.cli._run_poc_search", return_value=0) as mock_run:
-            with patch("sys.argv", ["manus-use", "poc-search", "CVE-2024-3094"]):
+            with patch("sys.argv", ["manus-agent", "poc-search", "CVE-2024-3094"]):
                 with pytest.raises(SystemExit) as exc_info:
                     main()
                 assert exc_info.value.code == 0

--- a/tests/test_variant_agent.py
+++ b/tests/test_variant_agent.py
@@ -316,7 +316,7 @@ def test_main_routes_variants_subcommand():
         captured["argv"] = argv
         return 0
 
-    with mock.patch.object(sys, "argv", ["manus-use", "variants", "CVE-2024-3094"]):
+    with mock.patch.object(sys, "argv", ["manus-agent", "variants", "CVE-2024-3094"]):
         with mock.patch.object(cli, "_run_variants", side_effect=fake_run_variants) as m_rv:
             with pytest.raises(SystemExit) as exc_info:
                 cli.main()
@@ -336,7 +336,7 @@ def test_main_variants_passes_output_flag():
         captured["argv"] = argv
         return 0
 
-    with mock.patch.object(sys, "argv", ["manus-use", "variants", "CVE-2024-3094", "--output", "json"]):
+    with mock.patch.object(sys, "argv", ["manus-agent", "variants", "CVE-2024-3094", "--output", "json"]):
         with mock.patch.object(cli, "_run_variants", side_effect=fake_run_variants):
             with pytest.raises(SystemExit):
                 cli.main()

--- a/tests/test_vd_agent.py
+++ b/tests/test_vd_agent.py
@@ -103,7 +103,7 @@ def test_build_request_normal_mode():
 
 
 def test_discover_help_exits_zero():
-    """`manus-use discover --help` prints help and exits 0."""
+    """`manus-agent discover --help` prints help and exits 0."""
     from manus_use import cli
 
     parser = cli._build_discover_parser()
@@ -113,7 +113,7 @@ def test_discover_help_exits_zero():
 
 
 def test_discover_defaults():
-    """`manus-use discover` with no args has expected defaults."""
+    """`manus-agent discover` with no args has expected defaults."""
     from manus_use import cli
 
     parser = cli._build_discover_parser()
@@ -161,7 +161,7 @@ def test_discover_dry_run_flag():
 
 
 def test_discover_registered_in_main():
-    """`manus-use discover` routes to `_run_discover`, not the task runner."""
+    """`manus-agent discover` routes to `_run_discover`, not the task runner."""
     from manus_use import cli
 
     captured = {}
@@ -171,7 +171,7 @@ def test_discover_registered_in_main():
         return 0
 
     argv = [
-        "manus-use",
+        "manus-agent",
         "discover",
         "--since",
         "2025-06-01",

--- a/tests/test_vi_agent.py
+++ b/tests/test_vi_agent.py
@@ -48,7 +48,7 @@ def test_build_request_enables_verification():
 
 
 def test_analyze_help_exits_zero():
-    """`manus-use analyze --help` prints help and exits 0."""
+    """`manus-agent analyze --help` prints help and exits 0."""
     from manus_use import cli
 
     parser = cli._build_analyze_parser()
@@ -58,7 +58,7 @@ def test_analyze_help_exits_zero():
 
 
 def test_analyze_missing_cve_is_error():
-    """`manus-use analyze` with no CVE produces an argparse error (exit 2)."""
+    """`manus-agent analyze` with no CVE produces an argparse error (exit 2)."""
     from manus_use import cli
 
     parser = cli._build_analyze_parser()
@@ -68,7 +68,7 @@ def test_analyze_missing_cve_is_error():
 
 
 def test_analyze_registered_in_main():
-    """`manus-use analyze CVE-...` routes to _run_analyze, not the task runner."""
+    """`manus-agent analyze CVE-...` routes to _run_analyze, not the task runner."""
     from manus_use import cli
 
     captured = {}
@@ -77,7 +77,7 @@ def test_analyze_registered_in_main():
         captured.update(cve_id=cve_id, verify=verify, output=output)
         return 0
 
-    argv = ["manus-use", "analyze", "CVE-2025-6554", "--verify", "--output", "json"]
+    argv = ["manus-agent", "analyze", "CVE-2025-6554", "--verify", "--output", "json"]
     with mock.patch.object(sys, "argv", argv):
         with mock.patch.object(cli, "_run_analyze", side_effect=fake_run_analyze):
             with mock.patch("manus_use.cli.Config") as m_cfg:


### PR DESCRIPTION
PR #68 was merged before these two commits landed on the branch. This PR contains just the rename changes.

## What changes

- **pyproject.toml**: `name = "manus-agent"`, script entry `manus-agent = "manus_use.cli:main"`, project URLs updated
- **cli.py**: all `prog=` strings, help text, and epilog examples updated to `manus-agent` (82 occurrences total)
- **tests/** (13 files): all `sys.argv` patches updated `"manus-use"` → `"manus-agent"`
- **README.md**: `pip install manus-use` → `pip install manus-agent`, all CLI command examples updated

## Notes
- `~/.manus-use/` config/history directory intentionally left unchanged — renaming that is a separate user-migration decision
- After merging, consider publishing a tombstone `manus-use` PyPI package that depends on `manus-agent`

## Tests
901 passing, ruff clean.