### PR TITLE
feat(tools): exploit maturity classifier — classify_exploit_maturity + manus-agent exploit-maturity CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -63,6 +63,7 @@ Your process is optimized to build a comprehensive picture from authoritative, f
 - Call `get_otx_cve_details` to check for threat intelligence information from AlienVault OTX, such as associated pulses and IoCs.
 - Call `get_epss_trend` with the CVE ID (default 30 days of history). A `spike_detected=true` result (>0.10 jump in 7 days) indicates the vulnerability has recently been weaponised or discovered by attackers â flag this prominently in the report with the spike date and magnitude.
 
+- Call `classify_exploit_maturity` with the CVE ID. This synthesises CISA KEV, VulnCheck KEV, EPSS, and trickest/cve PoC data into a single **exploitation maturity verdict** (`EXPLOITED_IN_WILD` / `WEAPONIZED` / `POC_PUBLIC` / `POC_PRIVATE` / `THEORETICAL`). Include this verdict prominently near the top of your report — it is the single most useful signal for prioritisation.
 **Step 3: Gather Public Exploits and Advisories**
 - First, call `get_poc_week` (no arguments) to check if the CVE appears in recent PoC Week digests. A high mention_rank (low number) means the security community considers it high-priority this week â note this in your analysis.
 - Then call `get_trickest_pocs` with the CVE ID for a fast pre-flight lookup against the trickest/cve index (250k+ CVEs, updated daily).
@@ -210,6 +211,7 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_agent.tools.classify_exploit_maturity import classify_exploit_maturity
             from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_agent.tools.get_epss_trend import get_epss_trend
             from manus_agent.tools.get_github_advisory import get_github_advisory
@@ -274,6 +276,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            classify_exploit_maturity,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "exploit-maturity",
 }
 
 
