### PR TITLE
feat(tools): EPSS watchlist — watch_epss tool + manus-agent watch CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [sbom-scan](#manus-agent-sbom-scan-bomfile--sbom-scanner)
   - [temporal-priority](#manus-agent-temporal-priority-cve-id--temporal-priority-scorer)
   - [cluster-variants](#manus-agent-cluster-variants-cve-id--cve-variant-clustering)
+  - [watch](#manus-agent-watch--epss-watchlist)
   - [changelog](#manus-agent-changelog--manage-project-changelog)
 - [Configuration](#configuration)
 - [Python API](#python-api)
@@ -475,6 +476,46 @@ Groups CVEs related to the input across three cluster dimensions: same component
 
 ---
 
+### `manus-agent watch` — EPSS watchlist
+
+Track CVEs over time and be alerted when their exploitation probability spikes.
+The watchlist is stored in `~/.manus-agent/watchlist.jsonl`.
+
+```bash
+# Add CVEs to the watchlist
+manus-agent watch add CVE-2024-3094
+manus-agent watch add CVE-2021-44228
+
+# List all watched CVEs with their last EPSS snapshot
+manus-agent watch list
+
+# Fetch current EPSS for all watched CVEs and flag any that spiked >= 0.10
+manus-agent watch check
+
+# Machine-readable output
+manus-agent watch check --output json | jq '.records[] | select(.last_epss > 0.5)'
+
+# Remove a CVE from the watchlist
+manus-agent watch remove CVE-2024-3094
+
+# Custom spike threshold
+manus-agent watch check --threshold 0.05
+```
+
+`manus-agent analyze` automatically adds the analysed CVE to the watchlist (Step 6d),
+so you can run `manus-agent watch check` daily to track any EPSS movement.
+
+| Subcommand | CVE-ID | Options | Description |
+|---|---|---|---|
+| `add` | required | `--output {text,json}` | Add a CVE to the watchlist |
+| `remove` | required | `--output {text,json}` | Remove a CVE from the watchlist |
+| `list` | — | — | Show all watched CVEs |
+| `check` | — | `--threshold DELTA`, `--output {text,json}` | Check for EPSS spikes |
+
+The `MANUS_WATCHLIST_PATH` environment variable overrides the default file location.
+
+---
+
 ### `manus-agent changelog` — Manage project changelog
 
 ```bash
@@ -629,6 +670,10 @@ manus-agent temporal-priority CVE-2024-3094
 manus-agent blast-radius CVE-2021-44228
 manus-agent cluster-variants CVE-2021-44228
 manus-agent silent-patches apache/log4j
+
+# Track EPSS changes over time
+manus-agent watch add CVE-2024-3094
+manus-agent watch check
 ```
 
 ### VulnCheck enrichment (optional)

--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -120,6 +120,12 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
   A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
 
+**Step 6d: EPSS Watchlist**
+- After completing the blast-radius step, call `watch_epss` with `action="add"` and the CVE ID to add it
+  to the persistent EPSS watchlist. This lets the user track exploitation-probability changes over time
+  using `manus-agent watch check`. Only call this once per CVE; it is a no-op if the CVE is already
+  on the watchlist.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -219,6 +225,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
             from manus_agent.tools.score_exploit_complexity import score_exploit_complexity
             from manus_agent.tools.search_poc_sources import search_poc_sources
+            from manus_agent.tools.watch_epss import watch_epss
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -274,6 +281,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            watch_epss,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "watch",
 }
 
 
@@ -1859,6 +1860,121 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# watch subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_watch_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent watch",
+        description=(
+            "Manage a persistent EPSS watchlist stored in ~/.manus-agent/watchlist.jsonl.\n"
+            "Track CVEs and be alerted when their exploitation probability spikes."
+        ),
+        add_help=True,
+    )
+    sub = p.add_subparsers(dest="watch_action", metavar="{add,remove,list,check}")
+    sub.required = True
+
+    # add
+    p_add = sub.add_parser("add", help="Add a CVE to the watchlist")
+    p_add.add_argument("cve_id", metavar="CVE-ID", help="CVE to track, e.g. CVE-2024-3094")
+
+    # remove
+    p_rem = sub.add_parser("remove", help="Remove a CVE from the watchlist")
+    p_rem.add_argument("cve_id", metavar="CVE-ID", help="CVE to stop tracking")
+
+    # list
+    sub.add_parser("list", help="Show all watched CVEs with their last EPSS snapshot")
+
+    # check
+    p_chk = sub.add_parser("check", help="Fetch current EPSS for all watched CVEs and flag spikes")
+    p_chk.add_argument(
+        "--threshold",
+        type=float,
+        default=0.10,
+        metavar="DELTA",
+        help="Minimum EPSS delta to flag as a spike (default: 0.10)",
+    )
+    p_chk.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    # shared optional flag
+    for sub_p in (p_add, p_rem):
+        sub_p.add_argument(
+            "--output",
+            choices=["text", "json"],
+            default="text",
+            help="Output format (default: text)",
+        )
+
+    return p
+
+
+def _run_watch(argv: list[str]) -> int:  # noqa: C901
+    parser = _build_watch_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.watch_epss import (
+            _action_add,
+            _action_check,
+            _action_list,
+            _action_remove,
+            _load_watchlist,
+            _resolve_path,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import os
+
+    path = _resolve_path(os.environ.get("MANUS_WATCHLIST_PATH"))
+    records = _load_watchlist(path)
+
+    action = args.watch_action
+    output_fmt = getattr(args, "output", "text")
+
+    try:
+        if action == "add":
+            records, message = _action_add(records, args.cve_id, path)
+        elif action == "remove":
+            records, message = _action_remove(records, args.cve_id, path)
+        elif action == "list":
+            message = _action_list(records)
+        else:  # check
+            threshold = getattr(args, "threshold", 0.10)
+            records, message = _action_check(records, path, threshold)
+    except Exception as exc:
+        print(f"[error] watch {action} failed: {exc}", file=sys.stderr)
+        return 1
+
+    if output_fmt == "json":
+        import json as _json_mod
+
+        print(
+            _json_mod.dumps(
+                {
+                    "action": action,
+                    "watchlist_path": str(path),
+                    "count": len(records),
+                    "records": records,
+                },
+                indent=2,
+            )
+        )
+    else:
+        print(message)
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2188,6 +2304,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "watch":
+        idx = argv.index("watch")
+        sys.exit(_run_watch(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/watch_epss.py
+++ b/src/manus_agent/tools/watch_epss.py
@@ -1,0 +1,383 @@
+"""
+Tool for managing a persistent EPSS watchlist.
+
+Stores watched CVEs in ``~/.manus-agent/watchlist.jsonl`` (one JSON record per
+line).  Each record has the shape::
+
+    {
+        "cve_id": "CVE-2024-3094",
+        "added_at": "2026-06-30",
+        "last_checked": "2026-06-30",
+        "last_epss": 0.8512,
+        "baseline_epss": 0.8512
+    }
+
+Supported operations (``action`` parameter):
+- **add**    — append a CVE to the watchlist (no-op if already present).
+- **remove** — remove a CVE from the watchlist.
+- **list**   — return all watched CVEs with their stored EPSS snapshot.
+- **check**  — fetch the current EPSS for every watched CVE, compare against
+               ``last_epss``, flag any that spiked ≥ ``spike_threshold``
+               (default 0.10), and persist the new scores.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WATCHLIST_PATH = Path.home() / ".manus-agent" / "watchlist.jsonl"
+_SPIKE_THRESHOLD = 0.10
+_CVE_RE_PREFIX = "CVE-"
+
+TOOL_SPEC = {
+    "name": "watch_epss",
+    "description": (
+        "Manage a persistent EPSS watchlist stored in ~/.manus-agent/watchlist.jsonl. "
+        "Supported actions: "
+        "'add' — add a CVE to the watchlist; "
+        "'remove' — remove a CVE from the watchlist; "
+        "'list' — show all watched CVEs with their last-recorded EPSS score; "
+        "'check' — fetch current EPSS scores for all watched CVEs and report any "
+        "that spiked >= spike_threshold (default 0.10) since the last check. "
+        "Use this to monitor whether exploitation probability is rising for specific CVEs."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "action": {
+                    "type": "string",
+                    "enum": ["add", "remove", "list", "check"],
+                    "description": "Operation to perform on the watchlist.",
+                },
+                "cve_id": {
+                    "type": "string",
+                    "description": (
+                        "CVE identifier (e.g. 'CVE-2024-3094'). "
+                        "Required for 'add' and 'remove'; ignored for 'list' and 'check'."
+                    ),
+                },
+                "spike_threshold": {
+                    "type": "number",
+                    "description": (
+                        "Minimum EPSS delta to flag as a spike during 'check'. Defaults to 0.10 (10 percentage points)."
+                    ),
+                    "default": 0.10,
+                },
+                "watchlist_path": {
+                    "type": "string",
+                    "description": ("Override the watchlist file path. Defaults to ~/.manus-agent/watchlist.jsonl."),
+                },
+            },
+            "required": ["action"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(override: str | None) -> Path:
+    """Return the watchlist path, creating parent dirs if needed."""
+    p = Path(override) if override else _DEFAULT_WATCHLIST_PATH
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _load_watchlist(path: Path) -> list[dict[str, Any]]:
+    """Load all records from the watchlist file (empty list if absent)."""
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line:
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass  # skip corrupt lines
+    return records
+
+
+def _save_watchlist(path: Path, records: list[dict[str, Any]]) -> None:
+    """Overwrite the watchlist file with *records* (one JSON line each)."""
+    path.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in records) + ("\n" if records else ""),
+        encoding="utf-8",
+    )
+
+
+def _today() -> str:
+    return date.today().isoformat()
+
+
+def _fetch_current_epss(cve_ids: list[str]) -> dict[str, float]:
+    """
+    Fetch the current EPSS score for each CVE in *cve_ids* from FIRST.org.
+
+    Returns a dict mapping CVE-ID (uppercase) → float score.
+    Missing or errored CVEs map to -1.0.
+    """
+    if not cve_ids:
+        return {}
+
+    scores: dict[str, float] = {}
+    # FIRST.org supports up to ~100 CVEs per request via repeated ?cve= params.
+    # We batch in chunks of 50 to stay well within any undocumented server limit.
+    chunk_size = 50
+    for i in range(0, len(cve_ids), chunk_size):
+        chunk = cve_ids[i : i + chunk_size]
+        params = [("cve", cid.upper()) for cid in chunk]
+        try:
+            resp = requests.get(
+                "https://api.first.org/data/v1/epss",
+                params=params,
+                timeout=20,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for entry in data.get("data", []):
+                cid = entry.get("cve", "").upper()
+                try:
+                    scores[cid] = float(entry.get("epss", -1))
+                except (TypeError, ValueError):
+                    scores[cid] = -1.0
+        except requests.exceptions.RequestException:
+            for cid in chunk:
+                scores[cid.upper()] = -1.0
+
+    # Fill any that didn't appear in the response
+    for cid in cve_ids:
+        scores.setdefault(cid.upper(), -1.0)
+
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# Action implementations
+# ---------------------------------------------------------------------------
+
+
+def _action_add(
+    records: list[dict[str, Any]],
+    cve_id: str,
+    path: Path,
+) -> tuple[list[dict[str, Any]], str]:
+    """Add *cve_id* to the watchlist. Returns (updated_records, message)."""
+    cve_upper = cve_id.upper()
+    existing = {r["cve_id"].upper() for r in records}
+    if cve_upper in existing:
+        return records, f"{cve_upper} is already on the watchlist."
+
+    records.append(
+        {
+            "cve_id": cve_upper,
+            "added_at": _today(),
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    )
+    _save_watchlist(path, records)
+    return records, f"Added {cve_upper} to the watchlist ({len(records)} total)."
+
+
+def _action_remove(
+    records: list[dict[str, Any]],
+    cve_id: str,
+    path: Path,
+) -> tuple[list[dict[str, Any]], str]:
+    """Remove *cve_id* from the watchlist. Returns (updated_records, message)."""
+    cve_upper = cve_id.upper()
+    before = len(records)
+    records = [r for r in records if r["cve_id"].upper() != cve_upper]
+    if len(records) == before:
+        return records, f"{cve_upper} was not found on the watchlist."
+    _save_watchlist(path, records)
+    return records, f"Removed {cve_upper} from the watchlist ({len(records)} remaining)."
+
+
+def _action_list(records: list[dict[str, Any]]) -> str:
+    """Return a human-readable summary of all watched CVEs."""
+    if not records:
+        return "Watchlist is empty. Use 'add' to track CVEs."
+
+    lines = [f"Watching {len(records)} CVE(s):"]
+    lines.append(f"  {'CVE-ID':<20}  {'Last EPSS':>10}  {'Checked':<12}  {'Added':<12}")
+    lines.append("  " + "-" * 60)
+    for r in records:
+        epss_str = f"{r['last_epss']:.4f}" if r["last_epss"] is not None else "  (none)"
+        checked = r.get("last_checked") or "never"
+        added = r.get("added_at", "unknown")
+        lines.append(f"  {r['cve_id']:<20}  {epss_str:>10}  {checked:<12}  {added:<12}")
+    return "\n".join(lines)
+
+
+def _action_check(
+    records: list[dict[str, Any]],
+    path: Path,
+    spike_threshold: float,
+) -> tuple[list[dict[str, Any]], str]:
+    """
+    Fetch current EPSS for all watched CVEs, detect spikes, persist new scores.
+    Returns (updated_records, report_text).
+    """
+    if not records:
+        return records, "Watchlist is empty. Nothing to check."
+
+    cve_ids = [r["cve_id"].upper() for r in records]
+    current_scores = _fetch_current_epss(cve_ids)
+    today = _today()
+
+    spikes: list[str] = []
+    errors: list[str] = []
+    unchanged: list[str] = []
+
+    updated: list[dict[str, Any]] = []
+    for r in records:
+        cid = r["cve_id"].upper()
+        new_score = current_scores.get(cid, -1.0)
+        prev_score = r.get("last_epss")
+
+        r = dict(r)  # shallow copy — don't mutate in place
+        r["last_checked"] = today
+
+        if new_score < 0:
+            errors.append(cid)
+            updated.append(r)
+            continue
+
+        r["last_epss"] = new_score
+        if r.get("baseline_epss") is None:
+            r["baseline_epss"] = new_score
+
+        if prev_score is not None and prev_score >= 0:
+            delta = new_score - prev_score
+            if delta >= spike_threshold:
+                spikes.append(f"  ⚠️  {cid}: {prev_score:.4f} → {new_score:.4f}  (Δ +{delta:.4f})")
+            else:
+                unchanged.append(f"  ✅  {cid}: {new_score:.4f}  (Δ {delta:+.4f})")
+        else:
+            # First check — just record the score
+            unchanged.append(f"  ✅  {cid}: {new_score:.4f}  (first check)")
+
+        updated.append(r)
+
+    _save_watchlist(path, updated)
+
+    lines: list[str] = [f"EPSS watch check — {today} — {len(records)} CVE(s)"]
+    lines.append(f"  Spike threshold: ≥{spike_threshold:.2f}")
+    lines.append("")
+
+    if spikes:
+        lines.append(f"🚨 {len(spikes)} spike(s) detected:")
+        lines.extend(spikes)
+        lines.append("")
+
+    if unchanged:
+        lines.append("No significant change:")
+        lines.extend(unchanged)
+        lines.append("")
+
+    if errors:
+        lines.append("⚡ EPSS lookup failed (API error or unknown CVE):")
+        lines.extend(f"  {cid}" for cid in errors)
+        lines.append("")
+
+    return updated, "\n".join(lines).rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Tool entry-point
+# ---------------------------------------------------------------------------
+
+
+def watch_epss(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Manage a persistent EPSS watchlist (add / remove / list / check)."""
+    tool_use_id = tool["toolUseId"]
+    inp = tool["input"]
+
+    action = (inp.get("action") or "").lower().strip()
+    cve_id = (inp.get("cve_id") or "").strip()
+    spike_threshold = float(inp.get("spike_threshold") or _SPIKE_THRESHOLD)
+    watchlist_path_override = inp.get("watchlist_path") or os.environ.get("MANUS_WATCHLIST_PATH")
+
+    # ------------------------------------------------------------------
+    # Validate action
+    # ------------------------------------------------------------------
+    valid_actions = {"add", "remove", "list", "check"}
+    if action not in valid_actions:
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Unknown action '{action}'. Must be one of: {', '.join(sorted(valid_actions))}."}],
+        }
+        log_tool_output_size("watch_epss", result)
+        return result
+
+    if action in {"add", "remove"} and not cve_id.upper().startswith(_CVE_RE_PREFIX):
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Invalid CVE ID '{cve_id}'. Must start with 'CVE-' (e.g. CVE-2024-3094)."}],
+        }
+        log_tool_output_size("watch_epss", result)
+        return result
+
+    path = _resolve_path(watchlist_path_override)
+    records = _load_watchlist(path)
+
+    # ------------------------------------------------------------------
+    # Dispatch
+    # ------------------------------------------------------------------
+    try:
+        if action == "add":
+            records, message = _action_add(records, cve_id, path)
+        elif action == "remove":
+            records, message = _action_remove(records, cve_id, path)
+        elif action == "list":
+            message = _action_list(records)
+        else:  # check
+            records, message = _action_check(records, path, spike_threshold)
+    except Exception as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"watch_epss '{action}' failed: {exc}"}],
+        }
+        log_tool_output_size("watch_epss", result)
+        return result
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": message},
+            {
+                "json": {
+                    "action": action,
+                    "watchlist_path": str(path),
+                    "count": len(records),
+                    "records": records,
+                }
+            },
+        ],
+    }
+    log_tool_output_size("watch_epss", result)
+    return result

--- a/tests/test_watch_epss.py
+++ b/tests/test_watch_epss.py
@@ -1,0 +1,997 @@
+"""Tests for the watch_epss tool and manus-agent watch CLI subcommand.
+
+All tests are unit tests — zero real HTTP calls.  Network calls are replaced by
+mocks/fakes throughout.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_tool_use(action: str, **extra: Any) -> dict:
+    return {
+        "toolUseId": "test-watch-001",
+        "input": {"action": action, **extra},
+    }
+
+
+@pytest.fixture()
+def watchlist_tmp(tmp_path: Path) -> Path:
+    """Return a temporary watchlist file path (does not need to exist yet)."""
+    return tmp_path / "watchlist.jsonl"
+
+
+@pytest.fixture()
+def watchlist_env(watchlist_tmp: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point MANUS_WATCHLIST_PATH to a temp file for the duration of the test."""
+    monkeypatch.setenv("MANUS_WATCHLIST_PATH", str(watchlist_tmp))
+    return watchlist_tmp
+
+
+# Mock EPSS API responses
+_MOCK_EPSS_SINGLE = {
+    "status": "OK",
+    "data": [
+        {"cve": "CVE-2024-3094", "epss": "0.8512", "percentile": "0.9970", "date": "2026-06-30"},
+    ],
+}
+
+_MOCK_EPSS_MULTI = {
+    "status": "OK",
+    "data": [
+        {"cve": "CVE-2024-3094", "epss": "0.9200", "percentile": "0.9980", "date": "2026-06-30"},
+        {"cve": "CVE-2021-44228", "epss": "0.9750", "percentile": "0.9999", "date": "2026-06-30"},
+    ],
+}
+
+# ---------------------------------------------------------------------------
+# Module import tests
+# ---------------------------------------------------------------------------
+
+
+def test_watch_epss_module_imports():
+    import manus_agent.tools.watch_epss as m
+
+    assert hasattr(m, "watch_epss")
+    assert hasattr(m, "TOOL_SPEC")
+
+
+def test_tool_spec_required_fields():
+    from manus_agent.tools.watch_epss import TOOL_SPEC
+
+    assert TOOL_SPEC["name"] == "watch_epss"
+    schema = TOOL_SPEC["inputSchema"]["json"]
+    assert "action" in schema["properties"]
+    assert "cve_id" in schema["properties"]
+    assert "spike_threshold" in schema["properties"]
+    assert schema["required"] == ["action"]
+
+
+def test_tool_spec_action_enum():
+    from manus_agent.tools.watch_epss import TOOL_SPEC
+
+    enum_vals = TOOL_SPEC["inputSchema"]["json"]["properties"]["action"]["enum"]
+    assert set(enum_vals) == {"add", "remove", "list", "check"}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_path
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_path_creates_parent(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _resolve_path
+
+    deep = tmp_path / "a" / "b" / "c" / "watchlist.jsonl"
+    result = _resolve_path(str(deep))
+    assert result == deep
+    assert deep.parent.exists()
+
+
+def test_resolve_path_default_is_under_home():
+    from manus_agent.tools.watch_epss import _DEFAULT_WATCHLIST_PATH, _resolve_path
+
+    result = _resolve_path(None)
+    assert result == _DEFAULT_WATCHLIST_PATH
+
+
+# ---------------------------------------------------------------------------
+# _load_watchlist / _save_watchlist
+# ---------------------------------------------------------------------------
+
+
+def test_load_empty_file_returns_empty_list(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _load_watchlist
+
+    p = tmp_path / "empty.jsonl"
+    assert _load_watchlist(p) == []
+
+
+def test_load_nonexistent_returns_empty_list(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _load_watchlist
+
+    assert _load_watchlist(tmp_path / "missing.jsonl") == []
+
+
+def test_save_and_reload_records(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _load_watchlist, _save_watchlist
+
+    p = tmp_path / "wl.jsonl"
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        },
+        {
+            "cve_id": "CVE-2021-44228",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        },
+    ]
+    _save_watchlist(p, records)
+    loaded = _load_watchlist(p)
+    assert len(loaded) == 2
+    assert loaded[0]["cve_id"] == "CVE-2024-3094"
+    assert loaded[1]["cve_id"] == "CVE-2021-44228"
+
+
+def test_save_empty_list(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _load_watchlist, _save_watchlist
+
+    p = tmp_path / "wl.jsonl"
+    _save_watchlist(p, [])
+    assert _load_watchlist(p) == []
+
+
+def test_load_skips_corrupt_lines(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _load_watchlist
+
+    p = tmp_path / "wl.jsonl"
+    p.write_text('{"cve_id": "CVE-2024-3094"}\nNOT_JSON\n{"cve_id": "CVE-2021-44228"}\n')
+    records = _load_watchlist(p)
+    assert len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# _action_add
+# ---------------------------------------------------------------------------
+
+
+def test_action_add_new_cve(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_add, _load_watchlist
+
+    p = tmp_path / "wl.jsonl"
+    records, msg = _action_add([], "CVE-2024-3094", p)
+    assert len(records) == 1
+    assert records[0]["cve_id"] == "CVE-2024-3094"
+    assert "Added" in msg
+    # Persisted
+    assert len(_load_watchlist(p)) == 1
+
+
+def test_action_add_normalises_to_uppercase(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_add
+
+    p = tmp_path / "wl.jsonl"
+    records, _ = _action_add([], "cve-2024-3094", p)
+    assert records[0]["cve_id"] == "CVE-2024-3094"
+
+
+def test_action_add_duplicate_is_noop(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_add
+
+    p = tmp_path / "wl.jsonl"
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    records, msg = _action_add(records, "CVE-2024-3094", p)
+    assert len(records) == 1
+    assert "already" in msg
+
+
+def test_action_add_sets_added_at(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_add
+
+    p = tmp_path / "wl.jsonl"
+    records, _ = _action_add([], "CVE-2024-3094", p)
+    assert records[0]["added_at"] is not None
+
+
+def test_action_add_multiple(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_add
+
+    p = tmp_path / "wl.jsonl"
+    records: list[dict] = []
+    records, _ = _action_add(records, "CVE-2024-3094", p)
+    records, _ = _action_add(records, "CVE-2021-44228", p)
+    assert len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# _action_remove
+# ---------------------------------------------------------------------------
+
+
+def test_action_remove_existing(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_remove
+
+    p = tmp_path / "wl.jsonl"
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        },
+        {
+            "cve_id": "CVE-2021-44228",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        },
+    ]
+    records, msg = _action_remove(records, "CVE-2024-3094", p)
+    assert len(records) == 1
+    assert records[0]["cve_id"] == "CVE-2021-44228"
+    assert "Removed" in msg
+
+
+def test_action_remove_not_found(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_remove
+
+    p = tmp_path / "wl.jsonl"
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    records, msg = _action_remove(records, "CVE-9999-9999", p)
+    assert len(records) == 1
+    assert "not found" in msg
+
+
+def test_action_remove_normalises_case(tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_remove
+
+    p = tmp_path / "wl.jsonl"
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    records, msg = _action_remove(records, "cve-2024-3094", p)
+    assert len(records) == 0
+    assert "Removed" in msg
+
+
+# ---------------------------------------------------------------------------
+# _action_list
+# ---------------------------------------------------------------------------
+
+
+def test_action_list_empty():
+    from manus_agent.tools.watch_epss import _action_list
+
+    msg = _action_list([])
+    assert "empty" in msg.lower()
+
+
+def test_action_list_with_entries():
+    from manus_agent.tools.watch_epss import _action_list
+
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": "2026-06-30",
+            "last_epss": 0.8512,
+            "baseline_epss": 0.8512,
+        },
+        {
+            "cve_id": "CVE-2021-44228",
+            "added_at": "2026-06-29",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        },
+    ]
+    msg = _action_list(records)
+    assert "CVE-2024-3094" in msg
+    assert "CVE-2021-44228" in msg
+    assert "2" in msg  # "Watching 2 CVE(s)"
+
+
+def test_action_list_shows_never_for_unchecked():
+    from manus_agent.tools.watch_epss import _action_list
+
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    msg = _action_list(records)
+    assert "never" in msg
+
+
+def test_action_list_shows_last_epss():
+    from manus_agent.tools.watch_epss import _action_list
+
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": "2026-06-30",
+            "last_epss": 0.8512,
+            "baseline_epss": 0.8512,
+        }
+    ]
+    msg = _action_list(records)
+    assert "0.8512" in msg
+
+
+# ---------------------------------------------------------------------------
+# _action_check
+# ---------------------------------------------------------------------------
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_empty_watchlist(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    records, msg = _action_check([], tmp_path / "wl.jsonl", 0.10)
+    assert "empty" in msg.lower()
+    mock_fetch.assert_not_called()
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_first_check_sets_scores(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8512}
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    updated, msg = _action_check(records, tmp_path / "wl.jsonl", 0.10)
+    assert updated[0]["last_epss"] == pytest.approx(0.8512)
+    assert updated[0]["baseline_epss"] == pytest.approx(0.8512)
+    assert "first check" in msg
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_no_spike(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8600}
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": "2026-06-29",
+            "last_epss": 0.8512,
+            "baseline_epss": 0.8512,
+        }
+    ]
+    updated, msg = _action_check(records, tmp_path / "wl.jsonl", 0.10)
+    assert "spike" not in msg.lower() or "🚨" not in msg
+    assert updated[0]["last_epss"] == pytest.approx(0.8600)
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_spike_detected(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.9600}  # was 0.85, now 0.96 → delta 0.11
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": "2026-06-29",
+            "last_epss": 0.85,
+            "baseline_epss": 0.85,
+        }
+    ]
+    updated, msg = _action_check(records, tmp_path / "wl.jsonl", 0.10)
+    assert "⚠️" in msg or "spike" in msg.lower() or "🚨" in msg
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_custom_threshold(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    # delta = 0.06; threshold 0.05 → should spike
+    mock_fetch.return_value = {"CVE-2024-3094": 0.91}
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": "2026-06-29",
+            "last_epss": 0.85,
+            "baseline_epss": 0.85,
+        }
+    ]
+    _, msg = _action_check(records, tmp_path / "wl.jsonl", 0.05)
+    assert "⚠️" in msg or "🚨" in msg
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_persists_scores(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check, _load_watchlist
+
+    p = tmp_path / "wl.jsonl"
+    mock_fetch.return_value = {"CVE-2024-3094": 0.9200}
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    _action_check(records, p, 0.10)
+    reloaded = _load_watchlist(p)
+    assert reloaded[0]["last_epss"] == pytest.approx(0.9200)
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_handles_api_error(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    mock_fetch.return_value = {"CVE-2024-3094": -1.0}  # sentinel for error
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-30",
+            "last_checked": None,
+            "last_epss": None,
+            "baseline_epss": None,
+        }
+    ]
+    updated, msg = _action_check(records, tmp_path / "wl.jsonl", 0.10)
+    assert "failed" in msg.lower() or "error" in msg.lower() or "⚡" in msg
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_action_check_multiple_cves(mock_fetch, tmp_path: Path):
+    from manus_agent.tools.watch_epss import _action_check
+
+    mock_fetch.return_value = {
+        "CVE-2024-3094": 0.9200,
+        "CVE-2021-44228": 0.9750,
+    }
+    records = [
+        {
+            "cve_id": "CVE-2024-3094",
+            "added_at": "2026-06-29",
+            "last_checked": "2026-06-29",
+            "last_epss": 0.85,
+            "baseline_epss": 0.85,
+        },
+        {
+            "cve_id": "CVE-2021-44228",
+            "added_at": "2026-06-29",
+            "last_checked": "2026-06-29",
+            "last_epss": 0.97,
+            "baseline_epss": 0.97,
+        },
+    ]
+    updated, msg = _action_check(records, tmp_path / "wl.jsonl", 0.10)
+    assert len(updated) == 2
+    assert "CVE-2024-3094" in msg or "CVE-2021-44228" in msg
+
+
+# ---------------------------------------------------------------------------
+# _fetch_current_epss unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_current_epss_empty_list():
+    from manus_agent.tools.watch_epss import _fetch_current_epss
+
+    result = _fetch_current_epss([])
+    assert result == {}
+
+
+@patch("manus_agent.tools.watch_epss.requests.get")
+def test_fetch_current_epss_happy_path(mock_get):
+    from unittest.mock import MagicMock
+
+    from manus_agent.tools.watch_epss import _fetch_current_epss
+
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _MOCK_EPSS_SINGLE
+    mock_get.return_value = resp
+
+    result = _fetch_current_epss(["CVE-2024-3094"])
+    assert "CVE-2024-3094" in result
+    assert abs(result["CVE-2024-3094"] - 0.8512) < 1e-4
+
+
+@patch("manus_agent.tools.watch_epss.requests.get")
+def test_fetch_current_epss_multi_cve(mock_get):
+    from unittest.mock import MagicMock
+
+    from manus_agent.tools.watch_epss import _fetch_current_epss
+
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = _MOCK_EPSS_MULTI
+    mock_get.return_value = resp
+
+    result = _fetch_current_epss(["CVE-2024-3094", "CVE-2021-44228"])
+    assert len(result) == 2
+    assert abs(result["CVE-2021-44228"] - 0.9750) < 1e-4
+
+
+@patch("manus_agent.tools.watch_epss.requests.get")
+def test_fetch_current_epss_network_error(mock_get):
+    import requests as req_mod
+
+    from manus_agent.tools.watch_epss import _fetch_current_epss
+
+    mock_get.side_effect = req_mod.exceptions.ConnectionError("down")
+    result = _fetch_current_epss(["CVE-2024-3094"])
+    assert result["CVE-2024-3094"] == -1.0
+
+
+@patch("manus_agent.tools.watch_epss.requests.get")
+def test_fetch_current_epss_missing_cve_defaults_to_minus_one(mock_get):
+    from unittest.mock import MagicMock
+
+    from manus_agent.tools.watch_epss import _fetch_current_epss
+
+    # API returns empty data
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"status": "OK", "data": []}
+    mock_get.return_value = resp
+
+    result = _fetch_current_epss(["CVE-9999-9999"])
+    assert result["CVE-9999-9999"] == -1.0
+
+
+# ---------------------------------------------------------------------------
+# watch_epss tool function — integration tests (all mocked)
+# ---------------------------------------------------------------------------
+
+
+def test_tool_invalid_action(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("bogus"))
+    assert result["status"] == "error"
+    assert "Unknown action" in result["content"][0]["text"]
+
+
+def test_tool_add_invalid_cve(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("add", cve_id="NOTACVE"))
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_tool_remove_invalid_cve(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("remove", cve_id="BAD"))
+    assert result["status"] == "error"
+    assert "Invalid CVE ID" in result["content"][0]["text"]
+
+
+def test_tool_add_success(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["count"] == 1
+    assert json_block["action"] == "add"
+
+
+def test_tool_add_then_list(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    result = watch_epss(_make_tool_use("list"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["count"] == 1
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "CVE-2024-3094" in text
+
+
+def test_tool_list_empty(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("list"))
+    assert result["status"] == "success"
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "empty" in text.lower()
+
+
+def test_tool_add_duplicate_returns_success_with_message(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    result = watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    assert result["status"] == "success"
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "already" in text
+
+
+def test_tool_remove_success(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    result = watch_epss(_make_tool_use("remove", cve_id="CVE-2024-3094"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["count"] == 0
+
+
+def test_tool_remove_not_found(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("remove", cve_id="CVE-9999-9999"))
+    assert result["status"] == "success"
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "not found" in text
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_tool_check_empty(mock_fetch, watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("check"))
+    assert result["status"] == "success"
+    mock_fetch.assert_not_called()
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_tool_check_with_entries(mock_fetch, watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8512}
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    result = watch_epss(_make_tool_use("check"))
+    assert result["status"] == "success"
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["count"] == 1
+    assert json_block["records"][0]["last_epss"] == pytest.approx(0.8512)
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_tool_check_json_content(mock_fetch, watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8512}
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    result = watch_epss(_make_tool_use("check"))
+    json_block = next(c["json"] for c in result["content"] if "json" in c)
+    assert json_block["action"] == "check"
+    assert "watchlist_path" in json_block
+    assert isinstance(json_block["records"], list)
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_tool_check_spike_detected_in_text(mock_fetch, watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    # Prime the watchlist with a previous score
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    # Simulate first check to set last_epss = 0.80
+    mock_fetch.return_value = {"CVE-2024-3094": 0.80}
+    watch_epss(_make_tool_use("check"))
+    # Second check: score jumps to 0.91 (delta 0.11 > threshold 0.10)
+    mock_fetch.return_value = {"CVE-2024-3094": 0.91}
+    result = watch_epss(_make_tool_use("check"))
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "⚠️" in text or "🚨" in text
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_tool_check_custom_spike_threshold(mock_fetch, watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    mock_fetch.return_value = {"CVE-2024-3094": 0.80}
+    watch_epss(_make_tool_use("check"))
+    # delta 0.06; default threshold 0.10 → no spike; custom 0.05 → spike
+    mock_fetch.return_value = {"CVE-2024-3094": 0.86}
+    result = watch_epss(_make_tool_use("check", spike_threshold=0.05))
+    text = next(c["text"] for c in result["content"] if "text" in c)
+    assert "⚠️" in text or "🚨" in text
+
+
+def test_tool_result_always_has_text_and_json(watchlist_env: Path):
+    from manus_agent.tools.watch_epss import watch_epss
+
+    result = watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094"))
+    content_keys = [list(c.keys())[0] for c in result["content"]]
+    assert "text" in content_keys
+    assert "json" in content_keys
+
+
+def test_tool_watchlist_path_override(tmp_path: Path):
+    """watchlist_path parameter overrides the default location."""
+    from manus_agent.tools.watch_epss import watch_epss
+
+    custom_path = str(tmp_path / "custom" / "wl.jsonl")
+    result = watch_epss(_make_tool_use("add", cve_id="CVE-2024-3094", watchlist_path=custom_path))
+    assert result["status"] == "success"
+    assert Path(custom_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand: manus-agent watch
+# ---------------------------------------------------------------------------
+
+
+def test_watch_subcommand_registered():
+    from manus_agent.cli import _SUBCOMMANDS
+
+    assert "watch" in _SUBCOMMANDS
+
+
+def test_watch_parser_help_exits_zero():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args(["--help"])
+    assert exc_info.value.code == 0
+
+
+def test_watch_parser_no_subcommand_exits_nonzero():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    with pytest.raises(SystemExit) as exc_info:
+        parser.parse_args([])
+    assert exc_info.value.code != 0
+
+
+def test_watch_add_parser():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["add", "CVE-2024-3094"])
+    assert args.watch_action == "add"
+    assert args.cve_id == "CVE-2024-3094"
+
+
+def test_watch_remove_parser():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["remove", "CVE-2024-3094"])
+    assert args.watch_action == "remove"
+    assert args.cve_id == "CVE-2024-3094"
+
+
+def test_watch_list_parser():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["list"])
+    assert args.watch_action == "list"
+
+
+def test_watch_check_parser_defaults():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["check"])
+    assert args.watch_action == "check"
+    assert args.threshold == pytest.approx(0.10)
+    assert args.output == "text"
+
+
+def test_watch_check_parser_custom_threshold():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["check", "--threshold", "0.05"])
+    assert args.threshold == pytest.approx(0.05)
+
+
+def test_watch_check_parser_json_output():
+    from manus_agent.cli import _build_watch_parser
+
+    parser = _build_watch_parser()
+    args = parser.parse_args(["check", "--output", "json"])
+    assert args.output == "json"
+
+
+def test_run_watch_add(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    rc = _run_watch(["add", "CVE-2024-3094"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CVE-2024-3094" in out
+
+
+def test_run_watch_list_empty(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    rc = _run_watch(["list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "empty" in out.lower()
+
+
+def test_run_watch_list_with_entry(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    _run_watch(["add", "CVE-2024-3094"])
+    capsys.readouterr()  # clear
+    rc = _run_watch(["list"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CVE-2024-3094" in out
+
+
+def test_run_watch_remove(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    _run_watch(["add", "CVE-2024-3094"])
+    capsys.readouterr()
+    rc = _run_watch(["remove", "CVE-2024-3094"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Removed" in out
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_run_watch_check_text(mock_fetch, watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8512}
+    _run_watch(["add", "CVE-2024-3094"])
+    capsys.readouterr()
+    rc = _run_watch(["check"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CVE-2024-3094" in out or "check" in out.lower()
+
+
+@patch("manus_agent.tools.watch_epss._fetch_current_epss")
+def test_run_watch_check_json(mock_fetch, watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    mock_fetch.return_value = {"CVE-2024-3094": 0.8512}
+    _run_watch(["add", "CVE-2024-3094"])
+    capsys.readouterr()
+    rc = _run_watch(["check", "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["action"] == "check"
+    assert data["count"] == 1
+    assert isinstance(data["records"], list)
+
+
+def test_run_watch_add_json_output(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    rc = _run_watch(["add", "CVE-2024-3094", "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["count"] == 1
+    assert data["action"] == "add"
+
+
+def test_run_watch_remove_json_output(watchlist_env: Path, capsys):
+    from manus_agent.cli import _run_watch
+
+    _run_watch(["add", "CVE-2024-3094"])
+    capsys.readouterr()
+    rc = _run_watch(["remove", "CVE-2024-3094", "--output", "json"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    data = json.loads(out)
+    assert data["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# README coverage
+# ---------------------------------------------------------------------------
+
+
+def test_readme_documents_watch():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "manus-agent watch" in content, "README must mention manus-agent watch"
+
+
+def test_readme_watch_has_subcommands():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "watch add" in content
+    assert "watch remove" in content
+    assert "watch list" in content
+    assert "watch check" in content
+
+
+def test_readme_watch_documents_threshold():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "--threshold" in content
+
+
+def test_readme_watch_in_toc():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    # TOC entry (anchor link)
+    assert "watch" in content
+
+
+def test_readme_watch_in_quick_reference():
+    readme = Path(__file__).resolve().parents[1] / "README.md"
+    content = readme.read_text()
+    assert "watch check" in content
+
+
+# ---------------------------------------------------------------------------
+# vi_agent integration
+# ---------------------------------------------------------------------------
+
+
+def test_vi_agent_system_prompt_references_watch_epss():
+    """The VI agent system prompt must mention watch_epss (Step 6d)."""
+    from manus_agent.agents.vi_agent import SYSTEM_PROMPT
+
+    assert "watch_epss" in SYSTEM_PROMPT
+    assert "Step 6d" in SYSTEM_PROMPT
+
+
+def test_watch_epss_tool_is_importable():
+    from manus_agent.tools.watch_epss import TOOL_SPEC, watch_epss
+
+    assert callable(watch_epss)
+    assert TOOL_SPEC["name"] == "watch_epss"


### PR DESCRIPTION
## Summary

Adds a persistent EPSS watchlist so users can track CVEs over time and be alerted when exploitation probability spikes.

## What is this?

EPSS scores change daily. A CVE that scored 0.02 yesterday might be actively weaponised today (score 0.85). The existing `epss-trend` subcommand gives a point-in-time history — but there was no way to continuously monitor a set of CVEs without scripting it yourself.

`watch_epss` + `manus-agent watch` fills this gap.

## New tool: `watch_epss`

Strands tool with four actions: add / remove / list / check.
Storage: `~/.manus-agent/watchlist.jsonl`. Override with `MANUS_WATCHLIST_PATH`.

## New CLI subcommand: `manus-agent watch`

```bash
manus-agent watch add CVE-2024-3094
manus-agent watch list
manus-agent watch check
manus-agent watch check --threshold 0.05 --output json
manus-agent watch remove CVE-2024-3094
```

## Integration with analyze

Step 6d in the VI agent system prompt auto-adds every analysed CVE to the watchlist.

## Design choices

- Batched FIRST.org API (50 CVEs/request)
- Independent degradation: score=-1.0 sentinel on API error
- Configurable spike threshold (default 0.10)
- Pipe-clean stdout for --output json
- No new dependencies

## Tests

75 new unit tests (all HTTP mocked, zero real network):
- Before: 902 passing → After: 977 passing (0 failures)
