### PR TITLE
fix: revert publish.yml Owner to manus-use (GitHub org name, not package name)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,7 +2,7 @@
 #
 # Uses PyPI Trusted Publishing (OIDC) — no long-lived API tokens needed.
 # To enable, create a Trusted Publisher on https://pypi.org with:
-#   Owner:    manus-agent
+#   Owner:    manus-use
 #   Repo:     manus-agent
 #   Workflow: publish.yml
 #   Environment: pypi


### PR DESCRIPTION
The previous rename PR incorrectly changed `Owner: manus-use` → `Owner: manus-agent` in `.github/workflows/publish.yml`.

`manus-use` is the **GitHub org name** (not the package name), so it must stay as-is. Only `Repo: manus-agent` is correct after the repo rename.

```yaml
#   Owner:    manus-use    ← GitHub org, correct
#   Repo:     manus-agent  ← repo name after rename, correct
```

901 tests passing, ruff clean.