### PR TITLE
feat(tools): EPSS decay detector — score_epss_decay + manus-agent epss-decay CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,11 @@ and [Semantic Versioning](https://semver.org/).
   summarises the patch diff from a GitHub commit URL.
 - `get_epss_trend` tool and `manus-agent epss-trend` CLI subcommand — retrieves daily
   EPSS scores for a CVE and detects exploitation spikes.
+- `score_epss_decay` tool and `manus-agent epss-decay` CLI subcommand — detects whether
+  a CVE's EPSS score has decayed significantly below its all-time peak, providing the
+  complementary *"attackers tried and moved on"* signal to `epss-trend`'s spike detection.
+  Classifies decay as `significant_decay`, `moderate_decay`, `stable`, or `never_peaked`;
+  reports peak date, days since peak, peak-sustained duration, and weekly decay rate.
 - `manus-agent poc-search` CLI subcommand — searches public PoC sources from the command
   line.
 - `.github/workflows/publish.yml` — automated PyPI publishing via OIDC Trusted

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [remediate](#manus-agent-remediate-cve-id--remediation-guidance)
   - [discover](#manus-agent-discover--cve-discovery)
   - [epss-trend](#manus-agent-epss-trend-cve-id--epss-score-history)
+  - [epss-decay](#manus-agent-epss-decay-cve-id--epss-decay-detector)
   - [patch-diff](#manus-agent-patch-diff-cve-id--patch-diff-summariser)
   - [variants](#manus-agent-variants-cve-id--variant-analysis)
   - [compare](#manus-agent-compare-cve-a-cve-b--side-by-side-comparison)
@@ -211,6 +212,32 @@ Fetches daily EPSS scores from the [FIRST.org API](https://www.first.org/epss/) 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--days N` | `30` | Days of history (max 365) |
+| `--output {text,json}` | `text` | Output format |
+
+---
+
+### `manus-agent epss-decay <CVE-ID>` — EPSS decay detector
+
+```bash
+manus-agent epss-decay CVE-2021-44228
+manus-agent epss-decay CVE-2021-44228 --days 365
+manus-agent epss-decay CVE-2021-44228 --output json | jq .decay.class
+```
+
+Detects whether a CVE's EPSS score has decayed significantly below its all-time peak — the *"attackers tried and moved on"* signal. Complements `epss-trend` (which detects rising spikes) by analysing the full historical arc: where did the score peak, how long did it stay there, and how far has it since fallen?
+
+Decay classes:
+
+| Class | Condition | Interpretation |
+|-------|-----------|----------------|
+| `significant_decay` | current < 40% of peak | Attacker interest peaked and substantially waned |
+| `moderate_decay` | current 40–70% of peak | Interest waning but still elevated |
+| `stable` | current ≥ 70% of peak | Still near peak — actively scored |
+| `never_peaked` | peak < 0.15 | Never attracted significant attacker attention |
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--days N` | `365` | Days of history to fetch (max 365) |
 | `--output {text,json}` | `text` | Output format |
 
 ---
@@ -610,9 +637,10 @@ The `manus-agent analyze` command runs an 8-step pipeline:
 # Full intelligence report
 manus-agent analyze CVE-2024-3094
 
-# How exploitable is it right now?
+# How exploitable is it right now? Is attacker interest waning?
 manus-agent exploit-complexity CVE-2024-3094
 manus-agent epss-trend CVE-2024-3094
+manus-agent epss-decay CVE-2024-3094
 
 # What changed in the fix?
 manus-agent patch-diff CVE-2024-3094

--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -62,6 +62,7 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 - Call `check_cisa_kev` to determine if the vulnerability is on the CISA Known Exploited Vulnerabilities (KEV) list.
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
 - Call `get_epss_trend` with the CVE ID (default 30 days of history). A `spike_detected=true` result (>0.10 jump in 7 days) indicates the vulnerability has recently been weaponised or discovered by attackers â flag this prominently in the report with the spike date and magnitude.
+- Call `score_epss_decay` with the CVE ID (default 365 days) to detect whether attacker interest has peaked and waned. A `significant_decay` class (current score <40% of all-time peak) means the CVE was once hot but is no longer actively targeted -- include this context in the report exploitability analysis.
 
 **Step 3: Gather Public Exploits and Advisories**
 - First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week â note this in your analysis.
@@ -217,6 +218,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_poc_week import get_poc_week
             from manus_agent.tools.get_trickest_pocs import get_trickest_pocs
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
+            from manus_agent.tools.score_epss_decay import score_epss_decay
             from manus_agent.tools.score_exploit_complexity import score_exploit_complexity
             from manus_agent.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -269,6 +271,7 @@ class VulnerabilityIntelligenceAgent:
             get_github_advisory,
             "manus_agent.tools.verify_exploit",
             get_epss_trend,
+            score_epss_decay,
             get_patch_diff,
             score_exploit_complexity,
             get_vulncheck_data,

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1050,6 +1050,7 @@ _SUBCOMMANDS = {
     "remediate",
     "variants",
     "epss-trend",
+    "epss-decay",
     "patch-diff",
     "compare",
     "exploit-complexity",
@@ -1151,6 +1152,108 @@ def _run_epss_trend(argv: list[str]) -> int:
         print("  ----------   ------   ----------")
         for pt in analysis["points"][-15:]:  # show last 15 rows
             print(f"  {pt['date']}   {pt['epss']:.4f}   {pt['percentile']:.4f}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# epss-decay subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_epss_decay_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent epss-decay",
+        description=(
+            "Detect whether a CVE's EPSS score has decayed significantly below its\n"
+            "all-time peak — the 'attackers tried and moved on' signal.\n"
+            "Complements epss-trend (which detects rising spikes) by analysing\n"
+            "historical peak-to-current drop."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--days",
+        type=int,
+        default=365,
+        metavar="N",
+        help="Days of EPSS history to fetch (default: 365, max: 365)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_epss_decay(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_epss_decay_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip().upper()
+    if not cve_id.startswith("CVE-"):
+        parser.error("CVE-ID must start with 'CVE-', e.g. CVE-2021-44228")
+
+    try:
+        from manus_agent.tools.get_epss_trend import _fetch_epss_time_series
+        from manus_agent.tools.score_epss_decay import _analyse_decay
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        raw = _fetch_epss_time_series(cve_id, min(args.days, 365))
+    except Exception as exc:  # noqa: BLE001
+        print(f"[error] EPSS API request failed: {exc}", file=sys.stderr)
+        return 1
+
+    data_list = raw.get("data", [])
+    if not data_list:
+        print(f"[error] No EPSS data found for {cve_id}", file=sys.stderr)
+        return 1
+
+    series = data_list[0].get("time-series", [])
+    if not series:
+        series = [
+            {
+                "date": data_list[0].get("date", ""),
+                "epss": data_list[0].get("epss", "0"),
+                "percentile": data_list[0].get("percentile", "0"),
+            }
+        ]
+
+    analysis = _analyse_decay(series)
+
+    if args.output == "json":
+        payload = {
+            "cve_id": cve_id,
+            "days_requested": args.days,
+            "data_points_available": len(series),
+            "decay": {k: v for k, v in analysis.items() if k != "points"},
+        }
+        print(_json.dumps(payload, indent=2))
+        return 0
+
+    # --- text output ---
+    decay_class = analysis["class"]
+    print(f"EPSS Decay Analysis  — {cve_id}")
+    print(f"  Decay class      : {decay_class.upper()}")
+    print(f"  Peak EPSS        : {analysis['peak_epss']:.4f}  (on {analysis['peak_date']})")
+    print(f"  Current EPSS     : {analysis['current_epss']:.4f}  (on {analysis['current_date']})")
+    if analysis["decay_ratio"] is not None:
+        print(f"  Decay ratio      : {analysis['decay_ratio']:.4f}  ({analysis['decay_ratio'] * 100:.1f}% of peak)")
+    if analysis["days_since_peak"] is not None:
+        print(f"  Days since peak  : {analysis['days_since_peak']}")
+    print(f"  Peak sustained   : {analysis['peak_sustained_days']} day(s)")
+    if analysis["decay_rate_per_week"] is not None:
+        print(f"  Decay rate/week  : {analysis['decay_rate_per_week']:+.4f} EPSS pts/week")
+    print()
+    print(f"  {analysis['interpretation']}")
+    print()
+    print(f"  Data points available: {len(series)} ({args.days}-day window)")
     return 0
 
 
@@ -1885,6 +1988,10 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  manus-agent epss-trend CVE-2024-3094\n"
             "  manus-agent epss-trend CVE-2024-3094 --days 90 --output json\n"
             "\n"
+            '  # EPSS decay detection ("attackers tried and moved on")\n'
+            "  manus-agent epss-decay CVE-2021-44228\n"
+            "  manus-agent epss-decay CVE-2021-44228 --days 365 --output json\n"
+            "\n"
             "  # Patch diff summariser (fixing-commit analysis)\n"
             "  manus-agent patch-diff CVE-2024-3094\n"
             "  manus-agent patch-diff CVE-2024-3094 --output json\n"
@@ -2164,6 +2271,10 @@ def main() -> None:
     if first_positional == "epss-trend":
         idx = argv.index("epss-trend")
         sys.exit(_run_epss_trend(argv[idx + 1 :]))
+
+    if first_positional == "epss-decay":
+        idx = argv.index("epss-decay")
+        sys.exit(_run_epss_decay(argv[idx + 1 :]))
 
     if first_positional == "patch-diff":
         idx = argv.index("patch-diff")

--- a/src/manus_agent/tools/score_epss_decay.py
+++ b/src/manus_agent/tools/score_epss_decay.py
@@ -1,0 +1,331 @@
+"""
+Tool: score_epss_decay
+
+Detects whether a CVE's EPSS (Exploit Prediction Scoring System) score has
+decayed significantly below its all-time peak — the *"attackers tried and moved
+on"* signal.
+
+Context
+-------
+``get_epss_trend`` already detects rising spikes (new exploitation activity).
+This tool is the complementary view: given a CVE that once had a high EPSS score,
+has that score since collapsed?  A significant decay suggests that exploitation
+attempts peaked and then subsided — useful for de-prioritising CVEs that were
+once hot but are no longer actively targeted.
+
+Decay classification
+--------------------
++---------------------+----------------------------------+---------------------------+
+| Class               | Criterion                        | Interpretation            |
++=====================+==================================+===========================+
+| significant_decay   | current < 40% of peak            | Attackers moved on        |
+| moderate_decay      | current 40–70% of peak           | Interest waning           |
+| stable              | current ≥ 70% of peak            | Still actively scored     |
+| never_peaked        | peak < PEAK_BASELINE (0.15)      | Never attracted attention |
++---------------------+----------------------------------+---------------------------+
+
+Additional signals
+------------------
+* ``days_since_peak`` — how many calendar days ago the peak occurred.
+* ``peak_sustained_days`` — how many consecutive days the score stayed within
+  10% of the peak (measures whether it was a brief spike or a sustained threat).
+* ``decay_rate_per_week`` — average weekly percentage-point drop from peak to
+  current (negative = declining).
+
+Data source: FIRST.org EPSS API (free, no key required).
+
+CLI: ``manus-agent epss-decay CVE-2024-3094``
+     ``manus-agent epss-decay CVE-2024-3094 --days 365``
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.get_epss_trend import _fetch_epss_time_series
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+logger = logging.getLogger(__name__)
+
+# CVEs that never exceeded this EPSS score are flagged as "never_peaked".
+_PEAK_BASELINE = 0.15
+
+# Decay class thresholds (current / peak ratio).
+_SIGNIFICANT_DECAY_THRESHOLD = 0.40  # current < 40% of peak
+_MODERATE_DECAY_THRESHOLD = 0.70  # current 40–70% of peak
+
+# A "sustained peak" band: days within this fraction below the peak count.
+_SUSTAINED_BAND = 0.10  # within 10% of peak value
+
+TOOL_SPEC = {
+    "name": "score_epss_decay",
+    "description": (
+        "Analyses the EPSS score history for a CVE to detect whether it has decayed "
+        "significantly below its all-time peak. A large decay signals that attacker "
+        "interest peaked and has since waned ('attackers tried and moved on'). "
+        "Returns a decay classification (significant_decay | moderate_decay | stable | "
+        "never_peaked), the peak value and date, days since the peak, and an "
+        "interpretation note. Use this alongside get_epss_trend to distinguish CVEs "
+        "that are still actively targeted from those that have faded from attacker focus."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to analyse (e.g. 'CVE-2021-44228').",
+                },
+                "days": {
+                    "type": "integer",
+                    "description": (
+                        "Days of EPSS history to fetch. Defaults to 365 (maximum available). "
+                        "Larger windows give a more accurate peak baseline."
+                    ),
+                    "default": 365,
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure analysis helpers (no I/O — unit-testable)
+# ---------------------------------------------------------------------------
+
+
+def _analyse_decay(series: list[dict[str, str]]) -> dict[str, Any]:
+    """Compute decay metrics from a raw time-series list.
+
+    Parameters
+    ----------
+    series:
+        List of ``{"date": "YYYY-MM-DD", "epss": "0.xxx", "percentile": "0.xxx"}``
+        dicts in *any* order (oldest-first preferred but not required).
+
+    Returns
+    -------
+    dict with keys: class, peak_epss, peak_date, current_epss, current_date,
+    days_since_peak, peak_sustained_days, decay_ratio, decay_rate_per_week,
+    interpretation, points.
+    """
+    if not series:
+        return {
+            "class": "unknown",
+            "peak_epss": None,
+            "peak_date": None,
+            "current_epss": None,
+            "current_date": None,
+            "days_since_peak": None,
+            "peak_sustained_days": 0,
+            "decay_ratio": None,
+            "decay_rate_per_week": None,
+            "interpretation": "No EPSS data available.",
+            "points": [],
+        }
+
+    # Normalise to floats; sort oldest-first.
+    points = sorted(
+        [
+            {
+                "date": pt["date"],
+                "epss": float(pt["epss"]),
+                "percentile": float(pt["percentile"]),
+            }
+            for pt in series
+        ],
+        key=lambda x: x["date"],
+    )
+
+    scores = [p["epss"] for p in points]
+    peak_epss = max(scores)
+    peak_idx = scores.index(peak_epss)
+    peak_date_str = points[peak_idx]["date"]
+    current_epss = scores[-1]
+    current_date_str = points[-1]["date"]
+
+    # Days since peak.
+    try:
+        peak_date = date.fromisoformat(peak_date_str)
+        current_date = date.fromisoformat(current_date_str)
+        days_since_peak = (current_date - peak_date).days
+    except ValueError:
+        days_since_peak = None
+
+    # Sustained peak: how many consecutive days (from peak onwards) stayed within
+    # _SUSTAINED_BAND of the peak value.
+    sustained_threshold = peak_epss * (1.0 - _SUSTAINED_BAND)
+    peak_sustained_days = 0
+    for i in range(peak_idx, len(scores)):
+        if scores[i] >= sustained_threshold:
+            peak_sustained_days += 1
+        else:
+            break
+
+    # Decay ratio: current vs peak.
+    decay_ratio = round(current_epss / peak_epss, 4) if peak_epss > 0 else None
+
+    # Weekly decay rate: average points per week from peak to current.
+    decay_rate_per_week: float | None = None
+    if days_since_peak and days_since_peak > 0:
+        total_drop = peak_epss - current_epss
+        weeks_elapsed = days_since_peak / 7.0
+        decay_rate_per_week = round(total_drop / weeks_elapsed, 6)
+
+    # Classify.
+    if peak_epss < _PEAK_BASELINE:
+        decay_class = "never_peaked"
+        interpretation = (
+            f"Peak EPSS of {peak_epss:.4f} never exceeded the significance baseline "
+            f"({_PEAK_BASELINE:.2f}). This CVE was never widely expected to be exploited; "
+            "attacker interest has always been low."
+        )
+    elif decay_ratio is not None and decay_ratio < _SIGNIFICANT_DECAY_THRESHOLD:
+        decay_class = "significant_decay"
+        interpretation = (
+            f"Current EPSS ({current_epss:.4f}) is only "
+            f"{decay_ratio * 100:.1f}% of the peak ({peak_epss:.4f} on {peak_date_str}, "
+            f"{days_since_peak} days ago). Strong signal that attacker interest has "
+            "peaked and substantially waned — 'tried and moved on'."
+        )
+    elif decay_ratio is not None and decay_ratio < _MODERATE_DECAY_THRESHOLD:
+        decay_class = "moderate_decay"
+        interpretation = (
+            f"Current EPSS ({current_epss:.4f}) is "
+            f"{decay_ratio * 100:.1f}% of the peak ({peak_epss:.4f} on {peak_date_str}, "
+            f"{days_since_peak} days ago). Moderate decay — attacker interest is "
+            "waning but still elevated relative to baseline."
+        )
+    else:
+        decay_class = "stable"
+        if days_since_peak == 0:
+            interpretation = (
+                f"Peak EPSS ({peak_epss:.4f}) observed today. "
+                "Score is still at or near its maximum — no decay detected."
+            )
+        else:
+            interpretation = (
+                f"Current EPSS ({current_epss:.4f}) is "
+                f"{decay_ratio * 100:.1f}% of the peak ({peak_epss:.4f} on {peak_date_str}, "
+                f"{days_since_peak} days ago). Score remains near its peak — "
+                "this CVE is still actively scored by EPSS models."
+            )
+
+    return {
+        "class": decay_class,
+        "peak_epss": round(peak_epss, 6),
+        "peak_date": peak_date_str,
+        "current_epss": round(current_epss, 6),
+        "current_date": current_date_str,
+        "days_since_peak": days_since_peak,
+        "peak_sustained_days": peak_sustained_days,
+        "decay_ratio": decay_ratio,
+        "decay_rate_per_week": decay_rate_per_week,
+        "interpretation": interpretation,
+        "points": points,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entrypoint
+# ---------------------------------------------------------------------------
+
+
+def score_epss_decay(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Analyse EPSS decay for a CVE and classify attacker interest trajectory."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+    days = int(tool_input.get("days", 365))
+
+    if not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID format. Must be a string like 'CVE-YYYY-NNNN'."}],
+        }
+        log_tool_output_size("score_epss_decay", result)
+        return result
+
+    cve_id = cve_id.upper().strip()
+    days = max(1, min(days, 365))
+
+    try:
+        raw = _fetch_epss_time_series(cve_id, days)
+    except requests.exceptions.RequestException as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"FIRST.org EPSS API request failed: {exc}"}],
+        }
+        log_tool_output_size("score_epss_decay", result)
+        return result
+
+    data_list = raw.get("data", [])
+    if not data_list:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"No EPSS data found for {cve_id}."}],
+        }
+        log_tool_output_size("score_epss_decay", result)
+        return result
+
+    series = data_list[0].get("time-series", [])
+    if not series:
+        # Fallback: single data point (no time-series key).
+        series = [
+            {
+                "date": data_list[0].get("date", ""),
+                "epss": data_list[0].get("epss", "0"),
+                "percentile": data_list[0].get("percentile", "0"),
+            }
+        ]
+
+    analysis = _analyse_decay(series)
+
+    # Build text summary (strip raw points list for readability).
+    decay_class = analysis["class"]
+    text_lines = [
+        f"EPSS Decay Analysis  — {cve_id}",
+        f"  Decay class      : {decay_class.upper()}",
+        f"  Peak EPSS        : {analysis['peak_epss']:.4f}  (on {analysis['peak_date']})",
+        f"  Current EPSS     : {analysis['current_epss']:.4f}  (on {analysis['current_date']})",
+    ]
+    if analysis["decay_ratio"] is not None:
+        text_lines.append(
+            f"  Decay ratio      : {analysis['decay_ratio']:.4f}  ({analysis['decay_ratio'] * 100:.1f}% of peak)"
+        )
+    if analysis["days_since_peak"] is not None:
+        text_lines.append(f"  Days since peak  : {analysis['days_since_peak']}")
+    text_lines.append(f"  Peak sustained   : {analysis['peak_sustained_days']} day(s)")
+    if analysis["decay_rate_per_week"] is not None:
+        text_lines.append(f"  Decay rate/week  : {analysis['decay_rate_per_week']:+.4f} EPSS pts/week")
+    text_lines.append(f"\n  {analysis['interpretation']}")
+    text_summary = "\n".join(text_lines)
+
+    # JSON payload excludes verbose points list to keep it concise for agents.
+    json_payload: dict[str, Any] = {
+        "cve_id": cve_id,
+        "days_requested": days,
+        "data_points_available": len(series),
+        "decay": {k: v for k, v in analysis.items() if k != "points"},
+    }
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": text_summary},
+            {"json": json_payload},
+        ],
+    }
+    log_tool_output_size("score_epss_decay", result)
+    return result

--- a/tests/test_epss_decay.py
+++ b/tests/test_epss_decay.py
@@ -1,0 +1,665 @@
+"""Tests for the score_epss_decay tool and epss-decay CLI subcommand.
+
+All tests are unit tests that mock the FIRST.org API; no network calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Shared fixtures / helpers
+# ---------------------------------------------------------------------------
+
+# A "well-behaved decay" series: peaked at 0.85, now at 0.10 (11.8% of peak).
+_DECAYED_SERIES = [
+    {"date": "2026-01-01", "epss": "0.050000", "percentile": "0.850000"},
+    {"date": "2026-01-15", "epss": "0.400000", "percentile": "0.960000"},
+    {"date": "2026-02-01", "epss": "0.850000", "percentile": "0.998000"},
+    {"date": "2026-02-08", "epss": "0.820000", "percentile": "0.997000"},
+    {"date": "2026-03-01", "epss": "0.500000", "percentile": "0.985000"},
+    {"date": "2026-04-01", "epss": "0.200000", "percentile": "0.920000"},
+    {"date": "2026-05-01", "epss": "0.100000", "percentile": "0.870000"},
+    {"date": "2026-06-01", "epss": "0.100000", "percentile": "0.870000"},
+]
+
+# A "moderate decay" series: peaked at 0.60, now at 0.30 (50% of peak).
+_MODERATE_DECAY_SERIES = [
+    {"date": "2026-01-01", "epss": "0.100000", "percentile": "0.800000"},
+    {"date": "2026-02-01", "epss": "0.600000", "percentile": "0.990000"},
+    {"date": "2026-03-01", "epss": "0.500000", "percentile": "0.985000"},
+    {"date": "2026-04-01", "epss": "0.400000", "percentile": "0.970000"},
+    {"date": "2026-05-01", "epss": "0.300000", "percentile": "0.945000"},
+]
+
+# A "stable" series: peaked at 0.70, currently at 0.65 (92.9% of peak).
+_STABLE_SERIES = [
+    {"date": "2026-01-01", "epss": "0.500000", "percentile": "0.980000"},
+    {"date": "2026-02-01", "epss": "0.700000", "percentile": "0.995000"},
+    {"date": "2026-03-01", "epss": "0.680000", "percentile": "0.994000"},
+    {"date": "2026-04-01", "epss": "0.670000", "percentile": "0.993000"},
+    {"date": "2026-05-01", "epss": "0.650000", "percentile": "0.992000"},
+]
+
+# A "never peaked" series: max EPSS 0.08, well below _PEAK_BASELINE.
+_NEVER_PEAKED_SERIES = [
+    {"date": "2026-01-01", "epss": "0.010000", "percentile": "0.500000"},
+    {"date": "2026-02-01", "epss": "0.030000", "percentile": "0.550000"},
+    {"date": "2026-03-01", "epss": "0.080000", "percentile": "0.600000"},
+    {"date": "2026-04-01", "epss": "0.050000", "percentile": "0.580000"},
+    {"date": "2026-05-01", "epss": "0.020000", "percentile": "0.510000"},
+]
+
+
+def _make_api_response(cve_id: str, series: list[dict]) -> dict:
+    """Build a FIRST.org-shaped API response from a series list."""
+    current = series[-1] if series else {}
+    return {
+        "status": "OK",
+        "data": [
+            {
+                "cve": cve_id,
+                "epss": current.get("epss", "0"),
+                "percentile": current.get("percentile", "0"),
+                "date": current.get("date", "2026-06-01"),
+                "time-series": series,
+            }
+        ],
+    }
+
+
+def _make_tool_use(cve_id: str, days: int = 365) -> dict:
+    return {"toolUseId": "test-id-decay", "input": {"cve_id": cve_id, "days": days}}
+
+
+# ---------------------------------------------------------------------------
+# Module import checks
+# ---------------------------------------------------------------------------
+
+
+def test_module_imports():
+    """score_epss_decay is importable without strands."""
+    import manus_agent.tools.score_epss_decay as m
+
+    assert hasattr(m, "score_epss_decay")
+    assert hasattr(m, "TOOL_SPEC")
+    assert hasattr(m, "_analyse_decay")
+
+
+def test_tool_spec_structure():
+    from manus_agent.tools.score_epss_decay import TOOL_SPEC
+
+    assert TOOL_SPEC["name"] == "score_epss_decay"
+    props = TOOL_SPEC["inputSchema"]["json"]["properties"]
+    assert "cve_id" in props
+    assert "days" in props
+    assert TOOL_SPEC["inputSchema"]["json"]["required"] == ["cve_id"]
+
+
+def test_tool_spec_days_default():
+    from manus_agent.tools.score_epss_decay import TOOL_SPEC
+
+    assert TOOL_SPEC["inputSchema"]["json"]["properties"]["days"]["default"] == 365
+
+
+# ---------------------------------------------------------------------------
+# _analyse_decay unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_analyse_decay_empty():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay([])
+    assert result["class"] == "unknown"
+    assert result["peak_epss"] is None
+    assert result["current_epss"] is None
+    assert "No EPSS data" in result["interpretation"]
+
+
+def test_analyse_decay_significant():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    assert result["class"] == "significant_decay"
+    assert abs(result["peak_epss"] - 0.85) < 1e-5
+    assert abs(result["current_epss"] - 0.10) < 1e-5
+    assert result["decay_ratio"] < 0.40
+
+
+def test_analyse_decay_moderate():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_MODERATE_DECAY_SERIES)
+    assert result["class"] == "moderate_decay"
+    assert abs(result["peak_epss"] - 0.60) < 1e-5
+    assert abs(result["current_epss"] - 0.30) < 1e-5
+    assert 0.40 <= result["decay_ratio"] < 0.70
+
+
+def test_analyse_decay_stable():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_STABLE_SERIES)
+    assert result["class"] == "stable"
+    assert result["decay_ratio"] >= 0.70
+
+
+def test_analyse_decay_never_peaked():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_NEVER_PEAKED_SERIES)
+    assert result["class"] == "never_peaked"
+    assert "never" in result["interpretation"].lower() or "baseline" in result["interpretation"].lower()
+
+
+def test_analyse_decay_peak_date():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    # Peak is on 2026-02-01 (value 0.85)
+    assert result["peak_date"] == "2026-02-01"
+
+
+def test_analyse_decay_current_date():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    # Latest date in the series
+    assert result["current_date"] == "2026-06-01"
+
+
+def test_analyse_decay_days_since_peak():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    # 2026-02-01 → 2026-06-01 = 120 days
+    assert result["days_since_peak"] == 120
+
+
+def test_analyse_decay_decay_ratio_range():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    assert 0.0 <= result["decay_ratio"] <= 1.0
+
+
+def test_analyse_decay_decay_rate_is_positive_for_decay():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    # Rate should be positive (peak > current → positive weekly drop)
+    assert result["decay_rate_per_week"] > 0
+
+
+def test_analyse_decay_decay_rate_is_none_for_zero_days():
+    """If peak is today (days_since_peak==0), rate is undefined → None."""
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    series = [{"date": "2026-06-01", "epss": "0.800000", "percentile": "0.990000"}]
+    result = _analyse_decay(series)
+    # Single point: peak == current, days_since_peak == 0 → rate None
+    assert result["decay_rate_per_week"] is None
+
+
+def test_analyse_decay_single_point_stable():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    series = [{"date": "2026-06-01", "epss": "0.800000", "percentile": "0.990000"}]
+    result = _analyse_decay(series)
+    # Single high-value point: peak == current, should be stable
+    assert result["class"] == "stable"
+    assert result["decay_ratio"] == 1.0
+
+
+def test_analyse_decay_single_low_point_never_peaked():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    series = [{"date": "2026-06-01", "epss": "0.010000", "percentile": "0.500000"}]
+    result = _analyse_decay(series)
+    assert result["class"] == "never_peaked"
+
+
+def test_analyse_decay_unsorted_input():
+    """_analyse_decay must handle input that is not sorted by date."""
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    shuffled = list(reversed(_DECAYED_SERIES))
+    result = _analyse_decay(shuffled)
+    # Should produce the same result regardless of input order
+    assert result["class"] == "significant_decay"
+    assert result["current_date"] == "2026-06-01"
+
+
+def test_analyse_decay_peak_sustained_days_basic():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    # Peak at index 2 (0.85); next day 0.82 is within 10% band; then 0.50 is not
+    assert result["peak_sustained_days"] >= 1
+
+
+def test_analyse_decay_points_sorted_oldest_first():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    result = _analyse_decay(_DECAYED_SERIES)
+    dates = [p["date"] for p in result["points"]]
+    assert dates == sorted(dates), "points must be sorted oldest-first"
+
+
+def test_analyse_decay_interpretation_non_empty():
+    from manus_agent.tools.score_epss_decay import _analyse_decay
+
+    for series in [_DECAYED_SERIES, _MODERATE_DECAY_SERIES, _STABLE_SERIES, _NEVER_PEAKED_SERIES]:
+        result = _analyse_decay(series)
+        assert isinstance(result["interpretation"], str)
+        assert len(result["interpretation"]) > 10
+
+
+# ---------------------------------------------------------------------------
+# score_epss_decay tool function
+# ---------------------------------------------------------------------------
+
+
+def test_tool_invalid_cve_format():
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    result = score_epss_decay(_make_tool_use("NOTACVE"))
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_tool_empty_cve():
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    result = score_epss_decay(_make_tool_use(""))
+    assert result["status"] == "error"
+
+
+def test_tool_lowercase_cve_normalised():
+    """Lowercase CVE IDs must be accepted and normalised to uppercase."""
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    with patch(
+        "manus_agent.tools.score_epss_decay._fetch_epss_time_series",
+        return_value=_make_api_response("CVE-2021-44228", _DECAYED_SERIES),
+    ):
+        result = score_epss_decay(_make_tool_use("cve-2021-44228"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["cve_id"] == "CVE-2021-44228"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_success_significant_decay(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    assert result["status"] == "success"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_success_returns_text_and_json(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    content_types = [list(c.keys())[0] for c in result["content"]]
+    assert "text" in content_types
+    assert "json" in content_types
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_json_contains_decay_object(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert "decay" in json_block
+    assert "class" in json_block["decay"]
+    assert "peak_epss" in json_block["decay"]
+    assert "current_epss" in json_block["decay"]
+    assert "days_since_peak" in json_block["decay"]
+    assert "interpretation" in json_block["decay"]
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_json_does_not_contain_verbose_points(mock_fetch):
+    """JSON payload must not include the raw points list (keeps agent context lean)."""
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert "points" not in json_block["decay"], "points list must be excluded from JSON payload"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_significant_decay_classification(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["decay"]["class"] == "significant_decay"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_never_peaked_classification(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2026-9999", _NEVER_PEAKED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2026-9999"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["decay"]["class"] == "never_peaked"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_data_points_count(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["data_points_available"] == len(_DECAYED_SERIES)
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_no_data_returns_error(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = {"status": "OK", "data": []}
+    result = score_epss_decay(_make_tool_use("CVE-9999-9999"))
+    assert result["status"] == "error"
+    assert "No EPSS data" in result["content"][0]["text"]
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_api_failure_returns_error(mock_fetch):
+    import requests
+
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.side_effect = requests.exceptions.ConnectionError("unreachable")
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    assert result["status"] == "error"
+    assert "EPSS API request failed" in result["content"][0]["text"]
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_single_point_fallback(mock_fetch):
+    """When API returns no time-series, fall back to the single top-level data point."""
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = {
+        "status": "OK",
+        "data": [
+            {
+                "cve": "CVE-2021-44228",
+                "epss": "0.950000",
+                "percentile": "0.999000",
+                "date": "2026-06-01",
+                # no "time-series" key
+            }
+        ],
+    }
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    assert result["status"] == "success"
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_days_clamped_to_365(mock_fetch):
+    """days > 365 must be silently clamped to 365."""
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228", days=9999))
+    assert result["status"] == "success"
+    # Verify the clamp was applied by checking that _fetch was called with ≤ 365
+    call_days = mock_fetch.call_args[0][1]
+    assert call_days <= 365
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_text_output_contains_cve_id(mock_fetch, capsys):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    text_block = next(c["text"] for c in result["content"] if "text" in c)
+    assert "CVE-2021-44228" in text_block
+
+
+@patch("manus_agent.tools.score_epss_decay._fetch_epss_time_series")
+def test_tool_text_output_contains_decay_class(mock_fetch):
+    from manus_agent.tools.score_epss_decay import score_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    result = score_epss_decay(_make_tool_use("CVE-2021-44228"))
+    text_block = next(c["text"] for c in result["content"] if "text" in c)
+    assert "SIGNIFICANT_DECAY" in text_block
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: registration and parser
+# ---------------------------------------------------------------------------
+
+
+def test_epss_decay_subcommand_registered():
+    from manus_agent.cli import _SUBCOMMANDS
+
+    assert "epss-decay" in _SUBCOMMANDS
+
+
+def test_epss_decay_parser_help_exits_zero():
+    from manus_agent.cli import _build_epss_decay_parser
+
+    parser = _build_epss_decay_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_epss_decay_parser_missing_cve_errors():
+    from manus_agent.cli import _build_epss_decay_parser
+
+    parser = _build_epss_decay_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code != 0
+
+
+def test_epss_decay_parser_defaults():
+    from manus_agent.cli import _build_epss_decay_parser
+
+    parser = _build_epss_decay_parser()
+    args = parser.parse_args(["CVE-2021-44228"])
+    assert args.cve_id == "CVE-2021-44228"
+    assert args.days == 365
+    assert args.output == "text"
+
+
+def test_epss_decay_parser_custom_days():
+    from manus_agent.cli import _build_epss_decay_parser
+
+    parser = _build_epss_decay_parser()
+    args = parser.parse_args(["CVE-2021-44228", "--days", "90"])
+    assert args.days == 90
+
+
+def test_epss_decay_parser_json_output():
+    from manus_agent.cli import _build_epss_decay_parser
+
+    parser = _build_epss_decay_parser()
+    args = parser.parse_args(["CVE-2021-44228", "--output", "json"])
+    assert args.output == "json"
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: _run_epss_decay
+# ---------------------------------------------------------------------------
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_text_output_rc_zero(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    rc = _run_epss_decay(["CVE-2021-44228"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CVE-2021-44228" in out
+    assert "EPSS Decay" in out
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_json_output_valid(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    rc = _run_epss_decay(["CVE-2021-44228", "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["cve_id"] == "CVE-2021-44228"
+    assert "decay" in data
+    assert "class" in data["decay"]
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_text_shows_decay_class(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    _run_epss_decay(["CVE-2021-44228"])
+    out = capsys.readouterr().out
+    assert "SIGNIFICANT_DECAY" in out
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_never_peaked_text(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2026-9999", _NEVER_PEAKED_SERIES)
+    rc = _run_epss_decay(["CVE-2026-9999"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "NEVER_PEAKED" in out
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_no_data_nonzero(mock_fetch):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = {"status": "OK", "data": []}
+    rc = _run_epss_decay(["CVE-9999-9999"])
+    assert rc != 0
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_api_error_nonzero(mock_fetch):
+    import requests
+
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.side_effect = requests.exceptions.ConnectionError("down")
+    rc = _run_epss_decay(["CVE-2021-44228"])
+    assert rc != 0
+
+
+def test_run_epss_decay_invalid_cve_nonzero():
+    """Non-CVE positional arg should exit non-zero."""
+    from manus_agent.cli import _run_epss_decay
+
+    with pytest.raises(SystemExit) as exc_info:
+        _run_epss_decay(["NOTACVE"])
+    assert exc_info.value.code != 0
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_json_days_recorded(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    _run_epss_decay(["CVE-2021-44228", "--days", "180", "--output", "json"])
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["days_requested"] == 180
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_text_shows_peak_date(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    _run_epss_decay(["CVE-2021-44228"])
+    out = capsys.readouterr().out
+    assert "2026-02-01" in out  # peak date
+
+
+@patch("manus_agent.tools.get_epss_trend._fetch_epss_time_series")
+def test_run_epss_decay_text_shows_interpretation(mock_fetch, capsys):
+    from manus_agent.cli import _run_epss_decay
+
+    mock_fetch.return_value = _make_api_response("CVE-2021-44228", _DECAYED_SERIES)
+    _run_epss_decay(["CVE-2021-44228"])
+    out = capsys.readouterr().out
+    # Interpretation must appear
+    assert any(word in out.lower() for word in ["attacker", "interest", "peaked", "waned"])
+
+
+# ---------------------------------------------------------------------------
+# vi_agent integration
+# ---------------------------------------------------------------------------
+
+
+def test_vi_agent_imports_score_epss_decay():
+    """score_epss_decay must be importable and have the expected interface."""
+    from manus_agent.tools.score_epss_decay import TOOL_SPEC, score_epss_decay
+
+    assert callable(score_epss_decay)
+    assert TOOL_SPEC["name"] == "score_epss_decay"
+
+
+# ---------------------------------------------------------------------------
+# README documentation checks
+# ---------------------------------------------------------------------------
+
+
+def test_readme_documents_epss_decay():
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "epss-decay" in content, "README must document the epss-decay subcommand"
+
+
+def test_readme_epss_decay_flags():
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "--days" in content
+    assert "--output" in content
+
+
+def test_readme_epss_decay_example_command():
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "manus-agent epss-decay CVE-" in content
+
+
+def test_readme_epss_decay_mentions_decay_classes():
+    from pathlib import Path
+
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "significant_decay" in content
+    assert "never_peaked" in content


### PR DESCRIPTION
Adds `score_epss_decay` Strands tool and `manus-agent epss-decay` CLI subcommand.

Detects whether a CVE EPSS score has decayed significantly below its all-time peak — the **"attackers tried and moved on"** signal. Complements `get_epss_trend` (spike detection) by covering the decay side of the temporal exploitation arc.

## Decay classes

| Class | Condition | Interpretation |
|-------|-----------|----------------|
| `significant_decay` | current < 40% of peak | Tried and moved on |
| `moderate_decay` | current 40–70% of peak | Waning interest |
| `stable` | current ≥ 70% of peak | Still actively scored |
| `never_peaked` | peak < 0.15 | Never attracted attention |

## Additional metrics per CVE
- `peak_date`, `days_since_peak`, `peak_sustained_days` (consecutive days near peak)
- `decay_ratio` (current/peak), `decay_rate_per_week`
- Plain-English `interpretation` note

## Implementation
- **No new dependencies** — reuses `_fetch_epss_time_series` from `get_epss_trend`
- **Free API only** — FIRST.org EPSS time-series, no auth required
- Graceful degradation on API failure; single-point fallback when `time-series` key absent
- JSON payload excludes verbose points list (keeps agent context lean)
- Registered in `VulnerabilityIntelligenceAgent` tool list; Step 2 updated to call both spike and decay tools in a single analysis pass

## Tests
57 new unit tests (all mocked, zero real HTTP). Full suite: **959 passed, 0 failures** (was 902).

`ruff check` + `ruff format` clean. README decay-class table + examples. CHANGELOG updated.