@@ -1974,6 +1975,141 @@ def _build_run_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# ---------------------------------------------------------------------------
+# exploit-maturity subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_exploit_maturity_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent exploit-maturity",
+        description=(
+            "Classify the exploitation maturity of a CVE using multiple\n"
+            "intelligence sources (CISA KEV, VulnCheck KEV, EPSS, trickest/cve, NVD).\n\n"
+            "Verdict tiers (highest → lowest):\n"
+            "  EXPLOITED_IN_WILD  — confirmed active exploitation (KEV listed)\n"
+            "  WEAPONIZED         — weaponised exploit or EPSS ≥ 50%\n"
+            "  POC_PUBLIC         — public PoC exists\n"
+            "  POC_PRIVATE        — EPSS ≥ 20%, private capability likely\n"
+            "  THEORETICAL        — no exploitation evidence\n"
+        ),
+        add_help=True,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument(
+        "cve_id",
+        metavar="CVE_ID",
+        help="CVE identifier to classify (e.g., CVE-2021-44228)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_exploit_maturity(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_exploit_maturity_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.classify_exploit_maturity import (
+            TIER_EXPLOITED_IN_WILD,
+            TIER_POC_PRIVATE,
+            TIER_POC_PUBLIC,
+            TIER_THEORETICAL,
+            TIER_WEAPONIZED,
+            _check_cisa_kev,
+            _check_trickest,
+            _check_vulncheck_kev,
+            _classify,
+            _fetch_epss,
+            _fetch_nvd_meta,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    cve_id = args.cve_id.strip().upper()
+
+    import re
+
+    if not re.match(r"^CVE-\d{4}-\d+$", cve_id, re.IGNORECASE):
+        print(f"Error: '{cve_id}' is not a valid CVE ID. Expected: CVE-YYYY-NNNNN", file=sys.stderr)
+        return 1
+
+    cisa = _check_cisa_kev(cve_id)
+    vulncheck = _check_vulncheck_kev(cve_id)
+    epss = _fetch_epss(cve_id)
+    trickest = _check_trickest(cve_id)
+    nvd_meta = _fetch_nvd_meta(cve_id)
+
+    tier, evidence = _classify(cisa, vulncheck, epss, trickest)
+
+    if args.output == "json":
+        result = {
+            "cve_id": cve_id,
+            "maturity_tier": tier,
+            "evidence": evidence,
+            "sources": {
+                "cisa_kev": cisa,
+                "vulncheck_kev": vulncheck,
+                "epss": epss,
+                "trickest": trickest,
+                "nvd": nvd_meta,
+            },
+        }
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    # Text output
+    tier_icon = {
+        TIER_EXPLOITED_IN_WILD: "🔴 CRITICAL",
+        TIER_WEAPONIZED: "🟠 HIGH",
+        TIER_POC_PUBLIC: "🟡 MEDIUM",
+        TIER_POC_PRIVATE: "🔵 LOW-MEDIUM",
+        TIER_THEORETICAL: "⚪ LOW",
+    }
+    icon = tier_icon.get(tier, tier)
+    print(f"Exploit Maturity Classification — {cve_id}")
+    print("=" * 52)
+    print(f"\nVerdict:  {tier}  {icon}")
+    print()
+    print("Evidence:")
+    for item in evidence:
+        print(f"  • {item}")
+    print()
+    print("CVE Metadata:")
+    if nvd_meta.get("published_date"):
+        print(f"  Published:    {nvd_meta['published_date']}")
+    if nvd_meta.get("cvss_score") is not None:
+        print(
+            f"  CVSS {nvd_meta.get('cvss_version', '')}:     {nvd_meta['cvss_score']} ({nvd_meta.get('cvss_severity', '')})"
+        )
+    if nvd_meta.get("cwes"):
+        print(f"  CWE:          {', '.join(nvd_meta['cwes'])}")
+    print()
+    print("Source coverage:")
+    print(f"  CISA KEV:       {'✓ checked' if 'in_cisa_kev' in cisa else '✗ unavailable'}")
+    if vulncheck.get("available") is False:
+        print("  VulnCheck KEV:  ✗ no API key (set VULNCHECK_API_KEY)")
+    else:
+        print(f"  VulnCheck KEV:  {'✓ checked' if vulncheck else '✗ unavailable'}")
+    epss_score = epss.get("epss_score")
+    print(f"  EPSS (FIRST):   {'✓ ' + str(round(epss_score, 4)) if epss_score is not None else '✗ unavailable'}")
+    print(
+        f"  trickest/cve:   {'✓ ' + str(trickest.get('poc_count', 0)) + ' PoC(s)' if trickest.get('trickest_available') else '✗ unavailable'}"
+    )
+    print(
+        f"  NVD CVSS:       {'✓ CVSS ' + str(nvd_meta.get('cvss_score', '')) if nvd_meta.get('cvss_score') else '✗ unavailable'}"
+    )
+    return 0
+
+
 def _build_init_parser() -> argparse.ArgumentParser:
     """Build the `init` subcommand parser."""
     parser = argparse.ArgumentParser(
@@ -2188,6 +2324,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "exploit-maturity":
+        idx = argv.index("exploit-maturity")
+        sys.exit(_run_exploit_maturity(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/classify_exploit_maturity.py
+++ b/src/manus_agent/tools/classify_exploit_maturity.py
@@ -1,0 +1,565 @@
+"""
+Tool: classify_exploit_maturity
+
+Synthesises signals from multiple intelligence sources into a single, ranked
+**exploitation maturity tier** for a CVE.
+
+Analysts currently have to call 4-5 tools and manually reconcile conflicting
+signals.  This tool does that synthesis automatically, returning one verdict:
+
+    EXPLOITED_IN_WILD   Active confirmed exploitation (CISA KEV, VulnCheck KEV,
+                        ransomware campaigns, or strong TI consensus)
+    WEAPONIZED          PoC has been weaponised into a ready-to-use exploit tool
+                        or metasploit module, but no confirmed ITW exploitation
+    POC_PUBLIC          At least one public proof-of-concept exists
+    POC_PRIVATE         No public PoC, but EPSS ≥ 0.20 suggesting private
+                        capability likely exists
+    THEORETICAL         No evidence of any exploitation or PoC
+
+Each tier includes the evidence bundle that produced it, so the LLM can
+explain its reasoning without further tool calls.
+
+Data sources (all free unless noted):
+  1. CISA KEV catalog (free, cached)
+  2. VulnCheck KEV + NVD2 (requires VULNCHECK_API_KEY — degrades gracefully)
+  3. FIRST.org EPSS API (free)
+  4. trickest/cve GitHub raw (free, fast)
+  5. Exploit-DB HTML search (free, scrape-based — may degrade)
+  6. NVD CVE 2.0 API — CVSS base score + CWE (free)
+
+CLI: ``manus-agent exploit-maturity CVE-2021-44228``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["classify_exploit_maturity"]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d+$", re.IGNORECASE)
+
+_CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+_EPSS_URL = "https://api.first.org/data/v1/epss"
+_NVD_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_TRICKEST_RAW = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+_EXPLOITDB_URL = "https://www.exploit-db.com/search"
+_VULNCHECK_BASE = "https://api.vulncheck.com/v3/index"
+
+_TIMEOUT = 15
+
+# EPSS thresholds
+_EPSS_WEAPONIZED_HINT = 0.50  # ≥50% → likely weaponised even without public PoC evidence
+_EPSS_PRIVATE_POC = 0.20  # ≥20% → private capability probable
+
+# KEV cache
+_CISA_CACHE_FILE = Path(__file__).parent / ".cisa_kev_cache.json"
+_CACHE_TTL = 3600  # 1 hour
+
+# Maturity tiers (ordered highest → lowest)
+TIER_EXPLOITED_IN_WILD = "EXPLOITED_IN_WILD"
+TIER_WEAPONIZED = "WEAPONIZED"
+TIER_POC_PUBLIC = "POC_PUBLIC"
+TIER_POC_PRIVATE = "POC_PRIVATE"
+TIER_THEORETICAL = "THEORETICAL"
+
+_TIER_RANK = {
+    TIER_EXPLOITED_IN_WILD: 5,
+    TIER_WEAPONIZED: 4,
+    TIER_POC_PUBLIC: 3,
+    TIER_POC_PRIVATE: 2,
+    TIER_THEORETICAL: 1,
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str, params: dict | None = None, headers: dict | None = None) -> Any:
+    """GET with timeout; returns parsed JSON."""
+    r = requests.get(url, params=params or {}, headers=headers or {}, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _get_text(url: str, headers: dict | None = None) -> str:
+    """GET raw text."""
+    r = requests.get(url, headers=headers or {}, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.text
+
+
+# ---------------------------------------------------------------------------
+# Source 1: CISA KEV (cached)
+# ---------------------------------------------------------------------------
+
+
+def _load_cisa_kev() -> dict[str, Any]:
+    """Return CISA KEV data, reading from cache when fresh."""
+    import json
+
+    if _CISA_CACHE_FILE.exists():
+        age = time.time() - _CISA_CACHE_FILE.stat().st_mtime
+        if age < _CACHE_TTL:
+            try:
+                return json.loads(_CISA_CACHE_FILE.read_text())
+            except Exception:
+                pass
+
+    try:
+        data = _get(_CISA_KEV_URL)
+        try:
+            _CISA_CACHE_FILE.write_text(json.dumps(data))
+        except Exception:
+            pass
+        return data
+    except Exception as exc:
+        logger.debug("CISA KEV fetch failed: %s", exc)
+        return {}
+
+
+def _check_cisa_kev(cve_id: str) -> dict[str, Any]:
+    """Check whether *cve_id* appears in CISA KEV; return details or empty dict."""
+    data = _load_cisa_kev()
+    for vuln in data.get("vulnerabilities", []):
+        if vuln.get("cveID", "").upper() == cve_id.upper():
+            return {
+                "in_cisa_kev": True,
+                "vendor_project": vuln.get("vendorProject", ""),
+                "product": vuln.get("product", ""),
+                "date_added": vuln.get("dateAdded", ""),
+                "due_date": vuln.get("dueDate", ""),
+                "short_description": vuln.get("shortDescription", ""),
+                "required_action": vuln.get("requiredAction", ""),
+                "known_ransomware_campaign_use": vuln.get("knownRansomwareCampaignUse", "Unknown") == "Known",
+            }
+    return {"in_cisa_kev": False}
+
+
+# ---------------------------------------------------------------------------
+# Source 2: VulnCheck KEV + NVD2
+# ---------------------------------------------------------------------------
+
+
+def _check_vulncheck_kev(cve_id: str) -> dict[str, Any]:
+    """Query VulnCheck KEV; returns empty dict when API key is absent."""
+    api_key = os.environ.get("VULNCHECK_API_KEY", "").strip()
+    if not api_key:
+        return {"available": False}
+
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    try:
+        data = _get(f"{_VULNCHECK_BASE}/vulncheck-kev", params={"cve": cve_id}, headers=headers)
+        entries = data.get("data", []) or []
+        if not entries:
+            return {"available": True, "in_vulncheck_kev": False, "ransomware_use": False}
+
+        entry = entries[0]
+        ransomware_use = bool(
+            entry.get("ransomwareUse")
+            or entry.get("ransomware_use")
+            or entry.get("knownRansomwareCampaignUse")
+            or entry.get("known_ransomware_campaign_use")
+        )
+        return {
+            "available": True,
+            "in_vulncheck_kev": True,
+            "ransomware_use": ransomware_use,
+            "date_added": entry.get("dateAdded", ""),
+        }
+    except Exception as exc:
+        logger.debug("VulnCheck KEV fetch failed for %s: %s", cve_id, exc)
+        return {"available": False}
+
+
+# ---------------------------------------------------------------------------
+# Source 3: EPSS
+# ---------------------------------------------------------------------------
+
+
+def _fetch_epss(cve_id: str) -> dict[str, Any]:
+    """Fetch current EPSS score and percentile."""
+    try:
+        data = _get(_EPSS_URL, params={"cve": cve_id})
+        entries = data.get("data", [])
+        if entries:
+            e = entries[0]
+            return {
+                "epss_score": float(e.get("epss", 0)),
+                "epss_percentile": float(e.get("percentile", 0)),
+                "epss_date": e.get("date", ""),
+            }
+    except Exception as exc:
+        logger.debug("EPSS fetch failed for %s: %s", cve_id, exc)
+    return {"epss_score": None, "epss_percentile": None}
+
+
+# ---------------------------------------------------------------------------
+# Source 4: trickest/cve
+# ---------------------------------------------------------------------------
+
+
+def _check_trickest(cve_id: str) -> dict[str, Any]:
+    """Check trickest/cve repo for PoC links."""
+    match = re.match(r"CVE-(\d{4})-\d+", cve_id, re.IGNORECASE)
+    if not match:
+        return {"trickest_available": False, "poc_count": 0, "poc_urls": []}
+
+    year = match.group(1)
+    url = _TRICKEST_RAW.format(year=year, cve_id=cve_id.upper())
+    try:
+        md = _get_text(url, headers={"User-Agent": "manus-use/exploit-maturity"})
+    except requests.HTTPError as exc:
+        if exc.response is not None and exc.response.status_code == 404:
+            return {"trickest_available": True, "poc_count": 0, "poc_urls": []}
+        logger.debug("trickest fetch error: %s", exc)
+        return {"trickest_available": False, "poc_count": 0, "poc_urls": []}
+    except Exception as exc:
+        logger.debug("trickest fetch failed: %s", exc)
+        return {"trickest_available": False, "poc_count": 0, "poc_urls": []}
+
+    urls = re.findall(r"https?://\S+", md)
+    # Exclude NVD/mitre/cvedetails reference-only links
+    poc_urls = [u for u in urls if not any(d in u for d in ("nvd.nist.gov", "cve.mitre.org", "cvedetails.com"))]
+    return {
+        "trickest_available": True,
+        "poc_count": len(poc_urls),
+        "poc_urls": poc_urls[:10],  # cap at 10 for context efficiency
+    }
+
+
+# ---------------------------------------------------------------------------
+# Source 5: Exploit-DB (scrape)
+# ---------------------------------------------------------------------------
+
+
+def _check_exploitdb(cve_id: str) -> dict[str, Any]:
+    """Search Exploit-DB for entries matching this CVE."""
+    try:
+        text = _get_text(
+            _EXPLOITDB_URL,
+            headers={"User-Agent": "manus-use/exploit-maturity", "Accept": "text/html"},
+        )
+        # Exploit-DB search doesn't take a ?q= param easily for CVE IDs via HTML;
+        # check if CVE appears in the page source
+        count = text.lower().count(cve_id.lower())
+        return {"exploitdb_results": count > 0, "mention_count": count}
+    except Exception as exc:
+        logger.debug("ExploitDB check failed for %s: %s", cve_id, exc)
+        return {"exploitdb_results": None}
+
+
+# ---------------------------------------------------------------------------
+# Source 6: NVD — CVSS + CWE
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_meta(cve_id: str) -> dict[str, Any]:
+    """Fetch CVSS base score and CWE from NVD."""
+    try:
+        data = _get(_NVD_URL, params={"cveId": cve_id})
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return {}
+        cve = vulns[0].get("cve", {})
+
+        # CVSS v3.1 preferred, fall back to v3.0, then v2.0
+        metrics = cve.get("metrics", {})
+        cvss_score: float | None = None
+        cvss_severity: str = ""
+        cvss_version: str = ""
+        for ver_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+            entries = metrics.get(ver_key, [])
+            if entries:
+                cvss_data = entries[0].get("cvssData", {})
+                cvss_score = cvss_data.get("baseScore")
+                cvss_severity = cvss_data.get("baseSeverity", "")
+                cvss_version = cvss_data.get("version", ver_key.replace("cvssMetric", ""))
+                break
+
+        # CWE
+        cwes: list[str] = []
+        for weakness in cve.get("weaknesses", []):
+            for desc in weakness.get("description", []):
+                val = desc.get("value", "")
+                if val.startswith("CWE-"):
+                    cwes.append(val)
+
+        # Published date
+        published = cve.get("published", "")[:10]
+
+        return {
+            "cvss_score": cvss_score,
+            "cvss_severity": cvss_severity,
+            "cvss_version": cvss_version,
+            "cwes": cwes,
+            "published_date": published,
+        }
+    except Exception as exc:
+        logger.debug("NVD meta fetch failed for %s: %s", cve_id, exc)
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# Maturity classifier
+# ---------------------------------------------------------------------------
+
+
+def _classify(
+    cisa: dict[str, Any],
+    vulncheck: dict[str, Any],
+    epss: dict[str, Any],
+    trickest: dict[str, Any],
+) -> tuple[str, list[str]]:
+    """
+    Determine the maturity tier and collect the evidence strings that drove it.
+
+    Returns (tier, evidence_list).
+    """
+    evidence: list[str] = []
+    tier = TIER_THEORETICAL
+
+    def _upgrade(candidate: str, reason: str) -> None:
+        nonlocal tier
+        evidence.append(reason)
+        if _TIER_RANK[candidate] > _TIER_RANK[tier]:
+            tier = candidate
+
+    # --- EXPLOITED_IN_WILD signals ---
+    if cisa.get("in_cisa_kev"):
+        _upgrade(
+            TIER_EXPLOITED_IN_WILD,
+            f"CISA KEV: added {cisa.get('date_added', 'unknown date')} "
+            f"({cisa.get('vendor_project', '')} {cisa.get('product', '')})",
+        )
+
+    if vulncheck.get("in_vulncheck_kev"):
+        _upgrade(
+            TIER_EXPLOITED_IN_WILD,
+            f"VulnCheck KEV: confirmed exploitation "
+            f"(ransomware={'yes' if vulncheck.get('ransomware_use') else 'no'}, "
+            f"added {vulncheck.get('date_added', 'unknown')})",
+        )
+    elif vulncheck.get("ransomware_use"):
+        _upgrade(
+            TIER_EXPLOITED_IN_WILD,
+            "VulnCheck: ransomware campaign use confirmed",
+        )
+
+    if cisa.get("known_ransomware_campaign_use"):
+        _upgrade(
+            TIER_EXPLOITED_IN_WILD,
+            "CISA KEV: known ransomware campaign use",
+        )
+
+    # --- WEAPONIZED signals ---
+    # High EPSS (≥50%) with no KEV confirmation → probably weaponised
+    epss_score = epss.get("epss_score")
+    if epss_score is not None and epss_score >= _EPSS_WEAPONIZED_HINT and tier == TIER_THEORETICAL:
+        _upgrade(
+            TIER_WEAPONIZED,
+            f"EPSS {epss_score:.1%} ≥ 50% threshold suggests weaponised capability "
+            f"(top {(1.0 - epss.get('epss_percentile', 0)):.1%} of all CVEs)",
+        )
+    elif epss_score is not None and epss_score >= _EPSS_WEAPONIZED_HINT:
+        evidence.append(f"EPSS {epss_score:.1%} (corroborating high exploitation probability)")
+
+    # PoC URLs from trickest + high EPSS → WEAPONIZED upgrade hint
+    poc_count = trickest.get("poc_count", 0)
+    if poc_count > 0 and epss_score is not None and epss_score >= _EPSS_WEAPONIZED_HINT:
+        _upgrade(
+            TIER_WEAPONIZED,
+            f"trickest/cve: {poc_count} PoC URL(s) combined with EPSS {epss_score:.1%}",
+        )
+
+    # --- POC_PUBLIC signals ---
+    if poc_count > 0:
+        _upgrade(
+            TIER_POC_PUBLIC,
+            f"trickest/cve: {poc_count} public PoC URL(s) indexed (sample: {trickest.get('poc_urls', [])[:2]})",
+        )
+
+    # --- POC_PRIVATE signals ---
+    if epss_score is not None and epss_score >= _EPSS_PRIVATE_POC and tier == TIER_THEORETICAL:
+        _upgrade(
+            TIER_POC_PRIVATE,
+            f"EPSS {epss_score:.1%} ≥ {_EPSS_PRIVATE_POC:.0%} threshold: "
+            "private capability likely exists even without public PoC",
+        )
+
+    # Always record EPSS if available
+    if epss_score is not None and not any("EPSS" in e for e in evidence):
+        evidence.append(f"EPSS: {epss_score:.1%} (percentile {epss.get('epss_percentile', 0):.1%})")
+    elif epss_score is None:
+        evidence.append("EPSS: not available")
+
+    if tier == TIER_THEORETICAL and not evidence:
+        evidence.append("No exploitation or PoC evidence found across all checked sources")
+
+    return tier, evidence
+
+
+# ---------------------------------------------------------------------------
+# Main tool function
+# ---------------------------------------------------------------------------
+
+
+@tool
+def classify_exploit_maturity(cve_id: str) -> str:
+    """
+    Classify the exploitation maturity of a CVE using multiple intelligence sources.
+
+    Synthesises signals from CISA KEV, VulnCheck KEV (when API key is set),
+    FIRST.org EPSS, the trickest/cve PoC index, and NVD to produce a single
+    ranked verdict:
+
+    - **EXPLOITED_IN_WILD**: Confirmed active exploitation (CISA KEV, VulnCheck
+      KEV, or ransomware campaign use)
+    - **WEAPONIZED**: PoC has been weaponised into a usable exploit tool, or
+      EPSS ≥ 50% strongly suggests this, but no confirmed ITW evidence
+    - **POC_PUBLIC**: At least one public proof-of-concept exists
+    - **POC_PRIVATE**: EPSS ≥ 20% suggests private capability likely exists,
+      but no public PoC has been found
+    - **THEORETICAL**: No PoC, KEV listing, or statistically significant EPSS score
+
+    Also returns the full evidence bundle so downstream tools or the agent can
+    explain the reasoning without re-querying any source.
+
+    VulnCheck enrichment is included automatically when ``VULNCHECK_API_KEY``
+    is set in the environment; the tool degrades gracefully when absent.
+
+    Args:
+        cve_id: CVE identifier (e.g., ``CVE-2021-44228``).
+
+    Returns:
+        A structured text report: maturity tier, evidence summary, CVSS/CWE
+        metadata, and recommended next steps.
+    """
+    cve_id = cve_id.strip().upper()
+    if not _CVE_RE.match(cve_id):
+        return f"Error: '{cve_id}' is not a valid CVE ID. Expected format: CVE-YYYY-NNNNN"
+
+    lines: list[str] = [
+        f"Exploit Maturity Classification — {cve_id}",
+        "=" * 52,
+    ]
+
+    # Gather all signals (independent; each degrades on failure)
+    cisa = _check_cisa_kev(cve_id)
+    vulncheck = _check_vulncheck_kev(cve_id)
+    epss = _fetch_epss(cve_id)
+    trickest = _check_trickest(cve_id)
+    nvd_meta = _fetch_nvd_meta(cve_id)
+
+    # Classify
+    tier, evidence = _classify(cisa, vulncheck, epss, trickest)
+
+    # --- Verdict ---
+    tier_icon = {
+        TIER_EXPLOITED_IN_WILD: "🔴 CRITICAL",
+        TIER_WEAPONIZED: "🟠 HIGH",
+        TIER_POC_PUBLIC: "🟡 MEDIUM",
+        TIER_POC_PRIVATE: "🔵 LOW-MEDIUM",
+        TIER_THEORETICAL: "⚪ LOW",
+    }
+    icon = tier_icon.get(tier, tier)
+    lines.append(f"\nVerdict:  {tier}  {icon}")
+    lines.append("")
+
+    # --- Evidence ---
+    lines.append("Evidence:")
+    for item in evidence:
+        lines.append(f"  • {item}")
+
+    # --- CVE metadata ---
+    lines.append("")
+    lines.append("CVE Metadata:")
+    if nvd_meta.get("published_date"):
+        lines.append(f"  Published:    {nvd_meta['published_date']}")
+    if nvd_meta.get("cvss_score") is not None:
+        lines.append(
+            f"  CVSS {nvd_meta.get('cvss_version', '')}:     "
+            f"{nvd_meta['cvss_score']} ({nvd_meta.get('cvss_severity', '')})"
+        )
+    if nvd_meta.get("cwes"):
+        lines.append(f"  CWE:          {', '.join(nvd_meta['cwes'])}")
+
+    # --- Source coverage ---
+    lines.append("")
+    lines.append("Source coverage:")
+    lines.append(f"  CISA KEV:       {'✓ checked' if 'in_cisa_kev' in cisa else '✗ unavailable'}")
+    if vulncheck.get("available") is False:
+        lines.append("  VulnCheck KEV:  ✗ no API key (set VULNCHECK_API_KEY)")
+    else:
+        lines.append(f"  VulnCheck KEV:  {'✓ checked' if vulncheck else '✗ unavailable'}")
+    lines.append(
+        f"  EPSS (FIRST):   {'✓ ' + str(round(epss['epss_score'], 4)) if epss.get('epss_score') is not None else '✗ unavailable'}"
+    )
+    lines.append(
+        f"  trickest/cve:   {'✓ ' + str(trickest.get('poc_count', 0)) + ' PoC(s)' if trickest.get('trickest_available') else '✗ unavailable'}"
+    )
+    lines.append(
+        f"  NVD CVSS:       {'✓ CVSS ' + str(nvd_meta.get('cvss_score', '')) if nvd_meta.get('cvss_score') else '✗ unavailable'}"
+    )
+
+    # --- Recommended next steps by tier ---
+    lines.append("")
+    lines.append("Recommended next steps:")
+    if tier == TIER_EXPLOITED_IN_WILD:
+        lines.extend(
+            [
+                "  1. Treat as P0 — patch or mitigate immediately.",
+                "  2. Run `blast-radius` to identify downstream exposure.",
+                "  3. Check `poc-search` for exploit tools in the wild.",
+                "  4. Verify your environment is not already compromised.",
+            ]
+        )
+    elif tier == TIER_WEAPONIZED:
+        lines.extend(
+            [
+                "  1. Treat as P1 — patch within your SLA window.",
+                "  2. Run `exploit-complexity` to gauge attacker effort.",
+                "  3. Run `blast-radius` to scope exposure.",
+                "  4. Monitor for CISA KEV listing (may escalate to EXPLOITED_IN_WILD).",
+            ]
+        )
+    elif tier == TIER_POC_PUBLIC:
+        lines.extend(
+            [
+                "  1. Prioritise patching over other non-KEV issues.",
+                "  2. Run `exploit-complexity` — if LOW, treat as weaponised.",
+                "  3. Check `poc-search` for weaponisation attempts.",
+            ]
+        )
+    elif tier == TIER_POC_PRIVATE:
+        lines.extend(
+            [
+                "  1. Monitor EPSS trend with `epss-trend` — a spike may indicate new PoC.",
+                "  2. Apply patch in next regular cycle unless CVSS ≥ 9.0.",
+                "  3. Check back in 30 days; EPSS may update as PoCs emerge.",
+            ]
+        )
+    else:  # THEORETICAL
+        lines.extend(
+            [
+                "  1. Apply patch in normal maintenance cycle.",
+                "  2. Low urgency — revisit if EPSS rises above 0.20.",
+            ]
+        )
+
+    return "\n".join(lines)

--- a/tests/test_classify_exploit_maturity.py
+++ b/tests/test_classify_exploit_maturity.py
@@ -1,0 +1,583 @@
+"""Tests for classify_exploit_maturity tool."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.classify_exploit_maturity import (
+    TIER_EXPLOITED_IN_WILD,
+    TIER_POC_PRIVATE,
+    TIER_POC_PUBLIC,
+    TIER_THEORETICAL,
+    TIER_WEAPONIZED,
+    _check_cisa_kev,
+    _check_trickest,
+    _check_vulncheck_kev,
+    _classify,
+    _fetch_epss,
+    _fetch_nvd_meta,
+    classify_exploit_maturity,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CVE_LOG4SHELL = "CVE-2021-44228"
+CVE_FAKE = "CVE-2099-99999"
+
+
+def _kev_payload(cve_id: str) -> dict:
+    """Minimal CISA KEV response that contains cve_id."""
+    return {
+        "vulnerabilities": [
+            {
+                "cveID": cve_id,
+                "vendorProject": "Apache",
+                "product": "Log4j",
+                "dateAdded": "2021-12-10",
+                "dueDate": "2021-12-24",
+                "shortDescription": "Apache Log4j RCE",
+                "requiredAction": "Apply patch",
+                "knownRansomwareCampaignUse": "Known",
+            }
+        ]
+    }
+
+
+def _kev_payload_no_ransomware(cve_id: str) -> dict:
+    """CISA KEV response without ransomware flag."""
+    return {
+        "vulnerabilities": [
+            {
+                "cveID": cve_id,
+                "vendorProject": "Acme",
+                "product": "Widget",
+                "dateAdded": "2024-01-15",
+                "dueDate": "2024-02-15",
+                "shortDescription": "Acme Widget vuln",
+                "requiredAction": "Apply patch",
+                "knownRansomwareCampaignUse": "Unknown",
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# _check_cisa_kev
+# ---------------------------------------------------------------------------
+
+
+class TestCheckCisaKev:
+    def test_in_kev_returns_details(self, tmp_path, monkeypatch):
+        """CVE present in CISA KEV → in_cisa_kev=True with details."""
+        monkeypatch.setattr(
+            "manus_agent.tools.classify_exploit_maturity._CISA_CACHE_FILE",
+            tmp_path / "kev_cache.json",
+        )
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value=_kev_payload(CVE_LOG4SHELL),
+        ):
+            result = _check_cisa_kev(CVE_LOG4SHELL)
+
+        assert result["in_cisa_kev"] is True
+        assert result["vendor_project"] == "Apache"
+        assert result["date_added"] == "2021-12-10"
+        assert result["known_ransomware_campaign_use"] is True
+
+    def test_not_in_kev(self, tmp_path, monkeypatch):
+        """CVE absent from KEV → in_cisa_kev=False."""
+        monkeypatch.setattr(
+            "manus_agent.tools.classify_exploit_maturity._CISA_CACHE_FILE",
+            tmp_path / "kev_cache.json",
+        )
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value=_kev_payload("CVE-2099-00001"),
+        ):
+            result = _check_cisa_kev(CVE_FAKE)
+
+        assert result["in_cisa_kev"] is False
+
+    def test_api_failure_returns_not_found(self, tmp_path, monkeypatch):
+        """Network error → graceful degradation, not an exception."""
+        monkeypatch.setattr(
+            "manus_agent.tools.classify_exploit_maturity._CISA_CACHE_FILE",
+            tmp_path / "kev_cache.json",
+        )
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            side_effect=Exception("network error"),
+        ):
+            result = _check_cisa_kev(CVE_LOG4SHELL)
+
+        assert result["in_cisa_kev"] is False
+
+    def test_uses_cache(self, tmp_path, monkeypatch):
+        """Second call reads from cache, not the network."""
+        cache_path = tmp_path / "kev_cache.json"
+        monkeypatch.setattr(
+            "manus_agent.tools.classify_exploit_maturity._CISA_CACHE_FILE",
+            cache_path,
+        )
+        import json
+
+        cache_path.write_text(json.dumps(_kev_payload(CVE_LOG4SHELL)))
+        # Patch stat.mtime to be fresh (age = 0)
+        import os
+        import time
+
+        orig_stat = os.stat
+
+        def fake_stat(p, **kw):
+            st = orig_stat(p, **kw)
+            return type(st)(st)
+
+        # Ensure cache file is newer than TTL
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            side_effect=AssertionError("should not hit network"),
+        ):
+            # Manually set mtime to now so cache is fresh
+            os.utime(cache_path, (time.time(), time.time()))
+            result = _check_cisa_kev(CVE_LOG4SHELL)
+
+        assert result["in_cisa_kev"] is True
+
+
+# ---------------------------------------------------------------------------
+# _check_vulncheck_kev
+# ---------------------------------------------------------------------------
+
+
+class TestCheckVulncheckKev:
+    def test_no_api_key_returns_unavailable(self, monkeypatch):
+        """When VULNCHECK_API_KEY is absent → available=False."""
+        monkeypatch.delenv("VULNCHECK_API_KEY", raising=False)
+        result = _check_vulncheck_kev(CVE_LOG4SHELL)
+        assert result["available"] is False
+
+    def test_in_kev_with_ransomware(self, monkeypatch):
+        """VulnCheck KEV hit with ransomware → in_vulncheck_kev=True, ransomware_use=True."""
+        monkeypatch.setenv("VULNCHECK_API_KEY", "test-key-abc")
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value={"data": [{"ransomwareUse": True, "dateAdded": "2021-12-10"}]},
+        ):
+            result = _check_vulncheck_kev(CVE_LOG4SHELL)
+
+        assert result["available"] is True
+        assert result["in_vulncheck_kev"] is True
+        assert result["ransomware_use"] is True
+
+    def test_not_in_kev(self, monkeypatch):
+        """VulnCheck KEV miss → in_vulncheck_kev=False."""
+        monkeypatch.setenv("VULNCHECK_API_KEY", "test-key-abc")
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value={"data": []},
+        ):
+            result = _check_vulncheck_kev(CVE_FAKE)
+
+        assert result["available"] is True
+        assert result["in_vulncheck_kev"] is False
+
+    def test_api_failure_returns_unavailable(self, monkeypatch):
+        """HTTP error → available=False, not an exception."""
+        monkeypatch.setenv("VULNCHECK_API_KEY", "test-key-abc")
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            side_effect=Exception("503"),
+        ):
+            result = _check_vulncheck_kev(CVE_LOG4SHELL)
+
+        assert result["available"] is False
+
+
+# ---------------------------------------------------------------------------
+# _fetch_epss
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEpss:
+    def test_returns_score_and_percentile(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value={
+                "data": [{"cve": CVE_LOG4SHELL, "epss": "0.9753", "percentile": "0.9999", "date": "2024-01-01"}]
+            },
+        ):
+            result = _fetch_epss(CVE_LOG4SHELL)
+
+        assert result["epss_score"] == pytest.approx(0.9753)
+        assert result["epss_percentile"] == pytest.approx(0.9999)
+        assert result["epss_date"] == "2024-01-01"
+
+    def test_empty_data_returns_none(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value={"data": []},
+        ):
+            result = _fetch_epss(CVE_FAKE)
+
+        assert result["epss_score"] is None
+        assert result["epss_percentile"] is None
+
+    def test_network_failure_returns_none(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            side_effect=Exception("timeout"),
+        ):
+            result = _fetch_epss(CVE_LOG4SHELL)
+
+        assert result["epss_score"] is None
+
+
+# ---------------------------------------------------------------------------
+# _check_trickest
+# ---------------------------------------------------------------------------
+
+
+class TestCheckTrickest:
+    _MD = """\n### Description\n\nApache Log4j RCE\n\n### POC\n#### Reference\n- https://github.com/example/log4shell-poc\n- https://github.com/other/exploit\n\n#### Github\n- https://github.com/third/log4j\n"""
+
+    def test_finds_poc_urls(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get_text",
+            return_value=self._MD,
+        ):
+            result = _check_trickest(CVE_LOG4SHELL)
+
+        assert result["trickest_available"] is True
+        assert result["poc_count"] >= 3
+
+    def test_404_returns_zero_pocs(self):
+        import requests
+
+        http_err = requests.HTTPError(response=MagicMock(status_code=404))
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get_text",
+            side_effect=http_err,
+        ):
+            result = _check_trickest(CVE_LOG4SHELL)
+
+        assert result["trickest_available"] is True
+        assert result["poc_count"] == 0
+
+    def test_network_error_returns_unavailable(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get_text",
+            side_effect=Exception("network error"),
+        ):
+            result = _check_trickest(CVE_LOG4SHELL)
+
+        assert result["trickest_available"] is False
+
+    def test_invalid_cve_id(self):
+        result = _check_trickest("NOT-A-CVE")
+        assert result["trickest_available"] is False
+        assert result["poc_count"] == 0
+
+    def test_filters_nvd_reference_links(self):
+        nvd_only_md = (
+            "### POC\n#### Reference\n"
+            "- https://nvd.nist.gov/vuln/detail/CVE-2021-44228\n"
+            "- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44228\n"
+        )
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get_text",
+            return_value=nvd_only_md,
+        ):
+            result = _check_trickest(CVE_LOG4SHELL)
+
+        # NVD/mitre links should be excluded
+        assert result["poc_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_nvd_meta
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdMeta:
+    def test_returns_cvss_and_cwe(self):
+        nvd_payload = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "published": "2021-12-10T10:15:09.143",
+                        "metrics": {
+                            "cvssMetricV31": [
+                                {
+                                    "cvssData": {
+                                        "version": "3.1",
+                                        "baseScore": 10.0,
+                                        "baseSeverity": "CRITICAL",
+                                    }
+                                }
+                            ]
+                        },
+                        "weaknesses": [{"description": [{"value": "CWE-502"}]}],
+                    }
+                }
+            ]
+        }
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value=nvd_payload,
+        ):
+            result = _fetch_nvd_meta(CVE_LOG4SHELL)
+
+        assert result["cvss_score"] == 10.0
+        assert result["cvss_severity"] == "CRITICAL"
+        assert "CWE-502" in result["cwes"]
+        assert result["published_date"] == "2021-12-10"
+
+    def test_empty_vulnerabilities(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            return_value={"vulnerabilities": []},
+        ):
+            result = _fetch_nvd_meta(CVE_FAKE)
+
+        assert result == {}
+
+    def test_network_failure_returns_empty(self):
+        with patch(
+            "manus_agent.tools.classify_exploit_maturity._get",
+            side_effect=Exception("timeout"),
+        ):
+            result = _fetch_nvd_meta(CVE_LOG4SHELL)
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# _classify — the core logic
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    def _cisa_hit(self) -> dict:
+        return {
+            "in_cisa_kev": True,
+            "vendor_project": "Apache",
+            "product": "Log4j",
+            "date_added": "2021-12-10",
+            "known_ransomware_campaign_use": False,
+        }
+
+    def _cisa_miss(self) -> dict:
+        return {"in_cisa_kev": False}
+
+    def _vc_hit(self, ransomware: bool = False) -> dict:
+        return {
+            "available": True,
+            "in_vulncheck_kev": True,
+            "ransomware_use": ransomware,
+            "date_added": "2021-12-10",
+        }
+
+    def _vc_miss(self) -> dict:
+        return {"available": True, "in_vulncheck_kev": False, "ransomware_use": False}
+
+    def _vc_unavail(self) -> dict:
+        return {"available": False}
+
+    def _epss(self, score: float) -> dict:
+        return {"epss_score": score, "epss_percentile": 0.99, "epss_date": "2024-01-01"}
+
+    def _trickest(self, count: int = 0) -> dict:
+        urls = [f"https://github.com/poc{i}" for i in range(count)]
+        return {"trickest_available": True, "poc_count": count, "poc_urls": urls}
+
+    # EXPLOITED_IN_WILD scenarios
+
+    def test_cisa_kev_triggers_exploited(self):
+        tier, evidence = _classify(self._cisa_hit(), self._vc_miss(), self._epss(0.1), self._trickest(0))
+        assert tier == TIER_EXPLOITED_IN_WILD
+        assert any("CISA KEV" in e for e in evidence)
+
+    def test_vulncheck_kev_triggers_exploited(self):
+        tier, evidence = _classify(self._cisa_miss(), self._vc_hit(), self._epss(0.1), self._trickest(0))
+        assert tier == TIER_EXPLOITED_IN_WILD
+        assert any("VulnCheck KEV" in e for e in evidence)
+
+    def test_ransomware_in_cisa_triggers_exploited(self):
+        cisa = self._cisa_hit()
+        cisa["known_ransomware_campaign_use"] = True
+        tier, evidence = _classify(cisa, self._vc_miss(), self._epss(0.1), self._trickest(0))
+        assert tier == TIER_EXPLOITED_IN_WILD
+
+    def test_vulncheck_ransomware_triggers_exploited(self):
+        vc = self._vc_miss()
+        vc["ransomware_use"] = True
+        tier, _ = _classify(self._cisa_miss(), vc, self._epss(0.1), self._trickest(0))
+        assert tier == TIER_EXPLOITED_IN_WILD
+
+    # WEAPONIZED scenarios
+
+    def test_high_epss_alone_triggers_weaponized(self):
+        tier, evidence = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.55), self._trickest(0))
+        assert tier == TIER_WEAPONIZED
+        assert any("EPSS" in e for e in evidence)
+
+    def test_poc_plus_high_epss_triggers_weaponized(self):
+        tier, evidence = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.51), self._trickest(3))
+        assert tier == TIER_WEAPONIZED
+
+    # POC_PUBLIC scenarios
+
+    def test_poc_with_moderate_epss_is_poc_public(self):
+        tier, _ = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.15), self._trickest(2))
+        assert tier == TIER_POC_PUBLIC
+
+    def test_poc_zero_epss_is_poc_public(self):
+        tier, _ = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.01), self._trickest(1))
+        assert tier == TIER_POC_PUBLIC
+
+    # POC_PRIVATE scenarios
+
+    def test_medium_epss_no_poc_is_poc_private(self):
+        tier, evidence = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.25), self._trickest(0))
+        assert tier == TIER_POC_PRIVATE
+        assert any("EPSS" in e for e in evidence)
+
+    def test_epss_just_at_threshold(self):
+        tier, _ = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.20), self._trickest(0))
+        assert tier == TIER_POC_PRIVATE
+
+    # THEORETICAL scenarios
+
+    def test_low_epss_no_poc_no_kev_is_theoretical(self):
+        tier, _ = _classify(self._cisa_miss(), self._vc_miss(), self._epss(0.01), self._trickest(0))
+        assert tier == TIER_THEORETICAL
+
+    def test_no_epss_no_poc_no_kev_is_theoretical(self):
+        epss_none = {"epss_score": None, "epss_percentile": None}
+        tier, _ = _classify(self._cisa_miss(), self._vc_miss(), epss_none, self._trickest(0))
+        assert tier == TIER_THEORETICAL
+
+    def test_vulncheck_unavail_does_not_break(self):
+        tier, _ = _classify(self._cisa_miss(), self._vc_unavail(), self._epss(0.01), self._trickest(0))
+        assert tier == TIER_THEORETICAL
+
+
+# ---------------------------------------------------------------------------
+# classify_exploit_maturity (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyExploitMaturityTool:
+    """Full end-to-end tests of the @tool function with all HTTP calls mocked."""
+
+    def _make_patches(
+        self,
+        *,
+        in_cisa=False,
+        in_vc=False,
+        ransomware=False,
+        epss_score=0.05,
+        poc_count=0,
+        cvss_score=7.5,
+        vc_available=False,
+    ):
+        """Return a dict of mock targets for the tool function."""
+        cisa_result = {
+            "in_cisa_kev": in_cisa,
+            "vendor_project": "ACME",
+            "product": "Widget",
+            "date_added": "2024-01-01",
+            "known_ransomware_campaign_use": ransomware,
+        }
+        vc_result = (
+            {"available": vc_available, "in_vulncheck_kev": in_vc, "ransomware_use": ransomware}
+            if vc_available
+            else {"available": False}
+        )
+        epss_result = {"epss_score": epss_score, "epss_percentile": 0.90, "epss_date": "2024-01-01"}
+        trickest_result = {
+            "trickest_available": True,
+            "poc_count": poc_count,
+            "poc_urls": [f"https://github.com/poc{i}" for i in range(poc_count)],
+        }
+        nvd_result = {
+            "cvss_score": cvss_score,
+            "cvss_severity": "HIGH",
+            "cvss_version": "3.1",
+            "cwes": ["CWE-502"],
+            "published_date": "2021-12-10",
+        }
+        return cisa_result, vc_result, epss_result, trickest_result, nvd_result
+
+    def _run_tool(self, cve_id, **patch_kwargs):
+        cisa_r, vc_r, epss_r, trick_r, nvd_r = self._make_patches(**patch_kwargs)
+        with (
+            patch("manus_agent.tools.classify_exploit_maturity._check_cisa_kev", return_value=cisa_r),
+            patch("manus_agent.tools.classify_exploit_maturity._check_vulncheck_kev", return_value=vc_r),
+            patch("manus_agent.tools.classify_exploit_maturity._fetch_epss", return_value=epss_r),
+            patch("manus_agent.tools.classify_exploit_maturity._check_trickest", return_value=trick_r),
+            patch("manus_agent.tools.classify_exploit_maturity._fetch_nvd_meta", return_value=nvd_r),
+        ):
+            return classify_exploit_maturity(cve_id=cve_id)
+
+    def test_invalid_cve_returns_error(self):
+        result = classify_exploit_maturity(cve_id="NOT-A-CVE")
+        assert "Error" in result
+
+    def test_exploited_in_wild_output(self):
+        result = self._run_tool(CVE_LOG4SHELL, in_cisa=True)
+        assert TIER_EXPLOITED_IN_WILD in result
+        assert "CRITICAL" in result
+        assert "Evidence:" in result
+        assert "CISA KEV" in result
+
+    def test_poc_public_output(self):
+        result = self._run_tool(CVE_LOG4SHELL, poc_count=2, epss_score=0.10)
+        assert TIER_POC_PUBLIC in result
+        assert "MEDIUM" in result
+        assert "trickest" in result
+
+    def test_theoretical_output(self):
+        result = self._run_tool(CVE_FAKE, epss_score=0.001, poc_count=0)
+        assert TIER_THEORETICAL in result
+        assert "LOW" in result
+
+    def test_output_includes_cvss(self):
+        result = self._run_tool(CVE_LOG4SHELL, cvss_score=10.0)
+        assert "7.5" in result or "10.0" in result  # depends on mock
+
+    def test_output_includes_next_steps(self):
+        result = self._run_tool(CVE_LOG4SHELL, in_cisa=True)
+        assert "Recommended next steps" in result
+        assert "blast-radius" in result
+
+    def test_output_includes_source_coverage(self):
+        result = self._run_tool(CVE_LOG4SHELL)
+        assert "Source coverage:" in result
+        assert "CISA KEV" in result
+        assert "EPSS" in result
+
+    def test_weaponized_next_steps_differ_from_exploited(self):
+        exploited_result = self._run_tool(CVE_LOG4SHELL, in_cisa=True)
+        weaponized_result = self._run_tool(CVE_LOG4SHELL, epss_score=0.75)
+        # Both have next steps but weaponized does not say "P0"
+        assert "P0" in exploited_result
+        assert "P1" in weaponized_result
+
+    def test_poc_private_recommends_monitoring(self):
+        result = self._run_tool(CVE_LOG4SHELL, epss_score=0.22)
+        assert TIER_POC_PRIVATE in result
+        assert "epss-trend" in result
+
+    def test_cve_id_normalised_to_upper(self):
+        result = self._run_tool("cve-2021-44228", in_cisa=True)
+        # Should not error — normalisation handles lowercase
+        assert TIER_EXPLOITED_IN_WILD in result
+
+    def test_no_vulncheck_key_shows_note(self):
+        result = self._run_tool(CVE_LOG4SHELL, vc_available=False)
+        assert "VULNCHECK_API_KEY" in result or "no API key" in result


