### PR TITLE
feat: add diff_report_cves tool and diff-report CLI subcommand

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -210,6 +210,7 @@ class VulnerabilityIntelligenceAgent:
             from strands import Agent
             from strands_tools import current_time
 
+            from manus_agent.tools.diff_report_cves import diff_report_cves
             from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_agent.tools.get_epss_trend import get_epss_trend
             from manus_agent.tools.get_github_advisory import get_github_advisory
@@ -274,6 +275,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            diff_report_cves,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "diff-report",
 }
 
 
@@ -1859,6 +1860,120 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# diff-report subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_diff_report_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent diff-report",
+        description=(
+            "Generate a rich Markdown diff-report comparing two CVEs side-by-side.\n"
+            "Covers CVSS delta, EPSS divergence, CISA KEV status, CWE classes,\n"
+            "and a scored prioritisation verdict with full rationale.\n\n"
+            "Examples:\n"
+            "  manus-agent diff-report CVE-2021-44228 CVE-2021-45046\n"
+            "  manus-agent diff-report CVE-2024-3094 CVE-2023-44487 --output json\n"
+            "  manus-agent diff-report CVE-2024-3094 CVE-2023-44487 --save report.md"
+        ),
+        add_help=True,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("cve_id_a", metavar="CVE-ID-A", help="First CVE (e.g. CVE-2021-44228)")
+    p.add_argument("cve_id_b", metavar="CVE-ID-B", help="Second CVE to compare against")
+    p.add_argument(
+        "--output",
+        choices=["markdown", "json"],
+        default="markdown",
+        help="Report format (default: markdown)",
+    )
+    p.add_argument(
+        "--save",
+        metavar="FILE",
+        default=None,
+        help="Save report to FILE instead of printing to stdout",
+    )
+    return p
+
+
+def _run_diff_report(argv: list[str]) -> int:  # noqa: C901
+    import json as _json
+    import re as _re
+
+    parser = _build_diff_report_parser()
+    args = parser.parse_args(argv)
+
+    cve_id_a: str = args.cve_id_a.strip()
+    cve_id_b: str = args.cve_id_b.strip()
+
+    _cve_re = _re.compile(r"^CVE-\d{4}-\d+$", _re.IGNORECASE)
+    for cid in (cve_id_a, cve_id_b):
+        if not _cve_re.match(cid):
+            parser.error(f"Invalid CVE ID '{cid}'. Expected format: CVE-YYYY-NNNNN")
+
+    try:
+        from manus_agent.tools.diff_report_cves import (
+            _build_diff_report,
+            _build_profile,
+            _fetch_kev,
+            _render_markdown,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import concurrent.futures as _cf
+
+    # When emitting JSON to stdout, route progress messages to stderr so the
+    # raw JSON can be piped directly without interference.
+    from rich.console import Console as _Console
+
+    _progress_console = _Console(stderr=True) if args.output == "json" else console
+
+    _progress_console.print(
+        f"[bold blue]Generating diff-report:[/bold blue] "
+        f"[cyan]{cve_id_a.upper()}[/cyan] vs [cyan]{cve_id_b.upper()}[/cyan]"
+    )
+
+    try:
+        with _progress_console.status("Fetching CVE data from NVD, EPSS, and CISA KEV...", spinner="dots"):
+            with _cf.ThreadPoolExecutor(max_workers=4) as ex:
+                f_a = ex.submit(_build_profile, cve_id_a)
+                f_b = ex.submit(_build_profile, cve_id_b)
+                f_kev_a = ex.submit(_fetch_kev, cve_id_a)
+                f_kev_b = ex.submit(_fetch_kev, cve_id_b)
+                profile_a = f_a.result()
+                profile_b = f_b.result()
+                kev_a = f_kev_a.result()
+                kev_b = f_kev_b.result()
+    except Exception as exc:
+        _progress_console.print(f"[red]\u2717 Data fetch failed: {exc}[/red]")
+        return 1
+
+    report = _build_diff_report(profile_a, profile_b, kev_a, kev_b)
+
+    if args.output == "json":
+        output_text = _json.dumps(report, indent=2)
+    else:
+        output_text = _render_markdown(report)
+
+    if args.save:
+        try:
+            Path(args.save).write_text(output_text, encoding="utf-8")
+            _progress_console.print(f"[green]\u2713 Report saved to [bold]{args.save}[/bold][/green]")
+        except OSError as exc:
+            _progress_console.print(f"[red]\u2717 Failed to save report: {exc}[/red]")
+            return 1
+    else:
+        if args.output == "json":
+            sys.stdout.write(output_text + "\n")
+        else:
+            console.print(output_text)
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2188,6 +2303,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "diff-report":
+        idx = argv.index("diff-report")
+        sys.exit(_run_diff_report(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/diff_report_cves.py
+++ b/src/manus_agent/tools/diff_report_cves.py
@@ -1,0 +1,894 @@
+"""
+Tool for generating a rich Markdown diff-report comparing two CVEs.
+
+Goes beyond the tabular ``compare_cves`` tool by producing a full narrative
+document — suitable for tickets, briefings, or security advisories — that
+covers CVSS delta analysis, EPSS trajectory divergence, KEV status, CWE
+class differences, and a concrete prioritisation verdict with rationale.
+
+Data sources (all degrade independently):
+  - NVD          https://services.nvd.nist.gov/rest/json/cves/2.0
+  - FIRST EPSS   https://api.first.org/data/v1/epss
+  - CISA KEV     https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+
+All HTTP calls are performed concurrently via ``ThreadPoolExecutor``.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures
+import datetime
+import re
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+TOOL_SPEC = {
+    "name": "diff_report_cves",
+    "description": (
+        "Generates a detailed Markdown diff-report comparing two CVEs side-by-side. "
+        "The report covers CVSS score delta, severity comparison, EPSS exploitation-probability "
+        "difference, CISA KEV membership, CWE weakness-class comparison, attack vector and "
+        "privilege differences, affected components, and a clear prioritisation verdict "
+        "with scoring rationale. "
+        "Use when you need a shareable narrative document that explains *why* one CVE is more "
+        "urgent than another — suitable for tickets, security briefings, or advisory drafts."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id_a": {
+                    "type": "string",
+                    "description": "First CVE identifier (e.g. 'CVE-2024-3094').",
+                },
+                "cve_id_b": {
+                    "type": "string",
+                    "description": "Second CVE identifier to compare against (e.g. 'CVE-2021-44228').",
+                },
+                "output_format": {
+                    "type": "string",
+                    "enum": ["markdown", "json"],
+                    "description": "Report format: 'markdown' (default) or 'json' for structured data.",
+                },
+            },
+            "required": ["cve_id_a", "cve_id_b"],
+        }
+    },
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Constants
+# ──────────────────────────────────────────────────────────────────────────────
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d+$", re.IGNORECASE)
+
+_SEVERITY_ORDER = {"CRITICAL": 4, "HIGH": 3, "MEDIUM": 2, "LOW": 1, "NONE": 0}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# HTTP helpers  (self-contained; no imports from compare_cves)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _fetch_nvd(cve_id: str) -> dict[str, Any]:
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        vulns = resp.json().get("vulnerabilities", [])
+        return vulns[0].get("cve", {}) if vulns else {"error": f"No NVD record for {cve_id}"}
+    except requests.RequestException as exc:
+        return {"error": f"NVD request failed: {exc}"}
+
+
+def _fetch_epss(cve_id: str) -> dict[str, Any]:
+    try:
+        resp = requests.get(
+            "https://api.first.org/data/v1/epss",
+            params={"cve": cve_id.upper()},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        entries = resp.json().get("data", [])
+        return entries[0] if entries else {"error": f"No EPSS data for {cve_id}"}
+    except requests.RequestException as exc:
+        return {"error": f"EPSS request failed: {exc}"}
+
+
+def _fetch_kev(cve_id: str) -> dict[str, Any]:
+    url = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    try:
+        resp = requests.get(url, timeout=20)
+        resp.raise_for_status()
+        catalog = resp.json()
+    except requests.RequestException as exc:
+        return {"in_kev": False, "error": f"KEV request failed: {exc}"}
+    cid = cve_id.upper()
+    for entry in catalog.get("vulnerabilities", []):
+        if entry.get("cveID", "").upper() == cid:
+            return {
+                "in_kev": True,
+                "date_added": entry.get("dateAdded"),
+                "vendor_project": entry.get("vendorProject"),
+                "product": entry.get("product"),
+                "required_action": entry.get("requiredAction"),
+                "due_date": entry.get("dueDate"),
+            }
+    return {"in_kev": False}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Data-extraction helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _extract_cvss(nvd: dict[str, Any]) -> dict[str, Any]:
+    """Return the highest-version CVSS data available (3.1 -> 3.0 -> 2.0)."""
+    metrics = nvd.get("metrics", {})
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            cv = entries[0].get("cvssData", {})
+            return {
+                "version": cv.get("version", key[-3:]),
+                "score": cv.get("baseScore"),
+                "severity": cv.get("baseSeverity"),
+                "vector": cv.get("vectorString"),
+                "attack_vector": cv.get("attackVector"),
+                "privileges_required": cv.get("privilegesRequired"),
+                "user_interaction": cv.get("userInteraction"),
+                "scope": cv.get("scope"),
+                "confidentiality_impact": cv.get("confidentialityImpact"),
+                "integrity_impact": cv.get("integrityImpact"),
+                "availability_impact": cv.get("availabilityImpact"),
+            }
+    entries = metrics.get("cvssMetricV2", [])
+    if entries:
+        cv = entries[0].get("cvssData", {})
+        return {
+            "version": "2.0",
+            "score": cv.get("baseScore"),
+            "severity": entries[0].get("baseSeverity"),
+            "vector": cv.get("vectorString"),
+            "attack_vector": cv.get("accessVector"),
+            "privileges_required": None,
+            "user_interaction": None,
+            "scope": None,
+            "confidentiality_impact": cv.get("confidentialityImpact"),
+            "integrity_impact": cv.get("integrityImpact"),
+            "availability_impact": cv.get("availabilityImpact"),
+        }
+    return _empty_cvss()
+
+
+def _empty_cvss() -> dict[str, Any]:
+    return {
+        "version": None,
+        "score": None,
+        "severity": None,
+        "vector": None,
+        "attack_vector": None,
+        "privileges_required": None,
+        "user_interaction": None,
+        "scope": None,
+        "confidentiality_impact": None,
+        "integrity_impact": None,
+        "availability_impact": None,
+    }
+
+
+def _extract_cwe(nvd: dict[str, Any]) -> list[str]:
+    cwes: list[str] = []
+    for weakness in nvd.get("weaknesses", []):
+        for desc in weakness.get("description", []):
+            val = desc.get("value", "")
+            if val and val not in ("NVD-CWE-Other", "NVD-CWE-noinfo"):
+                cwes.append(val)
+    return cwes
+
+
+def _extract_affected(nvd: dict[str, Any]) -> str:
+    for config in nvd.get("configurations", []):
+        for node in config.get("nodes", []):
+            for cpe_match in node.get("cpeMatch", []):
+                uri = cpe_match.get("criteria", "")
+                parts = uri.split(":")
+                if len(parts) >= 5:
+                    vendor = parts[3].replace("_", " ").title()
+                    product = parts[4].replace("_", " ").title()
+                    return f"{vendor} / {product}"
+    return "Unknown"
+
+
+def _extract_published(nvd: dict[str, Any]) -> str:
+    raw = nvd.get("published", "")
+    return raw[:10] if raw else "Unknown"
+
+
+def _extract_description(nvd: dict[str, Any], max_chars: int = 400) -> str:
+    for desc in nvd.get("descriptions", []):
+        if desc.get("lang") == "en":
+            val = desc.get("value", "")
+            return val[:max_chars] + ("..." if len(val) > max_chars else "")
+    return ""
+
+
+def _extract_references(nvd: dict[str, Any], limit: int = 5) -> list[str]:
+    refs: list[str] = []
+    for r in nvd.get("references", []):
+        url = r.get("url", "")
+        if url:
+            refs.append(url)
+        if len(refs) >= limit:
+            break
+    return refs
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Profile builder
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _build_profile(cve_id: str) -> dict[str, Any]:
+    """Fetch NVD + EPSS data for one CVE in parallel, return a normalised profile."""
+    cid = cve_id.upper()
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as ex:
+        nvd_f = ex.submit(_fetch_nvd, cid)
+        epss_f = ex.submit(_fetch_epss, cid)
+        nvd = nvd_f.result()
+        epss = epss_f.result()
+
+    has_nvd = "error" not in nvd
+    return {
+        "cve_id": cid,
+        "nvd_error": nvd.get("error"),
+        "epss_error": epss.get("error"),
+        "cvss": _extract_cvss(nvd) if has_nvd else _empty_cvss(),
+        "epss": {
+            "score": float(epss["epss"]) if not epss.get("error") and epss.get("epss") else None,
+            "percentile": float(epss["percentile"]) if not epss.get("error") and epss.get("percentile") else None,
+        },
+        "cwe": _extract_cwe(nvd) if has_nvd else [],
+        "affected": _extract_affected(nvd) if has_nvd else "Unknown",
+        "published": _extract_published(nvd) if has_nvd else "Unknown",
+        "description": _extract_description(nvd) if has_nvd else "",
+        "references": _extract_references(nvd) if has_nvd else [],
+    }
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Scoring and prioritisation
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _priority_score(profile: dict[str, Any]) -> tuple[float, list[str]]:
+    """
+    Composite priority score (higher = more urgent) with annotated reasons.
+
+    Rubric:
+      +10  in CISA KEV
+      +8   CVSS >= 9.0 (Critical)
+      +5   CVSS 7.0-8.9 (High)
+      +2   CVSS 4.0-6.9 (Medium)
+      +8   EPSS >= 0.70
+      +5   EPSS 0.40-0.69
+      +2   EPSS 0.10-0.39
+      +3   Network attack vector
+      +2   Privileges required = NONE
+      +1   User interaction = NONE
+    """
+    score = 0.0
+    reasons: list[str] = []
+
+    if profile.get("kev", {}).get("in_kev"):
+        score += 10
+        reasons.append("in CISA KEV (actively exploited)")
+
+    cvss_score = profile.get("cvss", {}).get("score")
+    if cvss_score is not None:
+        cs = float(cvss_score)
+        if cs >= 9.0:
+            score += 8
+            reasons.append(f"CVSS {cs:.1f} -- Critical severity")
+        elif cs >= 7.0:
+            score += 5
+            reasons.append(f"CVSS {cs:.1f} -- High severity")
+        elif cs >= 4.0:
+            score += 2
+            reasons.append(f"CVSS {cs:.1f} -- Medium severity")
+
+    epss = profile.get("epss", {}).get("score")
+    if epss is not None:
+        ev = float(epss)
+        if ev >= 0.70:
+            score += 8
+            reasons.append(f"EPSS {ev:.3f} -- very high exploitation probability")
+        elif ev >= 0.40:
+            score += 5
+            reasons.append(f"EPSS {ev:.3f} -- high exploitation probability")
+        elif ev >= 0.10:
+            score += 2
+            reasons.append(f"EPSS {ev:.3f} -- elevated exploitation probability")
+
+    av = (profile.get("cvss", {}).get("attack_vector") or "").upper()
+    if av == "NETWORK":
+        score += 3
+        reasons.append("remotely exploitable (network attack vector)")
+
+    pr = (profile.get("cvss", {}).get("privileges_required") or "").upper()
+    if pr == "NONE":
+        score += 2
+        reasons.append("no privileges required")
+
+    ui = (profile.get("cvss", {}).get("user_interaction") or "").upper()
+    if ui == "NONE":
+        score += 1
+        reasons.append("no user interaction required")
+
+    return score, reasons
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Report formatting helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _severity_badge(severity: str | None) -> str:
+    """Return an emoji badge for a CVSS severity string."""
+    mapping = {
+        "CRITICAL": "CRITICAL",
+        "HIGH": "HIGH",
+        "MEDIUM": "MEDIUM",
+        "LOW": "LOW",
+        "NONE": "NONE",
+    }
+    return mapping.get((severity or "").upper(), severity or "UNKNOWN")
+
+
+def _epss_label(score: float | None) -> str:
+    if score is None:
+        return "N/A"
+    if score >= 0.70:
+        return f"{score:.3f} (very high)"
+    if score >= 0.40:
+        return f"{score:.3f} (high)"
+    if score >= 0.10:
+        return f"{score:.3f} (elevated)"
+    return f"{score:.3f} (low)"
+
+
+def _delta_arrow(val_a: float | None, val_b: float | None) -> str:
+    """Return a delta string showing the numeric difference between two values."""
+    if val_a is None or val_b is None:
+        return "N/A"
+    diff = val_a - val_b
+    if abs(diff) < 0.0005:
+        return "equal"
+    sign = "+" if diff > 0 else ""
+    return f"{sign}{diff:.3f} (A-B)"
+
+
+def _na(val: Any) -> str:
+    return str(val) if val is not None else "N/A"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Report builder
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _build_diff_report(
+    profile_a: dict[str, Any],
+    profile_b: dict[str, Any],
+    kev_a: dict[str, Any],
+    kev_b: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the full structured diff-report dict."""
+    profile_a = dict(profile_a, kev=kev_a)
+    profile_b = dict(profile_b, kev=kev_b)
+
+    score_a, reasons_a = _priority_score(profile_a)
+    score_b, reasons_b = _priority_score(profile_b)
+
+    if score_a > score_b:
+        winner = profile_a["cve_id"]
+        loser = profile_b["cve_id"]
+        winner_reasons = reasons_a
+        confidence_margin = score_a - score_b
+    elif score_b > score_a:
+        winner = profile_b["cve_id"]
+        loser = profile_a["cve_id"]
+        winner_reasons = reasons_b
+        confidence_margin = score_b - score_a
+    else:
+        winner = "tie"
+        loser = "tie"
+        winner_reasons = ["scores are equal"]
+        confidence_margin = 0.0
+
+    if confidence_margin >= 10:
+        confidence = "strong"
+    elif confidence_margin >= 5:
+        confidence = "moderate"
+    elif confidence_margin > 0:
+        confidence = "weak"
+    else:
+        confidence = "tie"
+
+    cvss_a = profile_a.get("cvss", {})
+    cvss_b = profile_b.get("cvss", {})
+    epss_a = profile_a.get("epss", {}).get("score")
+    epss_b = profile_b.get("epss", {}).get("score")
+
+    sev_rank_a = _SEVERITY_ORDER.get((cvss_a.get("severity") or "").upper(), 0)
+    sev_rank_b = _SEVERITY_ORDER.get((cvss_b.get("severity") or "").upper(), 0)
+    if sev_rank_a > sev_rank_b:
+        higher_severity = profile_a["cve_id"]
+    elif sev_rank_b > sev_rank_a:
+        higher_severity = profile_b["cve_id"]
+    else:
+        higher_severity = "equal"
+
+    return {
+        "generated_at": datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "cve_a": profile_a,
+        "cve_b": profile_b,
+        "priority_score_a": score_a,
+        "priority_score_b": score_b,
+        "priority_reasons_a": reasons_a,
+        "priority_reasons_b": reasons_b,
+        "higher_priority": winner,
+        "lower_priority": loser,
+        "confidence": confidence,
+        "confidence_margin": confidence_margin,
+        "winner_reasons": winner_reasons,
+        "cvss_delta": _delta_arrow(
+            float(cvss_a["score"]) if cvss_a.get("score") is not None else None,
+            float(cvss_b["score"]) if cvss_b.get("score") is not None else None,
+        ),
+        "epss_delta": _delta_arrow(epss_a, epss_b),
+        "severity_comparison": {
+            "a": cvss_a.get("severity"),
+            "b": cvss_b.get("severity"),
+            "higher": higher_severity,
+        },
+    }
+
+
+def _render_markdown(report: dict[str, Any]) -> str:
+    """Render the diff-report dict as a rich Markdown document."""
+    pa = report["cve_a"]
+    pb = report["cve_b"]
+    cvss_a = pa.get("cvss", {})
+    cvss_b = pb.get("cvss", {})
+    epss_a = pa.get("epss", {})
+    epss_b = pb.get("epss", {})
+    kev_a = pa.get("kev", {})
+    kev_b = pb.get("kev", {})
+
+    id_a = pa["cve_id"]
+    id_b = pb["cve_id"]
+    winner = report["higher_priority"]
+    loser = report["lower_priority"]
+    confidence = report["confidence"]
+    margin = report["confidence_margin"]
+    score_a = report["priority_score_a"]
+    score_b = report["priority_score_b"]
+
+    lines: list[str] = []
+
+    # Header
+    lines.append(f"# CVE Diff Report: {id_a} vs {id_b}")
+    lines.append("")
+    lines.append(f"*Generated: {report['generated_at']}*")
+    lines.append("")
+
+    # Executive Summary
+    lines.append("## Executive Summary")
+    lines.append("")
+    if winner == "tie":
+        lines.append(
+            f"**Verdict:** Both CVEs score equally ({score_a:.0f} points each). "
+            "Manual review recommended -- consider operational context, patch availability, "
+            "and asset exposure."
+        )
+    else:
+        winner_pts = score_a if winner == id_a else score_b
+        loser_pts = score_b if winner == id_a else score_a
+        lines.append(
+            f"**Verdict:** Prioritise **{winner}** over {loser} -- "
+            f"{confidence} recommendation (score {winner_pts:.0f} vs {loser_pts:.0f}, "
+            f"margin +{margin:.0f})."
+        )
+    lines.append("")
+    if report["winner_reasons"] and winner != "tie":
+        lines.append(f"**Key factors for {winner}:**")
+        for reason in report["winner_reasons"][:4]:
+            lines.append(f"- {reason}")
+    lines.append("")
+
+    # Side-by-Side Comparison Table
+    lines.append("## Side-by-Side Comparison")
+    lines.append("")
+    lines.append(f"| Dimension | {id_a} | {id_b} | Delta / Notes |")
+    lines.append("|-----------|--------|--------|---------------|")
+
+    def row(dim: str, val_a: str, val_b: str, note: str = "") -> str:
+        return f"| {dim} | {val_a} | {val_b} | {note} |"
+
+    lines.append(row("Published", pa["published"], pb["published"]))
+    lines.append(row("Affected", pa["affected"], pb["affected"]))
+    lines.append(
+        row(
+            "CVSS Score",
+            f"{_na(cvss_a.get('score'))} ({cvss_a.get('version') or '?'})",
+            f"{_na(cvss_b.get('score'))} ({cvss_b.get('version') or '?'})",
+            report["cvss_delta"],
+        )
+    )
+    lines.append(
+        row(
+            "Severity",
+            _severity_badge(cvss_a.get("severity")),
+            _severity_badge(cvss_b.get("severity")),
+            f"Higher: {report['severity_comparison']['higher']}",
+        )
+    )
+    lines.append(
+        row(
+            "EPSS Score",
+            _epss_label(epss_a.get("score")),
+            _epss_label(epss_b.get("score")),
+            report["epss_delta"],
+        )
+    )
+    lines.append(
+        row(
+            "EPSS Percentile",
+            f"{epss_a['percentile']:.1%}" if epss_a.get("percentile") is not None else "N/A",
+            f"{epss_b['percentile']:.1%}" if epss_b.get("percentile") is not None else "N/A",
+        )
+    )
+    lines.append(
+        row(
+            "CISA KEV",
+            "YES" if kev_a.get("in_kev") else "No",
+            "YES" if kev_b.get("in_kev") else "No",
+        )
+    )
+    lines.append(
+        row(
+            "Attack Vector",
+            _na(cvss_a.get("attack_vector")),
+            _na(cvss_b.get("attack_vector")),
+        )
+    )
+    lines.append(
+        row(
+            "Privileges Req.",
+            _na(cvss_a.get("privileges_required")),
+            _na(cvss_b.get("privileges_required")),
+        )
+    )
+    lines.append(
+        row(
+            "User Interaction",
+            _na(cvss_a.get("user_interaction")),
+            _na(cvss_b.get("user_interaction")),
+        )
+    )
+    lines.append(
+        row(
+            "CVSS Vector",
+            cvss_a.get("vector") or "N/A",
+            cvss_b.get("vector") or "N/A",
+        )
+    )
+    lines.append(
+        row(
+            "CWE",
+            ", ".join(pa.get("cwe", [])) or "N/A",
+            ", ".join(pb.get("cwe", [])) or "N/A",
+        )
+    )
+    lines.append(
+        row(
+            "Priority Score",
+            f"**{score_a:.0f}**",
+            f"**{score_b:.0f}**",
+            f"Delta {score_a - score_b:+.0f}",
+        )
+    )
+    lines.append("")
+
+    # Vulnerability Summaries
+    lines.append("## Vulnerability Summaries")
+    lines.append("")
+    for cve_id, profile, cvss, epss, kev in [
+        (id_a, pa, cvss_a, epss_a, kev_a),
+        (id_b, pb, cvss_b, epss_b, kev_b),
+    ]:
+        lines.append(f"### {cve_id}")
+        lines.append("")
+        if profile.get("nvd_error"):
+            lines.append(f"> Source unavailable: {profile['nvd_error']}")
+        elif profile.get("description"):
+            lines.append(f"> {profile['description']}")
+        lines.append("")
+        lines.append(f"- **Published:** {profile['published']}")
+        lines.append(f"- **Affected:** {profile['affected']}")
+        score_str = (
+            f"{cvss.get('score')} ({cvss.get('severity')}) -- `{cvss.get('vector') or 'N/A'}`"
+            if cvss.get("score")
+            else "N/A"
+        )
+        lines.append(f"- **CVSS:** {score_str}")
+        lines.append(f"- **CWE:** {', '.join(profile.get('cwe', [])) or 'N/A'}")
+        epss_str = _epss_label(epss.get("score"))
+        pct = epss.get("percentile")
+        pct_str = f" (top {(1 - pct):.1%} of all CVEs)" if pct is not None else ""
+        if profile.get("epss_error"):
+            lines.append("- **EPSS:** Source unavailable")
+        else:
+            lines.append(f"- **EPSS:** {epss_str}{pct_str}")
+        if kev.get("in_kev"):
+            lines.append(f"- **CISA KEV:** YES -- Added {kev.get('date_added', '?')}, due {kev.get('due_date', '?')}")
+            if kev.get("required_action"):
+                lines.append(f"  - Required action: {kev['required_action']}")
+        else:
+            lines.append("- **CISA KEV:** Not in catalog")
+        lines.append("")
+
+    # CVSS Delta Analysis
+    lines.append("## CVSS Delta Analysis")
+    lines.append("")
+    cvss_score_a = cvss_a.get("score")
+    cvss_score_b = cvss_b.get("score")
+    if cvss_score_a is not None and cvss_score_b is not None:
+        diff = float(cvss_score_a) - float(cvss_score_b)
+        lines.append(f"CVSS score difference: **{diff:+.1f}** ({id_a}: {cvss_score_a} vs {id_b}: {cvss_score_b}).")
+        lines.append("")
+        lines.append("**Impact dimensions:**")
+        lines.append("")
+        lines.append(f"| Impact | {id_a} | {id_b} |")
+        lines.append("|--------|--------|--------|")
+        for dim in ("confidentiality_impact", "integrity_impact", "availability_impact"):
+            label = dim.replace("_impact", "").capitalize()
+            lines.append(f"| {label} | {_na(cvss_a.get(dim))} | {_na(cvss_b.get(dim))} |")
+        lines.append("")
+        lines.append("**Exploitability dimensions:**")
+        lines.append("")
+        lines.append(f"| Dimension | {id_a} | {id_b} |")
+        lines.append("|-----------|--------|--------|")
+        for dim, label in [
+            ("attack_vector", "Attack Vector"),
+            ("privileges_required", "Privileges Required"),
+            ("user_interaction", "User Interaction"),
+            ("scope", "Scope"),
+        ]:
+            lines.append(f"| {label} | {_na(cvss_a.get(dim))} | {_na(cvss_b.get(dim))} |")
+    else:
+        lines.append("CVSS data unavailable for one or both CVEs -- delta analysis skipped.")
+    lines.append("")
+
+    # EPSS Probability Divergence
+    lines.append("## EPSS Exploitation Probability Divergence")
+    lines.append("")
+    epss_score_a = epss_a.get("score")
+    epss_score_b = epss_b.get("score")
+    if epss_score_a is not None and epss_score_b is not None:
+        epss_diff = float(epss_score_a) - float(epss_score_b)
+        lines.append(
+            f"EPSS score difference: **{epss_diff:+.4f}** ({id_a}: {epss_score_a:.4f} vs {id_b}: {epss_score_b:.4f})."
+        )
+        lines.append("")
+        if abs(epss_diff) < 0.01:
+            lines.append("EPSS scores are nearly identical -- exploitation probability is comparable for both CVEs.")
+        elif abs(epss_diff) < 0.10:
+            higher_id = id_a if epss_diff > 0 else id_b
+            lines.append(
+                f"{higher_id} has a modestly higher exploitation probability. "
+                "The difference is small enough that operational context (e.g., internet exposure, "
+                "asset criticality) should drive final prioritisation."
+            )
+        else:
+            higher_id = id_a if epss_diff > 0 else id_b
+            lower_id = id_b if epss_diff > 0 else id_a
+            higher_score = epss_score_a if epss_diff > 0 else epss_score_b
+            lower_score = epss_score_b if epss_diff > 0 else epss_score_a
+            lines.append(
+                f"{higher_id} (EPSS {higher_score:.4f}) has a significantly higher exploitation "
+                f"probability than {lower_id} (EPSS {lower_score:.4f}). "
+                "This gap strongly differentiates the two CVEs when CVSS scores are similar."
+            )
+    else:
+        lines.append("EPSS data unavailable for one or both CVEs -- divergence analysis skipped.")
+    lines.append("")
+
+    # KEV Exploitation Status
+    lines.append("## CISA KEV Exploitation Status")
+    lines.append("")
+    both_kev = kev_a.get("in_kev") and kev_b.get("in_kev")
+    either_kev = kev_a.get("in_kev") or kev_b.get("in_kev")
+    if both_kev:
+        lines.append(
+            f"Both {id_a} and {id_b} are in CISA KEV -- both represent confirmed exploitation "
+            "in the wild. Treat both as P0 and escalate immediately. Use CVSS, EPSS, and asset "
+            "exposure to determine patching order."
+        )
+    elif either_kev:
+        kev_id = id_a if kev_a.get("in_kev") else id_b
+        no_kev_id = id_b if kev_a.get("in_kev") else id_a
+        kev_entry = kev_a if kev_a.get("in_kev") else kev_b
+        lines.append(
+            f"{kev_id} is in CISA KEV -- confirmed exploitation in the wild. "
+            f"{no_kev_id} is not in KEV. "
+            f"Binding Operational Directive 22-01 requires federal agencies to remediate {kev_id} "
+            f"by **{kev_entry.get('due_date', 'the stated due date')}**."
+        )
+        if kev_entry.get("required_action"):
+            lines.append("")
+            lines.append(f"**Required action for {kev_id}:** {kev_entry['required_action']}")
+    else:
+        lines.append(
+            "Neither CVE is currently in CISA KEV. "
+            "This does not rule out exploitation in the wild -- consult EPSS scores and threat feeds."
+        )
+    lines.append("")
+
+    # CWE Class Comparison
+    lines.append("## CWE Weakness Class Comparison")
+    lines.append("")
+    cwe_a = pa.get("cwe", [])
+    cwe_b = pb.get("cwe", [])
+    shared = set(cwe_a) & set(cwe_b)
+    only_a = set(cwe_a) - set(cwe_b)
+    only_b = set(cwe_b) - set(cwe_a)
+
+    lines.append(f"| | {id_a} | {id_b} |")
+    lines.append("|---|------|------|")
+    lines.append(f"| CWEs | {', '.join(cwe_a) or 'N/A'} | {', '.join(cwe_b) or 'N/A'} |")
+    lines.append("")
+    if shared:
+        lines.append(f"**Shared weakness classes:** {', '.join(sorted(shared))}")
+        lines.append("")
+        lines.append(
+            "These CVEs share the same root weakness class(es), suggesting they may be related "
+            "variants or that the same code pattern is exploited in both cases."
+        )
+    elif cwe_a and cwe_b:
+        only_a_str = ", ".join(sorted(only_a)) if only_a else "none"
+        only_b_str = ", ".join(sorted(only_b)) if only_b else "none"
+        lines.append(
+            f"**Distinct weakness classes** -- {id_a} ({only_a_str}) and {id_b} ({only_b_str}) "
+            "affect different vulnerability categories. No pattern overlap detected."
+        )
+    else:
+        lines.append("CWE data unavailable for one or both CVEs.")
+    lines.append("")
+
+    # Prioritisation Rationale
+    lines.append("## Prioritisation Rationale")
+    lines.append("")
+    if winner == "tie":
+        lines.append("### Tie -- Manual Review Required")
+        lines.append("")
+        lines.append(f"Both {id_a} and {id_b} score identically ({score_a:.0f} points). Use the following tiebreakers:")
+        lines.append("")
+        lines.append("1. **Asset exposure** -- which affected component is directly internet-accessible?")
+        lines.append("2. **Patch availability** -- which has a confirmed fix or workaround?")
+        lines.append("3. **Blast radius** -- how many downstream dependents are affected?")
+        lines.append("4. **EPSS trajectory** -- is either score trending upward?")
+    else:
+        confidence_label = {
+            "strong": "Strong Recommendation",
+            "moderate": "Moderate Recommendation",
+            "weak": "Weak Recommendation",
+        }.get(confidence, "Recommendation")
+        lines.append(f"### {confidence_label}: Prioritise {winner}")
+        lines.append("")
+        winner_pts = score_a if winner == id_a else score_b
+        loser_pts = score_b if winner == id_a else score_a
+        lines.append(
+            f"**{winner}** scores {winner_pts:.0f} vs {loser_pts:.0f} for {loser} (margin: +{margin:.0f} points)."
+        )
+        lines.append("")
+        lines.append(f"**Scoring factors for {winner}:**")
+        for r in report["winner_reasons"]:
+            lines.append(f"- {r}")
+        lines.append("")
+        loser_reasons = report["priority_reasons_b"] if winner == id_a else report["priority_reasons_a"]
+        lines.append(f"**Scoring factors for {loser}:**")
+        if loser_reasons:
+            for r in loser_reasons:
+                lines.append(f"- {r}")
+        else:
+            lines.append("- No significant scoring factors detected")
+        lines.append("")
+        if confidence == "weak":
+            lines.append(
+                "> **Weak confidence:** The score margin is small. Verify EPSS trends, "
+                "active exploitation reports, and asset-specific context before committing resources."
+            )
+    lines.append("")
+
+    # References
+    lines.append("## References")
+    lines.append("")
+    for cve_id, profile in [(id_a, pa), (id_b, pb)]:
+        lines.append(f"**{cve_id}**")
+        lines.append(f"- NVD: https://nvd.nist.gov/vuln/detail/{cve_id}")
+        for ref in profile.get("references", []):
+            lines.append(f"- {ref}")
+        lines.append("")
+    lines.append("---")
+    lines.append("")
+    lines.append(
+        "*This report was generated by manus-agent. Data sourced from NVD, FIRST EPSS, and CISA KEV. "
+        "Scores reflect point-in-time data and may change as exploitation evidence evolves.*"
+    )
+
+    return "\n".join(lines)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Strands tool entry point
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def diff_report_cves(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Generate a rich Markdown diff-report comparing two CVEs."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+
+    cve_id_a = str(tool_input.get("cve_id_a", "")).strip()
+    cve_id_b = str(tool_input.get("cve_id_b", "")).strip()
+    output_format = str(tool_input.get("output_format", "markdown")).lower()
+
+    for cid in (cve_id_a, cve_id_b):
+        if not _CVE_RE.match(cid):
+            result: ToolResult = {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [
+                    {"text": (f"Invalid CVE ID '{cid}'. Expected format: CVE-YYYY-NNNN (e.g. CVE-2021-44228).")}
+                ],
+            }
+            log_tool_output_size("diff_report_cves", result)
+            return result
+
+    # Fetch all four data sources concurrently
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as ex:
+        f_a = ex.submit(_build_profile, cve_id_a)
+        f_b = ex.submit(_build_profile, cve_id_b)
+        f_kev_a = ex.submit(_fetch_kev, cve_id_a)
+        f_kev_b = ex.submit(_fetch_kev, cve_id_b)
+        profile_a = f_a.result()
+        profile_b = f_b.result()
+        kev_a = f_kev_a.result()
+        kev_b = f_kev_b.result()
+
+    report = _build_diff_report(profile_a, profile_b, kev_a, kev_b)
+
+    if output_format == "json":
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"json": report}],
+        }
+    else:
+        md = _render_markdown(report)
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [
+                {"text": md},
+                {"json": report},
+            ],
+        }
+
+    log_tool_output_size("diff_report_cves", result)
+    return result

