### PR TITLE
fix: rename remaining manus-use refs in docs and scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,8 +2,8 @@
 #
 # Uses PyPI Trusted Publishing (OIDC) — no long-lived API tokens needed.
 # To enable, create a Trusted Publisher on https://pypi.org with:
-#   Owner:    manus-use
-#   Repo:     manus-use
+#   Owner:    manus-agent
+#   Repo:     manus-agent
 #   Workflow: publish.yml
 #   Environment: pypi
 #

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,4 @@
-# Pre-commit hooks for manus-use.
+# Pre-commit hooks for manus-agent.
 #
 # Install:
 #   pip install pre-commit          # already in [dev] deps

--- a/docs/browser-agent-setup.md
+++ b/docs/browser-agent-setup.md
@@ -1,6 +1,6 @@
 # BrowserAgent Setup with browser-use and AWS Bedrock
 
-This guide explains how to use the BrowserAgent with browser-use and AWS Bedrock in manus-use.
+This guide explains how to use the BrowserAgent with browser-use and AWS Bedrock in manus-agent.
 
 ## Prerequisites
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -99,7 +99,7 @@ enabled = true
 
 Run the interactive CLI:
 ```bash
-manus-use
+manus-agent
 ```
 
 Or:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Release helper for manus-use.
+"""Release helper for manus-agent.
 
 Usage
 -----
@@ -429,7 +429,7 @@ def cmd_bump(args: argparse.Namespace) -> int:  # noqa: C901
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="python scripts/release.py",
-        description="manus-use release helper -- bump version, update CHANGELOG, tag.",
+        description="manus-agent release helper -- bump version, update CHANGELOG, tag.",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Examples:\n"

--- a/va_agent.py
+++ b/va_agent.py
@@ -8,8 +8,8 @@ existing ``python va_agent.py CVE-... [--verify]`` and
 
 Prefer the CLI for new workflows::
 
-    manus-use analyze CVE-2024-3094
-    manus-use analyze CVE-2024-3094 --verify
+    manus-agent analyze CVE-2024-3094
+    manus-agent analyze CVE-2024-3094 --verify
 
 The agent runs an 8-step analysis pipeline for each CVE:
 

--- a/variant_analysis_agent.py
+++ b/variant_analysis_agent.py
@@ -6,7 +6,7 @@ The actual implementation lives in :mod:`manus_agent.agents.variant_agent`.
 Usage::
     python variant_analysis_agent.py CVE-2024-3094
 Or via CLI::
-    manus-use variants CVE-2024-3094
+    manus-agent variants CVE-2024-3094
 """
 
 import sys


### PR DESCRIPTION
Catches straggler `manus-use` references missed by the main rename PRs.

## Files changed

- `docs/quick-start.md` — bare `manus-use` CLI invocation → `manus-agent`
- `docs/browser-agent-setup.md` — "in manus-use" → "in manus-agent"
- `scripts/release.py` — module docstring + argparse description
- `va_agent.py` — CLI example comments (`manus-use analyze` → `manus-agent analyze`)
- `variant_analysis_agent.py` — CLI example comment (`manus-use variants` → `manus-agent variants`)

## Tests
901 passing, ruff clean.