### PR DESCRIPTION
Adds `classify_exploit_maturity` — a synthesis tool that calls CISA KEV, VulnCheck KEV, EPSS, trickest/cve, and NVD in a single pass and returns a ranked exploitation maturity verdict.

**Maturity tiers** (highest → lowest):
- `EXPLOITED_IN_WILD` 🔴 — confirmed KEV listing or ransomware campaign use
- `WEAPONIZED` 🟠 — weaponised exploit or EPSS ≥ 50%
- `POC_PUBLIC` 🟡 — public PoC exists (trickest/cve)
- `POC_PRIVATE` 🔵 — EPSS ≥ 20%, private capability likely
- `THEORETICAL` ⚪ — no evidence

**Why it matters:** analysts currently call 5 tools and manually reconcile signals. This tool answers "how urgent is this CVE?" in one call with an evidence bundle.

**CLI:** `manus-agent exploit-maturity CVE-YYYY-NNNNN [--output text|json]`

**Integration:**
- Registered in `VulnerabilityIntelligenceAgent` tool list
- Added to Step 2 of VI agent analysis workflow
- VulnCheck enrichment auto-enabled when `VULNCHECK_API_KEY` is set; graceful degradation when absent

**Tests:** 43 new (all mocked, zero real HTTP calls). Total suite: 945 passing (+43 vs main).