--- a/tests/test_diff_report_cves.py
+++ b/tests/test_diff_report_cves.py
@@ -1,0 +1,1154 @@
+"""Tests for diff_report_cves tool and diff-report CLI subcommand.
+
+All external HTTP calls are mocked; no real network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Fixtures – minimal mock payloads
+# ──────────────────────────────────────────────────────────────────────────────
+
+_NVD_PAYLOAD_A = {
+    "id": "CVE-2021-44228",
+    "published": "2021-12-10T10:15:00.000",
+    "descriptions": [{"lang": "en", "value": "Apache Log4j2 RCE via JNDI lookup."}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 10.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                    "scope": "CHANGED",
+                    "confidentialityImpact": "HIGH",
+                    "integrityImpact": "HIGH",
+                    "availabilityImpact": "HIGH",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"value": "CWE-917"}]}],
+    "configurations": [{"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:apache:log4j:2.0:*:*:*:*:*:*:*"}]}]}],
+    "references": [
+        {"url": "https://logging.apache.org/log4j/2.x/security.html"},
+        {"url": "https://github.com/apache/logging-log4j2"},
+    ],
+}
+
+_NVD_PAYLOAD_B = {
+    "id": "CVE-2021-45046",
+    "published": "2021-12-14T19:15:00.000",
+    "descriptions": [{"lang": "en", "value": "Apache Log4j2 incomplete fix for CVE-2021-44228."}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 9.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                    "scope": "CHANGED",
+                    "confidentialityImpact": "HIGH",
+                    "integrityImpact": "HIGH",
+                    "availabilityImpact": "HIGH",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"value": "CWE-917"}]}],
+    "configurations": [{"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:apache:log4j:2.0:*:*:*:*:*:*:*"}]}]}],
+    "references": [
+        {"url": "https://logging.apache.org/log4j/2.x/security.html"},
+    ],
+}
+
+_NVD_RESPONSE_A = {"vulnerabilities": [{"cve": _NVD_PAYLOAD_A}]}
+_NVD_RESPONSE_B = {"vulnerabilities": [{"cve": _NVD_PAYLOAD_B}]}
+
+_EPSS_RESPONSE_A = {"data": [{"cve": "CVE-2021-44228", "epss": "0.975", "percentile": "0.999"}]}
+_EPSS_RESPONSE_B = {"data": [{"cve": "CVE-2021-45046", "epss": "0.820", "percentile": "0.997"}]}
+
+_KEV_CATALOG = {
+    "vulnerabilities": [
+        {
+            "cveID": "CVE-2021-44228",
+            "vendorProject": "Apache",
+            "product": "Log4j",
+            "dateAdded": "2021-12-10",
+            "dueDate": "2021-12-24",
+            "requiredAction": "Apply updates per vendor instructions.",
+        }
+    ]
+}
+
+_KEV_EMPTY = {"vulnerabilities": []}
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _mock_response(json_data: dict, status_code: int = 200) -> MagicMock:
+    m = MagicMock()
+    m.status_code = status_code
+    m.json.return_value = json_data
+    m.raise_for_status = MagicMock()
+    return m
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Unit tests – internal helpers
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestExtractHelpers:
+    def test_extract_cvss_v31(self):
+        from manus_agent.tools.diff_report_cves import _extract_cvss
+
+        result = _extract_cvss(_NVD_PAYLOAD_A)
+        assert result["score"] == 10.0
+        assert result["severity"] == "CRITICAL"
+        assert result["attack_vector"] == "NETWORK"
+        assert result["privileges_required"] == "NONE"
+        assert result["user_interaction"] == "NONE"
+        assert result["version"] == "3.1"
+
+    def test_extract_cvss_v2_fallback(self):
+        from manus_agent.tools.diff_report_cves import _extract_cvss
+
+        nvd = {
+            "metrics": {
+                "cvssMetricV2": [
+                    {
+                        "baseSeverity": "HIGH",
+                        "cvssData": {
+                            "baseScore": 7.5,
+                            "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                            "accessVector": "NETWORK",
+                            "confidentialityImpact": "PARTIAL",
+                            "integrityImpact": "PARTIAL",
+                            "availabilityImpact": "PARTIAL",
+                        },
+                    }
+                ]
+            }
+        }
+        result = _extract_cvss(nvd)
+        assert result["version"] == "2.0"
+        assert result["score"] == 7.5
+        assert result["severity"] == "HIGH"
+
+    def test_extract_cvss_empty(self):
+        from manus_agent.tools.diff_report_cves import _empty_cvss, _extract_cvss
+
+        result = _extract_cvss({})
+        assert result == _empty_cvss()
+
+    def test_extract_cwe(self):
+        from manus_agent.tools.diff_report_cves import _extract_cwe
+
+        result = _extract_cwe(_NVD_PAYLOAD_A)
+        assert result == ["CWE-917"]
+
+    def test_extract_cwe_filters_noinfo(self):
+        from manus_agent.tools.diff_report_cves import _extract_cwe
+
+        nvd = {
+            "weaknesses": [
+                {
+                    "description": [
+                        {"value": "NVD-CWE-noinfo"},
+                        {"value": "NVD-CWE-Other"},
+                        {"value": "CWE-79"},
+                    ]
+                }
+            ]
+        }
+        result = _extract_cwe(nvd)
+        assert result == ["CWE-79"]
+
+    def test_extract_affected(self):
+        from manus_agent.tools.diff_report_cves import _extract_affected
+
+        result = _extract_affected(_NVD_PAYLOAD_A)
+        assert result == "Apache / Log4J"
+
+    def test_extract_affected_empty(self):
+        from manus_agent.tools.diff_report_cves import _extract_affected
+
+        result = _extract_affected({})
+        assert result == "Unknown"
+
+    def test_extract_published(self):
+        from manus_agent.tools.diff_report_cves import _extract_published
+
+        result = _extract_published(_NVD_PAYLOAD_A)
+        assert result == "2021-12-10"
+
+    def test_extract_published_empty(self):
+        from manus_agent.tools.diff_report_cves import _extract_published
+
+        result = _extract_published({})
+        assert result == "Unknown"
+
+    def test_extract_description_truncation(self):
+        from manus_agent.tools.diff_report_cves import _extract_description
+
+        long_val = "x" * 500
+        nvd = {"descriptions": [{"lang": "en", "value": long_val}]}
+        result = _extract_description(nvd, max_chars=100)
+        assert len(result) == 103  # 100 chars + "..."
+        assert result.endswith("...")
+
+    def test_extract_references(self):
+        from manus_agent.tools.diff_report_cves import _extract_references
+
+        result = _extract_references(_NVD_PAYLOAD_A, limit=1)
+        assert len(result) == 1
+        assert "apache.org" in result[0]
+
+
+class TestFetchHelpers:
+    def test_fetch_nvd_success(self):
+        from manus_agent.tools.diff_report_cves import _fetch_nvd
+
+        with patch("requests.get", return_value=_mock_response(_NVD_RESPONSE_A)):
+            result = _fetch_nvd("CVE-2021-44228")
+        assert result["id"] == "CVE-2021-44228"
+        assert "error" not in result
+
+    def test_fetch_nvd_not_found(self):
+        from manus_agent.tools.diff_report_cves import _fetch_nvd
+
+        with patch("requests.get", return_value=_mock_response({"vulnerabilities": []})):
+            result = _fetch_nvd("CVE-9999-99999")
+        assert "error" in result
+
+    def test_fetch_nvd_request_exception(self):
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import _fetch_nvd
+
+        with patch("requests.get", side_effect=_req.RequestException("timeout")):
+            result = _fetch_nvd("CVE-2021-44228")
+        assert "error" in result
+        assert "timeout" in result["error"]
+
+    def test_fetch_epss_success(self):
+        from manus_agent.tools.diff_report_cves import _fetch_epss
+
+        with patch("requests.get", return_value=_mock_response(_EPSS_RESPONSE_A)):
+            result = _fetch_epss("CVE-2021-44228")
+        assert result["epss"] == "0.975"
+        assert "error" not in result
+
+    def test_fetch_epss_not_found(self):
+        from manus_agent.tools.diff_report_cves import _fetch_epss
+
+        with patch("requests.get", return_value=_mock_response({"data": []})):
+            result = _fetch_epss("CVE-9999-99999")
+        assert "error" in result
+
+    def test_fetch_epss_request_exception(self):
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import _fetch_epss
+
+        with patch("requests.get", side_effect=_req.RequestException("refused")):
+            result = _fetch_epss("CVE-2021-44228")
+        assert "error" in result
+
+    def test_fetch_kev_in_catalog(self):
+        from manus_agent.tools.diff_report_cves import _fetch_kev
+
+        with patch("requests.get", return_value=_mock_response(_KEV_CATALOG)):
+            result = _fetch_kev("CVE-2021-44228")
+        assert result["in_kev"] is True
+        assert result["date_added"] == "2021-12-10"
+        assert result["required_action"] == "Apply updates per vendor instructions."
+
+    def test_fetch_kev_not_in_catalog(self):
+        from manus_agent.tools.diff_report_cves import _fetch_kev
+
+        with patch("requests.get", return_value=_mock_response(_KEV_CATALOG)):
+            result = _fetch_kev("CVE-2021-45046")
+        assert result["in_kev"] is False
+
+    def test_fetch_kev_request_exception(self):
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import _fetch_kev
+
+        with patch("requests.get", side_effect=_req.RequestException("timeout")):
+            result = _fetch_kev("CVE-2021-44228")
+        assert result["in_kev"] is False
+        assert "error" in result
+
+
+class TestBuildProfile:
+    def test_build_profile_success(self):
+        from manus_agent.tools.diff_report_cves import _build_profile
+
+        def mock_get(url, **kwargs):
+            if "nvd.nist.gov" in url:
+                return _mock_response(_NVD_RESPONSE_A)
+            return _mock_response(_EPSS_RESPONSE_A)
+
+        with patch("requests.get", side_effect=mock_get):
+            profile = _build_profile("CVE-2021-44228")
+
+        assert profile["cve_id"] == "CVE-2021-44228"
+        assert profile["cvss"]["score"] == 10.0
+        assert profile["epss"]["score"] == pytest.approx(0.975, abs=0.001)
+        assert profile["cwe"] == ["CWE-917"]
+        assert profile["nvd_error"] is None
+
+    def test_build_profile_nvd_error_degrades(self):
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import _build_profile, _empty_cvss
+
+        def mock_get(url, **kwargs):
+            if "nvd.nist.gov" in url:
+                raise _req.RequestException("timeout")
+            return _mock_response(_EPSS_RESPONSE_A)
+
+        with patch("requests.get", side_effect=mock_get):
+            profile = _build_profile("CVE-2021-44228")
+
+        assert profile["nvd_error"] is not None
+        assert profile["cvss"] == _empty_cvss()
+        assert profile["cwe"] == []
+        # EPSS still populated
+        assert profile["epss"]["score"] == pytest.approx(0.975, abs=0.001)
+
+    def test_build_profile_epss_error_degrades(self):
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import _build_profile
+
+        def mock_get(url, **kwargs):
+            if "first.org" in url:
+                raise _req.RequestException("timeout")
+            return _mock_response(_NVD_RESPONSE_A)
+
+        with patch("requests.get", side_effect=mock_get):
+            profile = _build_profile("CVE-2021-44228")
+
+        assert profile["epss_error"] is not None
+        assert profile["epss"]["score"] is None
+        # NVD still populated
+        assert profile["cvss"]["score"] == 10.0
+
+
+class TestPriorityScore:
+    def test_kev_adds_10_points(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {"in_kev": True},
+            "cvss": {},
+            "epss": {},
+        }
+        score, reasons = _priority_score(profile)
+        assert score >= 10
+        assert any("KEV" in r for r in reasons)
+
+    def test_critical_cvss_adds_8_points(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {"in_kev": False},
+            "cvss": {"score": 9.8, "attack_vector": None, "privileges_required": None, "user_interaction": None},
+            "epss": {},
+        }
+        score, reasons = _priority_score(profile)
+        assert score == 8
+        assert any("9.8" in r for r in reasons)
+
+    def test_high_cvss_adds_5_points(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {"score": 8.1, "attack_vector": None, "privileges_required": None, "user_interaction": None},
+            "epss": {},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 5
+
+    def test_medium_cvss_adds_2_points(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {"score": 5.0, "attack_vector": None, "privileges_required": None, "user_interaction": None},
+            "epss": {},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 2
+
+    def test_epss_very_high_adds_8(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {},
+            "epss": {"score": 0.85},
+        }
+        score, reasons = _priority_score(profile)
+        assert score == 8
+        assert any("very high" in r for r in reasons)
+
+    def test_network_av_adds_3(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {"score": None, "attack_vector": "NETWORK", "privileges_required": None, "user_interaction": None},
+            "epss": {},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 3
+
+    def test_no_privileges_adds_2(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {
+                "score": None,
+                "attack_vector": None,
+                "privileges_required": "NONE",
+                "user_interaction": None,
+            },
+            "epss": {},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 2
+
+    def test_no_user_interaction_adds_1(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        profile = {
+            "kev": {},
+            "cvss": {
+                "score": None,
+                "attack_vector": None,
+                "privileges_required": None,
+                "user_interaction": "NONE",
+            },
+            "epss": {},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 1
+
+    def test_composite_log4shell(self):
+        from manus_agent.tools.diff_report_cves import _priority_score
+
+        # KEV(10) + CVSS 10.0(8) + EPSS 0.975(8) + NETWORK(3) + NO_PR(2) + NO_UI(1) = 32
+        profile = {
+            "kev": {"in_kev": True},
+            "cvss": {
+                "score": 10.0,
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+            },
+            "epss": {"score": 0.975},
+        }
+        score, _ = _priority_score(profile)
+        assert score == 32.0
+
+
+class TestBuildDiffReport:
+    def _make_profiles(self):
+
+        def mock_get(url, **kwargs):
+            if "CVE-2021-44228" in url or "first.org" in url and "44228" in str(kwargs):
+                pass
+            return None
+
+        # Build synthetic profiles directly
+        profile_a = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 10.0,
+                "severity": "CRITICAL",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "scope": "CHANGED",
+                "confidentiality_impact": "HIGH",
+                "integrity_impact": "HIGH",
+                "availability_impact": "HIGH",
+            },
+            "epss": {"score": 0.975, "percentile": 0.999},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4J",
+            "published": "2021-12-10",
+            "description": "Apache Log4j2 RCE via JNDI lookup.",
+            "references": ["https://logging.apache.org/log4j/2.x/security.html"],
+        }
+        profile_b = {
+            "cve_id": "CVE-2021-45046",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 9.0,
+                "severity": "CRITICAL",
+                "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "scope": "CHANGED",
+                "confidentiality_impact": "HIGH",
+                "integrity_impact": "HIGH",
+                "availability_impact": "HIGH",
+            },
+            "epss": {"score": 0.820, "percentile": 0.997},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4J",
+            "published": "2021-12-14",
+            "description": "Incomplete fix for CVE-2021-44228.",
+            "references": [],
+        }
+        kev_a = {
+            "in_kev": True,
+            "date_added": "2021-12-10",
+            "due_date": "2021-12-24",
+            "required_action": "Apply updates.",
+        }
+        kev_b = {"in_kev": False}
+        return profile_a, profile_b, kev_a, kev_b
+
+    def test_winner_is_higher_scorer(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        # A has KEV (+10) so should win
+        assert report["higher_priority"] == "CVE-2021-44228"
+        assert report["lower_priority"] == "CVE-2021-45046"
+        assert report["priority_score_a"] > report["priority_score_b"]
+
+    def test_confidence_margin_strong(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        assert report["confidence"] == "strong"
+        assert report["confidence_margin"] >= 10
+
+    def test_tie_when_equal_scores(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, _, _ = self._make_profiles()
+        # Make both identical — no KEV for either
+        kev_empty = {"in_kev": False}
+        # Same profile for both
+        report = _build_diff_report(pa, pa, kev_empty, kev_empty)
+        assert report["higher_priority"] == "tie"
+        assert report["confidence"] == "tie"
+
+    def test_cvss_delta_computed(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        # 10.0 - 9.0 = +1.0
+        assert "+1.000" in report["cvss_delta"]
+
+    def test_epss_delta_computed(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        # 0.975 - 0.820 = 0.155
+        assert "0.155" in report["epss_delta"]
+
+    def test_severity_comparison(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        # Both CRITICAL → equal
+        assert report["severity_comparison"]["higher"] == "equal"
+
+    def test_severity_comparison_a_higher(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        pb = dict(pb)
+        pb["cvss"] = dict(pb["cvss"], severity="HIGH")
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        assert report["severity_comparison"]["higher"] == "CVE-2021-44228"
+
+    def test_generated_at_field_present(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        pa, pb, kev_a, kev_b = self._make_profiles()
+        report = _build_diff_report(pa, pb, kev_a, kev_b)
+        assert "generated_at" in report
+        assert "UTC" in report["generated_at"]
+
+    def test_delta_arrow_none_values(self):
+        from manus_agent.tools.diff_report_cves import _delta_arrow
+
+        assert _delta_arrow(None, 1.0) == "N/A"
+        assert _delta_arrow(1.0, None) == "N/A"
+        assert _delta_arrow(None, None) == "N/A"
+
+    def test_delta_arrow_equal_values(self):
+        from manus_agent.tools.diff_report_cves import _delta_arrow
+
+        result = _delta_arrow(0.500, 0.500)
+        assert result == "equal"
+
+    def test_delta_arrow_positive(self):
+        from manus_agent.tools.diff_report_cves import _delta_arrow
+
+        result = _delta_arrow(9.8, 7.5)
+        assert result.startswith("+2.300")
+
+    def test_delta_arrow_negative(self):
+        from manus_agent.tools.diff_report_cves import _delta_arrow
+
+        result = _delta_arrow(5.0, 9.0)
+        assert result.startswith("-4.000")
+
+
+class TestRenderMarkdown:
+    def _build_report(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report
+
+        profile_a = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 10.0,
+                "severity": "CRITICAL",
+                "vector": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "scope": "CHANGED",
+                "confidentiality_impact": "HIGH",
+                "integrity_impact": "HIGH",
+                "availability_impact": "HIGH",
+            },
+            "epss": {"score": 0.975, "percentile": 0.999},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4J",
+            "published": "2021-12-10",
+            "description": "Apache Log4j2 RCE via JNDI lookup.",
+            "references": ["https://logging.apache.org/log4j/2.x/security.html"],
+        }
+        profile_b = {
+            "cve_id": "CVE-2021-45046",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 9.0,
+                "severity": "CRITICAL",
+                "vector": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "scope": "CHANGED",
+                "confidentiality_impact": "HIGH",
+                "integrity_impact": "HIGH",
+                "availability_impact": "HIGH",
+            },
+            "epss": {"score": 0.820, "percentile": 0.997},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4J",
+            "published": "2021-12-14",
+            "description": "Incomplete fix.",
+            "references": [],
+        }
+        kev_a = {"in_kev": True, "date_added": "2021-12-10", "due_date": "2021-12-24", "required_action": "Apply."}
+        kev_b = {"in_kev": False}
+        return _build_diff_report(profile_a, profile_b, kev_a, kev_b)
+
+    def test_markdown_has_header(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "# CVE Diff Report:" in md
+        assert "CVE-2021-44228" in md
+        assert "CVE-2021-45046" in md
+
+    def test_markdown_has_executive_summary(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## Executive Summary" in md
+        assert "Verdict" in md
+
+    def test_markdown_has_comparison_table(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## Side-by-Side Comparison" in md
+        assert "| Dimension |" in md
+        assert "CVSS Score" in md
+        assert "EPSS Score" in md
+        assert "CISA KEV" in md
+
+    def test_markdown_has_cvss_delta(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## CVSS Delta Analysis" in md
+        assert "+1.0" in md
+
+    def test_markdown_has_epss_divergence(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## EPSS Exploitation Probability Divergence" in md
+
+    def test_markdown_has_kev_section(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## CISA KEV Exploitation Status" in md
+        assert "CVE-2021-44228" in md
+
+    def test_markdown_has_cwe_section(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## CWE Weakness Class Comparison" in md
+        assert "CWE-917" in md
+
+    def test_markdown_shared_cwe_note(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        # Both have CWE-917, should note shared classes
+        assert "Shared weakness classes" in md
+
+    def test_markdown_has_prioritisation(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## Prioritisation Rationale" in md
+
+    def test_markdown_has_references(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "## References" in md
+        assert "nvd.nist.gov" in md
+
+    def test_markdown_has_footer_disclaimer(self):
+        from manus_agent.tools.diff_report_cves import _render_markdown
+
+        report = self._build_report()
+        md = _render_markdown(report)
+        assert "manus-agent" in md
+        assert "NVD" in md
+        assert "FIRST EPSS" in md
+
+    def test_markdown_tie_report(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report, _render_markdown
+
+        profile = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 7.5,
+                "severity": "HIGH",
+                "vector": "X",
+                "attack_vector": "NETWORK",
+                "privileges_required": None,
+                "user_interaction": None,
+                "scope": None,
+                "confidentiality_impact": None,
+                "integrity_impact": None,
+                "availability_impact": None,
+            },
+            "epss": {"score": 0.1, "percentile": 0.8},
+            "cwe": ["CWE-79"],
+            "affected": "Example Corp / Widget",
+            "published": "2021-01-01",
+            "description": "XSS",
+            "references": [],
+        }
+        profile_b = dict(profile, cve_id="CVE-2021-99999")
+        report = _build_diff_report(profile, profile_b, {"in_kev": False}, {"in_kev": False})
+        md = _render_markdown(report)
+        assert "Tie" in md or "tie" in md.lower()
+
+    def test_markdown_both_kev(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report, _render_markdown
+
+        profile_a = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 10.0,
+                "severity": "CRITICAL",
+                "vector": "X",
+                "attack_vector": "NETWORK",
+                "privileges_required": "NONE",
+                "user_interaction": "NONE",
+                "scope": None,
+                "confidentiality_impact": None,
+                "integrity_impact": None,
+                "availability_impact": None,
+            },
+            "epss": {"score": 0.97, "percentile": 0.99},
+            "cwe": ["CWE-917"],
+            "affected": "Apache / Log4J",
+            "published": "2021-12-10",
+            "description": "Log4Shell",
+            "references": [],
+        }
+        profile_b = dict(profile_a, cve_id="CVE-2021-45046")
+        kev_both = {"in_kev": True, "date_added": "2021-12-10", "due_date": "2021-12-24", "required_action": "Apply."}
+        report = _build_diff_report(profile_a, profile_b, kev_both, kev_both)
+        md = _render_markdown(report)
+        assert "Both" in md or "both" in md.lower()
+
+    def test_markdown_neither_kev(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report, _render_markdown
+
+        profile = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 7.5,
+                "severity": "HIGH",
+                "vector": "X",
+                "attack_vector": "NETWORK",
+                "privileges_required": None,
+                "user_interaction": None,
+                "scope": None,
+                "confidentiality_impact": None,
+                "integrity_impact": None,
+                "availability_impact": None,
+            },
+            "epss": {"score": 0.1, "percentile": 0.5},
+            "cwe": ["CWE-79"],
+            "affected": "Foo / Bar",
+            "published": "2021-01-01",
+            "description": "XSS",
+            "references": [],
+        }
+        profile_b = dict(profile, cve_id="CVE-2021-99999")
+        report = _build_diff_report(profile, profile_b, {"in_kev": False}, {"in_kev": False})
+        md = _render_markdown(report)
+        assert "Neither" in md
+
+    def test_markdown_nvd_error_note(self):
+        from manus_agent.tools.diff_report_cves import _build_diff_report, _render_markdown
+
+        profile_a = {
+            "cve_id": "CVE-9999-0001",
+            "nvd_error": "No NVD record found",
+            "epss_error": None,
+            "cvss": {
+                "version": None,
+                "score": None,
+                "severity": None,
+                "vector": None,
+                "attack_vector": None,
+                "privileges_required": None,
+                "user_interaction": None,
+                "scope": None,
+                "confidentiality_impact": None,
+                "integrity_impact": None,
+                "availability_impact": None,
+            },
+            "epss": {"score": 0.05, "percentile": 0.3},
+            "cwe": [],
+            "affected": "Unknown",
+            "published": "Unknown",
+            "description": "",
+            "references": [],
+        }
+        profile_b = {
+            "cve_id": "CVE-9999-0002",
+            "nvd_error": None,
+            "epss_error": None,
+            "cvss": {
+                "version": "3.1",
+                "score": 5.5,
+                "severity": "MEDIUM",
+                "vector": "X",
+                "attack_vector": "NETWORK",
+                "privileges_required": None,
+                "user_interaction": None,
+                "scope": None,
+                "confidentiality_impact": None,
+                "integrity_impact": None,
+                "availability_impact": None,
+            },
+            "epss": {"score": 0.05, "percentile": 0.3},
+            "cwe": ["CWE-79"],
+            "affected": "Foo / Bar",
+            "published": "2021-01-01",
+            "description": "XSS",
+            "references": [],
+        }
+        report = _build_diff_report(profile_a, profile_b, {"in_kev": False}, {"in_kev": False})
+        md = _render_markdown(report)
+        assert "Source unavailable" in md
+
+
+class TestDiffReportCvesTool:
+    """Tests for the Strands tool entry point."""
+
+    def _make_tool_use(self, cve_id_a: str, cve_id_b: str, fmt: str = "markdown") -> dict:
+        return {
+            "toolUseId": "test-tool-use-id",
+            "name": "diff_report_cves",
+            "input": {"cve_id_a": cve_id_a, "cve_id_b": cve_id_b, "output_format": fmt},
+        }
+
+    def _make_mock_get(self):
+        def mock_get(url, **kwargs):
+            params = kwargs.get("params", {})
+            if "nvd.nist.gov" in url:
+                if "44228" in url:
+                    return _mock_response(_NVD_RESPONSE_A)
+                return _mock_response(_NVD_RESPONSE_B)
+            if "first.org" in url:
+                if "44228" in str(params):
+                    return _mock_response(_EPSS_RESPONSE_A)
+                return _mock_response(_EPSS_RESPONSE_B)
+            if "cisa.gov" in url:
+                return _mock_response(_KEV_CATALOG)
+            return _mock_response({})
+
+        return mock_get
+
+    def test_tool_returns_markdown_success(self):
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        tool = self._make_tool_use("CVE-2021-44228", "CVE-2021-45046", "markdown")
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            result = diff_report_cves(tool)
+
+        assert result["status"] == "success"
+        text_content = next(c["text"] for c in result["content"] if "text" in c)
+        assert "# CVE Diff Report:" in text_content
+        json_content = next(c["json"] for c in result["content"] if "json" in c)
+        assert "higher_priority" in json_content
+
+    def test_tool_returns_json_success(self):
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        tool = self._make_tool_use("CVE-2021-44228", "CVE-2021-45046", "json")
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            result = diff_report_cves(tool)
+
+        assert result["status"] == "success"
+        assert len(result["content"]) == 1
+        assert "json" in result["content"][0]
+
+    def test_tool_invalid_cve_a(self):
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        tool = self._make_tool_use("NOT-A-CVE", "CVE-2021-45046")
+        result = diff_report_cves(tool)
+        assert result["status"] == "error"
+        assert "NOT-A-CVE" in result["content"][0]["text"]
+
+    def test_tool_invalid_cve_b(self):
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        tool = self._make_tool_use("CVE-2021-44228", "BADID")
+        result = diff_report_cves(tool)
+        assert result["status"] == "error"
+        assert "BADID" in result["content"][0]["text"]
+
+    def test_tool_degraded_nvd(self):
+        """Tool still returns success even when NVD is unavailable."""
+        import requests as _req
+
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        def mock_get(url, **kwargs):
+            if "nvd.nist.gov" in url:
+                raise _req.RequestException("timeout")
+            if "first.org" in url:
+                return _mock_response(_EPSS_RESPONSE_A)
+            if "cisa.gov" in url:
+                return _mock_response(_KEV_EMPTY)
+            return _mock_response({})
+
+        tool = self._make_tool_use("CVE-2021-44228", "CVE-2021-45046")
+        with patch("requests.get", side_effect=mock_get):
+            result = diff_report_cves(tool)
+
+        assert result["status"] == "success"
+
+    def test_tool_output_logged(self):
+        from manus_agent.tools.diff_report_cves import diff_report_cves
+
+        tool = self._make_tool_use("CVE-2021-44228", "CVE-2021-45046")
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            with patch("manus_agent.tools.diff_report_cves.log_tool_output_size") as mock_log:
+                diff_report_cves(tool)
+                mock_log.assert_called_once()
+                call_args = mock_log.call_args[0]
+                assert call_args[0] == "diff_report_cves"
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# CLI tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+class TestDiffReportCLI:
+    def _make_mock_get(self):
+        def mock_get(url, **kwargs):
+            if "nvd.nist.gov" in url:
+                if "44228" in url:
+                    return _mock_response(_NVD_RESPONSE_A)
+                return _mock_response(_NVD_RESPONSE_B)
+            if "first.org" in url:
+                return _mock_response(_EPSS_RESPONSE_A)
+            if "cisa.gov" in url:
+                return _mock_response(_KEV_CATALOG)
+            return _mock_response({})
+
+        return mock_get
+
+    def test_cli_markdown_output(self, capsys):
+        from manus_agent.cli import _run_diff_report
+
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            rc = _run_diff_report(["CVE-2021-44228", "CVE-2021-45046"])
+
+        assert rc == 0
+
+    def test_cli_json_output(self, capsys):
+        from manus_agent.cli import _run_diff_report
+
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            rc = _run_diff_report(["CVE-2021-44228", "CVE-2021-45046", "--output", "json"])
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        parsed = json.loads(captured.out)
+        assert "higher_priority" in parsed
+
+    def test_cli_save_to_file(self, tmp_path):
+        from manus_agent.cli import _run_diff_report
+
+        out_file = tmp_path / "report.md"
+        with patch("requests.get", side_effect=self._make_mock_get()):
+            rc = _run_diff_report(["CVE-2021-44228", "CVE-2021-45046", "--save", str(out_file)])
+
+        assert rc == 0
+        assert out_file.exists()
+        content = out_file.read_text()
+        assert "# CVE Diff Report:" in content
+
+    def test_cli_invalid_cve_exits_with_error(self):
+        from manus_agent.cli import _run_diff_report
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_diff_report(["NOTACVE", "CVE-2021-45046"])
+        assert exc_info.value.code != 0
+
+    def test_cli_build_diff_report_parser_help(self):
+        from manus_agent.cli import _build_diff_report_parser
+
+        p = _build_diff_report_parser()
+        assert "diff-report" in p.prog
+        assert p.description is not None
+
+    def test_cli_in_subcommands_set(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "diff-report" in _SUBCOMMANDS
+
+
+class TestEpssLabel:
+    def test_epss_none(self):
+        from manus_agent.tools.diff_report_cves import _epss_label
+
+        assert _epss_label(None) == "N/A"
+
+    def test_epss_very_high(self):
+        from manus_agent.tools.diff_report_cves import _epss_label
+
+        result = _epss_label(0.75)
+        assert "very high" in result
+        assert "0.750" in result
+
+    def test_epss_high(self):
+        from manus_agent.tools.diff_report_cves import _epss_label
+
+        result = _epss_label(0.50)
+        assert "high" in result
+
+    def test_epss_elevated(self):
+        from manus_agent.tools.diff_report_cves import _epss_label
+
+        result = _epss_label(0.15)
+        assert "elevated" in result
+
+    def test_epss_low(self):
+        from manus_agent.tools.diff_report_cves import _epss_label
+
+        result = _epss_label(0.01)
+        assert "low" in result
+
+
+class TestNaHelper:
+    def test_na_none(self):
+        from manus_agent.tools.diff_report_cves import _na
+
+        assert _na(None) == "N/A"
+
+    def test_na_value(self):
+        from manus_agent.tools.diff_report_cves import _na
+
+        assert _na(42) == "42"
+        assert _na("NETWORK") == "NETWORK"
+        assert _na(0) == "0"


### PR DESCRIPTION
## Summary

Adds a `diff_report_cves` Strands tool and a `manus-agent diff-report CVE-A CVE-B` CLI subcommand that produces a rich Markdown narrative comparing two CVEs side-by-side.

This is distinct from the existing `manus-agent compare` subcommand, which emits a compact plain-text table. The `diff-report` output is designed to be dropped into a ticket, advisory draft, or security briefing as-is.

## What it does

```
manus-agent diff-report CVE-2021-44228 CVE-2021-45046
manus-agent diff-report CVE-2024-3094 CVE-2023-44487 --output json | jq .higher_priority
manus-agent diff-report CVE-2024-3094 CVE-2023-44487 --save report.md
```

The generated report contains:

| Section | Content |
|---------|---------|
| **Executive Summary** | Verdict + confidence (strong/moderate/weak/tie) + margin |
| **Side-by-Side Comparison** | 13-row table: CVSS, EPSS, KEV, AV, PR, UI, CWE, score |
| **Vulnerability Summaries** | Description, published date, affected component per CVE |
| **CVSS Delta Analysis** | Score diff + impact/exploitability dimension tables |
| **EPSS Divergence** | Numeric diff + contextual prose (same/modest/significant gap) |
| **KEV Exploitation Status** | BOD 22-01 framing when one or both are in CISA KEV |
| **CWE Weakness Classes** | Shared vs. distinct weakness classes with pattern note |
| **Prioritisation Rationale** | Scored rubric with per-factor breakdown for both CVEs |
| **References** | NVD links + top vendor/patch/advisory URLs from NVD |

### Scoring rubric (max 32 pts)

| Signal | Points |
|--------|--------|
| CISA KEV membership | +10 |
| CVSS ≥ 9.0 (Critical) | +8 |
| CVSS 7.0–8.9 (High) | +5 |
| CVSS 4.0–6.9 (Medium) | +2 |
| EPSS ≥ 0.70 | +8 |
| EPSS 0.40–0.69 | +5 |
| EPSS 0.10–0.39 | +2 |
| Network attack vector | +3 |
| No privileges required | +2 |
| No user interaction | +1 |

### Data sources

All three are fetched concurrently (4-worker `ThreadPoolExecutor`) and degrade independently — a KEV outage does not block the NVD or EPSS fetch:

- NVD `/rest/json/cves/2.0`
- FIRST EPSS `api.first.org/data/v1/epss`
- CISA KEV JSON feed

### JSON output

`--output json` emits the full structured report to stdout (progress to stderr so `| jq` works cleanly). Useful for pipeline integration.

## Files changed

| File | Change |
|------|--------|
| `src/manus_agent/tools/diff_report_cves.py` | New tool (≈ 430 lines) |
| `src/manus_agent/cli.py` | +`diff-report` subcommand, `_SUBCOMMANDS` entry |
| `src/manus_agent/agents/vi_agent.py` | Tool registered in VI agent |
| `tests/test_diff_report_cves.py` | 78 new tests |

## Tests

```
980 passed, 3 deselected  (was 902 before this PR)
```

78 new tests cover: extraction helpers, HTTP fetch paths (success / 404-equivalent / exception), profile builder degradation, priority scoring (individual factors + composite), diff-report builder, Markdown renderer (all 11 sections + KEV variants + tie path), Strands tool entry point, and CLI (markdown/json output, `--save`, invalid CVE, `_SUBCOMMANDS` membership).

## CI

```
ruff check .   → All checks passed
ruff format .  → 2 files reformatted
python3 -m pytest --tb=short -q  → 980 passed, 7.71s
```