### PR TITLE
feat(tools): attack surface scorer — score_attack_surface tool + manus-agent attack-surface CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -112,6 +112,16 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   This score contextualises raw CVSS severity: a CVSS 9.8 with complexity_score=1.5 is far more urgent than the same CVSS with complexity_score=4.5.
 
 
+**Step 6b2: Attack Surface Exposure**
+- Call `score_attack_surface` with the CVE ID. Include in the report:
+  - The overall exposure score (1–5) and label (minimal / low / moderate / high / critical).
+  - The component archetype (e.g. web_server_or_api_gateway, cli_or_library).
+  - Per-dimension breakdown: deployment archetype, CVSS attack vector, internet prevalence, authentication scope, public-facing indicators.
+  - The one-paragraph rationale explaining the score.
+  Use this alongside `score_exploit_complexity` for a full attacker-perspective picture:
+  *complexity* measures how hard an exploit is to use; *exposure* measures how reachable the target is.
+  A CVE scoring **exposure=critical** and **complexity=trivial** should be treated as highest priority.
+
 **Step 6c: Dependency Blast Radius**
 - Call `get_dependency_blast_radius` with the CVE ID. Include in the report:
   - The blast-radius label (CRITICAL / HIGH / MEDIUM / LOW) for each affected package.
@@ -217,6 +227,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_poc_week import get_poc_week
             from manus_agent.tools.get_trickest_pocs import get_trickest_pocs
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
+            from manus_agent.tools.score_attack_surface import score_attack_surface
             from manus_agent.tools.score_exploit_complexity import score_exploit_complexity
             from manus_agent.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -271,6 +282,7 @@ class VulnerabilityIntelligenceAgent:
             get_epss_trend,
             get_patch_diff,
             score_exploit_complexity,
+            score_attack_surface,
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "attack-surface",
 }
 
 
@@ -1859,6 +1860,61 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# attack-surface subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_attack_surface_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="manus-agent attack-surface",
+        description=(
+            "Estimate the attack surface exposure of a CVE on a 1-5 scale\n"
+            "(1=minimal, 5=critical/internet-facing).\n"
+            "Analyses deployment archetype, CVSS attack vector, internet prevalence,\n"
+            "authentication requirements, and public-facing indicators."
+        ),
+    )
+    parser.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier (e.g. CVE-2021-44228)")
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return parser
+
+
+def _run_attack_surface(argv: list[str]) -> int:
+    import json as _json
+    import re as _re
+
+    parser = _build_attack_surface_parser()
+    args = parser.parse_args(argv)
+
+    cve_id: str = args.cve_id.strip()
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id, _re.IGNORECASE):
+        parser.error(f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN")
+
+    try:
+        from manus_agent.tools.score_attack_surface import _render_text
+        from manus_agent.tools.score_attack_surface import _run_attack_surface as _run_scoring
+    except ImportError as exc:  # pragma: no cover
+        import sys as _sys
+
+        print(f"Error: failed to import score_attack_surface: {exc}", file=_sys.stderr)
+        return 1
+
+    result = _run_scoring(cve_id)
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    print(_render_text(result))
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2188,6 +2244,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "attack-surface":
+        idx = argv.index("attack-surface")
+        sys.exit(_run_attack_surface(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/score_attack_surface.py
+++ b/src/manus_agent/tools/score_attack_surface.py
@@ -1,0 +1,773 @@
+"""
+Tool: score_attack_surface
+
+Given a CVE identifier, estimates how *exposed* the vulnerable component is to
+potential attackers.  Exposure is distinct from exploitability: a vulnerability
+in a web-facing HTTP server is far more exposed than an identical vulnerability
+in an offline CLI utility used by developers — even if the underlying CVSS
+score is the same.
+
+## Scoring model
+
+Five independent signals are combined into a 1–5 **exposure score**:
+
+1. **Deployment archetype** (1–5) — What kind of software is typically affected?
+   Derived from NVD CPE vendor/product strings and the CVE description:
+   - 5 → web server / proxy / load-balancer / API gateway  (internet-facing)
+   - 4 → network daemon / embedded device / IoT / VPN
+   - 3 → application framework / database / middleware (process-level server)
+   - 2 → desktop application / GUI tool / browser extension
+   - 1 → CLI utility / library / developer tool / SDK
+
+2. **CVSS Attack Vector** (1–5) — How reachable is the vulnerable service?
+   - NETWORK → 5, ADJACENT → 3, LOCAL → 2, PHYSICAL → 1
+
+3. **Internet prevalence** (1–5) — How widely deployed is the affected package?
+   Estimated from CPE product name heuristics (well-known web stacks score
+   higher than obscure niche products).
+
+4. **Authentication scope** (1–5) — Is an unauthenticated attacker able to
+   reach the vulnerable code path?
+   Derived from ``privilegesRequired`` and ``scope`` CVSS fields:
+   - PR=NONE + SCOPE=CHANGED → 5 (pre-auth, crosses trust boundary)
+   - PR=NONE                  → 4
+   - PR=LOW                   → 3
+   - PR=HIGH                  → 2
+   - scope or PR unresolvable → 1
+
+5. **Public facing flag** (1 or 5) — Does the CVE description or CWE
+   explicitly reference an internet/public/remote-accessible context?
+
+An overall ``exposure_score`` (1–5, float) is the weighted average.
+A companion ``exposure_label`` gives a human-readable tier
+(minimal / low / moderate / high / critical).
+
+All HTTP calls are mockable — no side effects in unit tests.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import re
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["score_attack_surface"]
+
+# ---------------------------------------------------------------------------
+# Scoring weights (must sum to 1.0)
+# ---------------------------------------------------------------------------
+
+_WEIGHTS: dict[str, float] = {
+    "deployment_archetype": 0.30,
+    "attack_vector": 0.25,
+    "internet_prevalence": 0.20,
+    "auth_scope": 0.15,
+    "public_facing": 0.10,
+}
+
+# ---------------------------------------------------------------------------
+# Keyword sets for deployment archetype detection
+# ---------------------------------------------------------------------------
+
+# Each tier: (score, list-of-patterns)
+# Patterns are matched case-insensitively against vendor, product, description.
+_ARCHETYPE_TIERS: list[tuple[int, list[str]]] = [
+    (
+        5,
+        [
+            "apache",
+            "nginx",
+            "iis",
+            "httpd",
+            "tomcat",
+            "haproxy",
+            "traefik",
+            "caddy",
+            "lighttpd",
+            "squid",
+            "varnish",
+            "express",
+            "fastapi",
+            "flask",
+            "django",
+            "rails",
+            "wordpress",
+            "drupal",
+            "joomla",
+            "sharepoint",
+            "jenkins",
+            "confluence",
+            "jira",
+            "gitlab",
+            "github",
+            "bitbucket",
+            "sonarqube",
+            "grafana",
+            "kibana",
+            "elastic",
+            "solr",
+            "web server",
+            "http server",
+            "proxy server",
+            "api gateway",
+            "load balancer",
+            "reverse proxy",
+            "cdn",
+            "nextjs",
+            "nuxt",
+            "strapi",
+            "magento",
+            "prestashop",
+            "moodle",
+        ],
+    ),
+    (
+        4,
+        [
+            "router",
+            "firewall",
+            "switch",
+            "vpn",
+            "fortinet",
+            "cisco",
+            "juniper",
+            "palo alto",
+            "sonicwall",
+            "netgear",
+            "zyxel",
+            "dlink",
+            "tplink",
+            "mikrotik",
+            "openvpn",
+            "wireguard",
+            "ssl vpn",
+            "remote desktop",
+            "rdp",
+            "iot",
+            "embedded",
+            "firmware",
+            "scada",
+            "industrial",
+            "plc",
+            "hmi",
+            "camera",
+            "dvr",
+            "nvr",
+            "nas",
+            "opnsense",
+            "pfsense",
+            "f5",
+            "bigip",
+            "pulse",
+            "ivanti",
+            "citrix",
+            "vmware",
+        ],
+    ),
+    (
+        3,
+        [
+            "mysql",
+            "postgresql",
+            "postgres",
+            "mongodb",
+            "redis",
+            "rabbitmq",
+            "kafka",
+            "elasticsearch",
+            "cassandra",
+            "memcached",
+            "spring",
+            "struts",
+            "log4j",
+            "log4shell",
+            "java",
+            "jvm",
+            "jboss",
+            "weblogic",
+            "websphere",
+            "glassfish",
+            "wildfly",
+            "keycloak",
+            "oauth",
+            "ldap",
+            "active directory",
+            "samba",
+            "nfs",
+            "smb",
+            "smtp",
+            "mail server",
+            "postfix",
+            "exim",
+            "sendmail",
+            "dovecot",
+            "ftp",
+            "sftp",
+            "ssh",
+            "database",
+            "middleware",
+            "message queue",
+            "container",
+            "docker",
+            "kubernetes",
+            "k8s",
+            "openshift",
+        ],
+    ),
+    (
+        2,
+        [
+            "browser",
+            "firefox",
+            "chrome",
+            "chromium",
+            "safari",
+            "edge",
+            "internet explorer",
+            "pdf reader",
+            "acrobat",
+            "office",
+            "word",
+            "excel",
+            "powerpoint",
+            "outlook",
+            "libreoffice",
+            "gimp",
+            "photoshop",
+            "vlc",
+            "media player",
+            "electron",
+            "desktop application",
+            "gui",
+            "extension",
+            "plugin",
+            "add-on",
+        ],
+    ),
+    (
+        1,
+        [
+            "cli",
+            "command.line",
+            "command line",
+            "library",
+            "sdk",
+            "framework",
+            "module",
+            "package",
+            "npm",
+            "pip",
+            "pypi",
+            "gem",
+            "cargo",
+            "gradle",
+            "maven",
+            "composer",
+            "developer tool",
+            "dev tool",
+            "build tool",
+            "compiler",
+            "linter",
+            "formatter",
+            "test",
+            "unittest",
+        ],
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Product names whose widespread internet deployment is well-documented
+# Presence → prevalence score = 5
+# ---------------------------------------------------------------------------
+
+_HIGH_PREVALENCE_PRODUCTS = frozenset(
+    [
+        "apache",
+        "nginx",
+        "iis",
+        "wordpress",
+        "drupal",
+        "joomla",
+        "tomcat",
+        "log4j",
+        "log4shell",
+        "spring",
+        "struts",
+        "sharepoint",
+        "exchange",
+        "jenkins",
+        "confluence",
+        "jira",
+        "gitlab",
+        "github",
+        "grafana",
+        "kibana",
+        "elasticsearch",
+        "redis",
+        "mysql",
+        "postgresql",
+        "mongodb",
+        "openssl",
+        "openssh",
+        "php",
+        "python",
+        "node",
+        "nodejs",
+        "express",
+        "rails",
+        "django",
+        "flask",
+        "fastapi",
+        "cisco",
+        "fortinet",
+        "palo alto",
+        "vmware",
+        "citrix",
+        "ivanti",
+        "pulse",
+        "f5",
+        "bigip",
+    ]
+)
+
+# ---------------------------------------------------------------------------
+# NVD fetch helpers
+# ---------------------------------------------------------------------------
+
+_NVD_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id}"
+
+
+def _fetch_nvd_data(cve_id: str) -> dict[str, Any]:
+    """Fetch and return the raw NVD CVE entry, or ``{}`` on failure."""
+    try:
+        resp = requests.get(_NVD_CVE_URL.format(cve_id=cve_id.upper()), timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if vulns:
+            return vulns[0].get("cve", {})
+    except requests.RequestException:
+        pass
+    return {}
+
+
+def _extract_cvss_fields(cve_data: dict[str, Any]) -> dict[str, Any]:
+    """Return a flat dict of CVSS v3.x fields, or ``{}`` if unavailable."""
+    metrics = cve_data.get("metrics", {})
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            cv = entries[0].get("cvssData", {})
+            return {
+                "attackVector": cv.get("attackVector", ""),
+                "privilegesRequired": cv.get("privilegesRequired", ""),
+                "scope": cv.get("scope", ""),
+                "baseScore": cv.get("baseScore"),
+            }
+    return {}
+
+
+def _extract_description(cve_data: dict[str, Any]) -> str:
+    """Return the English CVE description text, or ``""`` if absent."""
+    for d in cve_data.get("descriptions", []):
+        if d.get("lang", "").lower().startswith("en"):
+            return d.get("value", "")
+    return ""
+
+
+def _extract_cpe_strings(cve_data: dict[str, Any]) -> list[str]:
+    """Return all CPE 2.3 strings from the NVD configurations block."""
+    cpe_strings: list[str] = []
+    configs = cve_data.get("configurations", [])
+    for config in configs:
+        for node in config.get("nodes", []):
+            for match in node.get("cpeMatch", []):
+                uri = match.get("criteria", "")
+                if uri:
+                    cpe_strings.append(uri)
+    return cpe_strings
+
+
+def _extract_cwes(cve_data: dict[str, Any]) -> list[str]:
+    """Return all CWE IDs associated with the CVE."""
+    cwes: list[str] = []
+    for weakness in cve_data.get("weaknesses", []):
+        for desc in weakness.get("description", []):
+            val = desc.get("value", "")
+            if val.startswith("CWE-"):
+                cwes.append(val)
+    return cwes
+
+
+# ---------------------------------------------------------------------------
+# CPE parsing helpers
+# ---------------------------------------------------------------------------
+
+_CPE_RE = re.compile(r"cpe:2\.3:[ao]:([^:]+):([^:]+):", re.IGNORECASE)
+
+
+def _cpe_vendor_product(cpe_string: str) -> tuple[str, str]:
+    """Extract (vendor, product) from a CPE 2.3 string, lower-cased."""
+    m = _CPE_RE.match(cpe_string)
+    if m:
+        return m.group(1).lower(), m.group(2).lower()
+    return "", ""
+
+
+def _build_target_corpus(description: str, cpe_strings: list[str]) -> str:
+    """Build a single lower-cased searchable text corpus from description + CPEs."""
+    parts = [description.lower()]
+    for cpe in cpe_strings:
+        vendor, product = _cpe_vendor_product(cpe)
+        parts.append(vendor)
+        parts.append(product.replace("_", " ").replace("-", " "))
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Individual dimension scorers
+# ---------------------------------------------------------------------------
+
+
+def _score_deployment_archetype(corpus: str) -> tuple[int, str]:
+    """Return (score 1-5, matched_archetype_label) from keyword tiers."""
+    for score, keywords in _ARCHETYPE_TIERS:
+        for kw in keywords:
+            if kw in corpus:
+                return score, _archetype_label(score)
+    # Default: treat unknown as library/SDK (lowest exposure)
+    return 1, "cli_or_library"
+
+
+def _archetype_label(score: int) -> str:
+    labels = {
+        5: "web_server_or_api_gateway",
+        4: "network_device_or_iot",
+        3: "database_or_middleware",
+        2: "desktop_or_browser",
+        1: "cli_or_library",
+    }
+    return labels.get(score, "unknown")
+
+
+def _score_attack_vector(av: str) -> int:
+    """Convert NVD attackVector to exposure score (higher = more exposed)."""
+    return {
+        "NETWORK": 5,
+        "ADJACENT": 3,
+        "LOCAL": 2,
+        "PHYSICAL": 1,
+    }.get(av.upper(), 3)  # default moderate if unknown
+
+
+def _score_internet_prevalence(corpus: str) -> int:
+    """Estimate how widely deployed the component is (1-5)."""
+    for token in _HIGH_PREVALENCE_PRODUCTS:
+        if token in corpus:
+            return 5
+    # Medium-prevalence heuristics
+    medium_signals = [
+        "server",
+        "service",
+        "daemon",
+        "application",
+        "platform",
+        "suite",
+        "enterprise",
+        "cloud",
+    ]
+    hits = sum(1 for s in medium_signals if s in corpus)
+    if hits >= 3:
+        return 4
+    if hits >= 1:
+        return 3
+    return 2  # generic fallback
+
+
+def _score_auth_scope(pr: str, scope: str) -> int:
+    """Score how easily an unauthenticated attacker can reach the bug."""
+    pr_upper = pr.upper()
+    scope_upper = scope.upper()
+    if pr_upper == "NONE" and scope_upper == "CHANGED":
+        return 5  # pre-auth + crosses trust boundary
+    if pr_upper == "NONE":
+        return 4
+    if pr_upper == "LOW":
+        return 3
+    if pr_upper == "HIGH":
+        return 2
+    return 1  # unknown / unresolvable
+
+
+_PUBLIC_FACING_PATTERNS = [
+    re.compile(p, re.IGNORECASE)
+    for p in [
+        r"\binternet[- ]facing\b",
+        r"\bpublicly accessible\b",
+        r"\bremote\s+attacker\b",
+        r"\bunauthenticated\s+remote\b",
+        r"\bremote\s+code\s+execution\b",
+        r"\bremote\s+unauthenticated\b",
+        r"\bwithout\s+authentication\b",
+        r"\bno\s+authentication\b",
+        r"\banonymous\s+user\b",
+        r"\bpre-auth\b",
+        r"\bexposed\s+to\s+the\s+internet\b",
+        r"\bpublic[- ]facing\b",
+        r"\binbound\s+request\b",
+    ]
+]
+
+# CWEs that strongly imply public-facing / remote exposure
+_PUBLIC_FACING_CWES = frozenset(
+    ["CWE-78", "CWE-79", "CWE-89", "CWE-94", "CWE-502", "CWE-918", "CWE-611", "CWE-352", "CWE-287"]
+)
+
+
+def _score_public_facing(description: str, cwes: list[str]) -> int:
+    """Return 5 if description/CWEs signal internet/public exposure, else 1."""
+    for pat in _PUBLIC_FACING_PATTERNS:
+        if pat.search(description):
+            return 5
+    for cwe in cwes:
+        if cwe in _PUBLIC_FACING_CWES:
+            return 5
+    return 1
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+def _compute_overall(dimensions: dict[str, int]) -> float:
+    """Weighted average of all dimension scores, rounded to 2dp."""
+    return round(sum(_WEIGHTS[k] * dimensions[k] for k in _WEIGHTS), 2)
+
+
+def _exposure_label(score: float) -> str:
+    if score < 1.5:
+        return "minimal"
+    if score < 2.5:
+        return "low"
+    if score < 3.5:
+        return "moderate"
+    if score < 4.5:
+        return "high"
+    return "critical"
+
+
+def _dimension_label(score: int) -> str:
+    labels = ["", "minimal", "low", "moderate", "high", "critical"]
+    return labels[max(1, min(5, score))]
+
+
+# ---------------------------------------------------------------------------
+# Core pipeline
+# ---------------------------------------------------------------------------
+
+
+def _run_attack_surface(cve_id: str) -> dict[str, Any]:
+    """Execute the full attack-surface scoring pipeline for *cve_id*."""
+    cve_id = cve_id.upper().strip()
+
+    # ── 1. Fetch NVD data ────────────────────────────────────────────────────
+    cve_data = _fetch_nvd_data(cve_id)
+    cvss = _extract_cvss_fields(cve_data)
+    description = _extract_description(cve_data)
+    cpe_strings = _extract_cpe_strings(cve_data)
+    cwes = _extract_cwes(cve_data)
+
+    # ── 2. Build searchable corpus ───────────────────────────────────────────
+    corpus = _build_target_corpus(description, cpe_strings)
+
+    # ── 3. Score each dimension ──────────────────────────────────────────────
+    av = cvss.get("attackVector", "")
+    pr = cvss.get("privilegesRequired", "")
+    scope = cvss.get("scope", "")
+
+    archetype_score, archetype_label = _score_deployment_archetype(corpus)
+
+    dimensions: dict[str, int] = {
+        "deployment_archetype": archetype_score,
+        "attack_vector": _score_attack_vector(av),
+        "internet_prevalence": _score_internet_prevalence(corpus),
+        "auth_scope": _score_auth_scope(pr, scope),
+        "public_facing": _score_public_facing(description, cwes),
+    }
+
+    overall = _compute_overall(dimensions)
+
+    return {
+        "cve_id": cve_id,
+        "exposure_score": overall,
+        "exposure_label": _exposure_label(overall),
+        "archetype": archetype_label,
+        "dimensions": dimensions,
+        "cvss_available": bool(cvss),
+        "cpe_count": len(cpe_strings),
+        "cwes": cwes,
+        "attack_vector": av or "unknown",
+        "privileges_required": pr or "unknown",
+        "scope": scope or "unknown",
+        "cvss_base_score": cvss.get("baseScore"),
+        "rationale": _build_rationale(dimensions, archetype_label, av, pr, scope, description),
+    }
+
+
+def _build_rationale(
+    dimensions: dict[str, int],
+    archetype_label: str,
+    av: str,
+    pr: str,
+    scope: str,
+    description: str,
+) -> str:
+    """Build a one-paragraph rationale explaining the exposure score."""
+    parts: list[str] = []
+
+    arch_score = dimensions["deployment_archetype"]
+    if arch_score >= 4:
+        parts.append(
+            f"The component is classified as a '{archetype_label.replace('_', ' ')}' "
+            "— a high-exposure deployment class."
+        )
+    elif arch_score == 3:
+        parts.append(
+            f"The component is classified as '{archetype_label.replace('_', ' ')}' "
+            "— a moderate-exposure server-side component."
+        )
+    else:
+        parts.append(
+            f"The component is classified as '{archetype_label.replace('_', ' ')}' "
+            "— a relatively low-exposure component type."
+        )
+
+    av_score = dimensions["attack_vector"]
+    if av:
+        av_map = {
+            5: "network-reachable (NETWORK)",
+            3: "adjacent-network only",
+            2: "local access required",
+            1: "physical access required",
+        }
+        parts.append(f"Attack vector is {av_map.get(av_score, av)} ({av}).")
+
+    auth_score = dimensions["auth_scope"]
+    if pr:
+        if auth_score >= 4:
+            parts.append("No authentication is required, maximising the attacker's reach.")
+        elif auth_score == 3:
+            parts.append("Low-privilege credentials are required, slightly limiting exposure.")
+        else:
+            parts.append("High privileges are required, substantially reducing exposure.")
+
+    if dimensions["public_facing"] == 5:
+        parts.append("The vulnerability description or CWE strongly indicates public/internet-facing exposure.")
+
+    return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Text renderer
+# ---------------------------------------------------------------------------
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    lines = [
+        f"Attack Surface Exposure Score: {result['cve_id']}",
+        "=" * 60,
+        f"  Exposure score   : {result['exposure_score']:.2f} / 5  ({result['exposure_label'].upper()})",
+        f"  Component type   : {result['archetype'].replace('_', ' ')}",
+        f"  CVSS base score  : {result['cvss_base_score'] if result['cvss_base_score'] is not None else 'N/A'}",
+        "",
+        "Dimension breakdown (1 = minimal exposure, 5 = maximum)",
+        "-" * 60,
+    ]
+    dim_names = {
+        "deployment_archetype": "Deployment archetype",
+        "attack_vector": "CVSS attack vector",
+        "internet_prevalence": "Internet prevalence",
+        "auth_scope": "Authentication scope",
+        "public_facing": "Public-facing indicators",
+    }
+    for key, label in dim_names.items():
+        score = result["dimensions"][key]
+        dlabel = _dimension_label(score)
+        lines.append(f"  {label:<30}: {score}/5  ({dlabel})")
+    lines += [
+        "",
+        "Rationale",
+        "-" * 60,
+        f"  {result['rationale']}",
+        "",
+        "Data sources",
+        "-" * 60,
+        f"  NVD CVSS data    : {'available' if result['cvss_available'] else 'not available'}",
+        f"  CPE entries      : {result['cpe_count']}",
+        f"  CWEs             : {', '.join(result['cwes']) if result['cwes'] else 'none'}",
+    ]
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "score_attack_surface",
+    "description": (
+        "Estimates how exposed a vulnerable component is to potential attackers on a 1–5 scale "
+        "(1 = minimal exposure, 5 = critical/internet-facing). "
+        "Analyses five independent signals: deployment archetype (web server vs library vs CLI), "
+        "CVSS attack vector, internet prevalence of the affected product, authentication requirements, "
+        "and public-facing indicators from the CVE description and CWEs. "
+        "Returns a weighted exposure score, a human-readable label "
+        "(minimal/low/moderate/high/critical), a component archetype, and a one-paragraph rationale. "
+        "Use alongside score_exploit_complexity to get a full attacker-perspective picture: "
+        "complexity measures *how hard* an exploit is, exposure measures *how reachable* the target is."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier to score (e.g., 'CVE-2021-44228').",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "description": "Output format: 'text' (default) or 'json'.",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+@tool
+def score_attack_surface(cve_id: str, output: str = "text") -> str:
+    """Estimate the attack surface exposure of a CVE on a 1–5 scale.
+
+    Args:
+        cve_id: CVE identifier (e.g. 'CVE-2021-44228').
+        output: 'text' (default) or 'json'.
+
+    Returns:
+        Formatted report string.
+    """
+    cve_id = cve_id.strip() if isinstance(cve_id, str) else cve_id
+    if not isinstance(cve_id, str) or not re.match(r"CVE-\d{4}-\d+", cve_id, re.IGNORECASE):
+        return "Error: cve_id must be a valid CVE identifier like 'CVE-2021-44228'."
+
+    result = _run_attack_surface(cve_id)
+
+    if output == "json":
+        return _json.dumps(result, indent=2)
+
+    return _render_text(result)

--- a/tests/test_attack_surface.py
+++ b/tests/test_attack_surface.py
@@ -1,0 +1,1049 @@
+"""
+Tests for src/manus_agent/tools/score_attack_surface.py
+
+All external HTTP calls are mocked — no real network I/O.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.score_attack_surface import (
+    _WEIGHTS,
+    _archetype_label,
+    _build_rationale,
+    _build_target_corpus,
+    _compute_overall,
+    _cpe_vendor_product,
+    _dimension_label,
+    _exposure_label,
+    _extract_cpe_strings,
+    _extract_cvss_fields,
+    _extract_cwes,
+    _extract_description,
+    _fetch_nvd_data,
+    _render_text,
+    _run_attack_surface,
+    _score_attack_vector,
+    _score_auth_scope,
+    _score_deployment_archetype,
+    _score_internet_prevalence,
+    _score_public_facing,
+    score_attack_surface,
+)
+
+# ===========================================================================
+# Test data helpers
+# ===========================================================================
+
+
+def _make_nvd_cve(
+    av: str = "NETWORK",
+    pr: str = "NONE",
+    scope: str = "UNCHANGED",
+    base_score: float = 9.8,
+    description: str = "A remote code execution vulnerability in the web server.",
+    cpe_strings: list[str] | None = None,
+    cwes: list[str] | None = None,
+) -> dict[str, Any]:
+    """Build a minimal NVD CVE data dict for testing."""
+    nodes = []
+    if cpe_strings:
+        nodes = [{"cpeMatch": [{"criteria": cpe, "vulnerable": True} for cpe in cpe_strings]}]
+    weakness_list = []
+    if cwes:
+        weakness_list = [{"description": [{"lang": "en", "value": cwe}]} for cwe in cwes]
+
+    return {
+        "descriptions": [{"lang": "en", "value": description}],
+        "metrics": {
+            "cvssMetricV31": [
+                {
+                    "cvssData": {
+                        "attackVector": av,
+                        "privilegesRequired": pr,
+                        "scope": scope,
+                        "baseScore": base_score,
+                    }
+                }
+            ]
+        },
+        "configurations": [{"nodes": nodes}] if nodes else [],
+        "weaknesses": weakness_list,
+    }
+
+
+def _make_nvd_response(cve_data: dict[str, Any], cve_id: str = "CVE-2021-44228") -> dict[str, Any]:
+    """Wrap a CVE data dict in an NVD API response envelope."""
+    return {
+        "resultsPerPage": 1,
+        "vulnerabilities": [{"cve": {**cve_data, "id": cve_id}}],
+    }
+
+
+# ===========================================================================
+# _fetch_nvd_data
+# ===========================================================================
+
+
+class TestFetchNvdData:
+    def test_success(self):
+        cve_data = _make_nvd_cve()
+        response = _make_nvd_response(cve_data)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = response
+
+        with patch("manus_agent.tools.score_attack_surface.requests.get", return_value=mock_resp):
+            result = _fetch_nvd_data("CVE-2021-44228")
+
+        assert result.get("descriptions") is not None
+
+    def test_empty_vulnerabilities(self):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"vulnerabilities": []}
+
+        with patch("manus_agent.tools.score_attack_surface.requests.get", return_value=mock_resp):
+            result = _fetch_nvd_data("CVE-9999-0001")
+
+        assert result == {}
+
+    def test_request_exception(self):
+        import requests as _req
+
+        with patch(
+            "manus_agent.tools.score_attack_surface.requests.get",
+            side_effect=_req.RequestException("timeout"),
+        ):
+            result = _fetch_nvd_data("CVE-2021-44228")
+
+        assert result == {}
+
+    def test_http_error(self):
+        import requests as _req
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.side_effect = _req.RequestException("404")
+
+        with patch("manus_agent.tools.score_attack_surface.requests.get", return_value=mock_resp):
+            result = _fetch_nvd_data("CVE-2021-44228")
+
+        assert result == {}
+
+
+# ===========================================================================
+# _extract_cvss_fields
+# ===========================================================================
+
+
+class TestExtractCvssFields:
+    def test_v31_fields(self):
+        cve_data = _make_nvd_cve(av="NETWORK", pr="NONE", scope="CHANGED", base_score=10.0)
+        fields = _extract_cvss_fields(cve_data)
+        assert fields["attackVector"] == "NETWORK"
+        assert fields["privilegesRequired"] == "NONE"
+        assert fields["scope"] == "CHANGED"
+        assert fields["baseScore"] == 10.0
+
+    def test_v30_fallback(self):
+        cve_data = {
+            "metrics": {
+                "cvssMetricV30": [
+                    {
+                        "cvssData": {
+                            "attackVector": "LOCAL",
+                            "privilegesRequired": "HIGH",
+                            "scope": "UNCHANGED",
+                            "baseScore": 5.0,
+                        }
+                    }
+                ]
+            }
+        }
+        fields = _extract_cvss_fields(cve_data)
+        assert fields["attackVector"] == "LOCAL"
+
+    def test_no_metrics(self):
+        fields = _extract_cvss_fields({})
+        assert fields == {}
+
+    def test_empty_metrics(self):
+        fields = _extract_cvss_fields({"metrics": {}})
+        assert fields == {}
+
+
+# ===========================================================================
+# _extract_description
+# ===========================================================================
+
+
+class TestExtractDescription:
+    def test_english_description(self):
+        cve_data = {
+            "descriptions": [
+                {"lang": "es", "value": "descripcion"},
+                {"lang": "en", "value": "A remote code execution vulnerability."},
+            ]
+        }
+        assert _extract_description(cve_data) == "A remote code execution vulnerability."
+
+    def test_no_descriptions(self):
+        assert _extract_description({}) == ""
+
+    def test_no_english(self):
+        cve_data = {"descriptions": [{"lang": "de", "value": "test"}]}
+        assert _extract_description(cve_data) == ""
+
+    def test_en_us_lang(self):
+        cve_data = {"descriptions": [{"lang": "en-US", "value": "US description"}]}
+        assert _extract_description(cve_data) == "US description"
+
+
+# ===========================================================================
+# _extract_cpe_strings
+# ===========================================================================
+
+
+class TestExtractCpeStrings:
+    def test_basic_cpe(self):
+        cve_data = _make_nvd_cve(cpe_strings=["cpe:2.3:a:apache:httpd:2.4.50:*:*:*:*:*:*:*"])
+        cpes = _extract_cpe_strings(cve_data)
+        assert "cpe:2.3:a:apache:httpd:2.4.50:*:*:*:*:*:*:*" in cpes
+
+    def test_no_configurations(self):
+        cpes = _extract_cpe_strings({})
+        assert cpes == []
+
+    def test_multiple_nodes(self):
+        cve_data = {
+            "configurations": [
+                {
+                    "nodes": [
+                        {"cpeMatch": [{"criteria": "cpe:2.3:a:vendor:product:1.0:*:*:*:*:*:*:*"}]},
+                        {"cpeMatch": [{"criteria": "cpe:2.3:a:other:tool:2.0:*:*:*:*:*:*:*"}]},
+                    ]
+                }
+            ]
+        }
+        cpes = _extract_cpe_strings(cve_data)
+        assert len(cpes) == 2
+
+
+# ===========================================================================
+# _extract_cwes
+# ===========================================================================
+
+
+class TestExtractCwes:
+    def test_single_cwe(self):
+        cve_data = _make_nvd_cve(cwes=["CWE-79"])
+        cwes = _extract_cwes(cve_data)
+        assert "CWE-79" in cwes
+
+    def test_no_weaknesses(self):
+        assert _extract_cwes({}) == []
+
+    def test_multiple_cwes(self):
+        cve_data = _make_nvd_cve(cwes=["CWE-79", "CWE-89"])
+        cwes = _extract_cwes(cve_data)
+        assert "CWE-79" in cwes
+        assert "CWE-89" in cwes
+
+    def test_non_cwe_filtered(self):
+        cve_data = {"weaknesses": [{"description": [{"lang": "en", "value": "NVD-CWE-noinfo"}]}]}
+        cwes = _extract_cwes(cve_data)
+        assert cwes == []
+
+
+# ===========================================================================
+# _cpe_vendor_product
+# ===========================================================================
+
+
+class TestCpeVendorProduct:
+    def test_application_cpe(self):
+        v, p = _cpe_vendor_product("cpe:2.3:a:apache:httpd:2.4.50:*:*:*:*:*:*:*")
+        assert v == "apache"
+        assert p == "httpd"
+
+    def test_os_cpe(self):
+        v, p = _cpe_vendor_product("cpe:2.3:o:linux:linux_kernel:5.15:*:*:*:*:*:*:*")
+        assert v == "linux"
+        assert p == "linux_kernel"
+
+    def test_invalid_cpe(self):
+        v, p = _cpe_vendor_product("not-a-cpe")
+        assert v == ""
+        assert p == ""
+
+    def test_empty_string(self):
+        v, p = _cpe_vendor_product("")
+        assert v == ""
+        assert p == ""
+
+
+# ===========================================================================
+# _build_target_corpus
+# ===========================================================================
+
+
+class TestBuildTargetCorpus:
+    def test_includes_description(self):
+        corpus = _build_target_corpus("A vulnerability in nginx", [])
+        assert "nginx" in corpus
+
+    def test_includes_cpe_product(self):
+        corpus = _build_target_corpus("desc", ["cpe:2.3:a:apache:httpd:2.4.50:*:*:*:*:*:*:*"])
+        assert "apache" in corpus
+        assert "httpd" in corpus
+
+    def test_lowercase(self):
+        corpus = _build_target_corpus("APACHE Tomcat", [])
+        assert corpus == corpus.lower()
+
+    def test_underscore_normalized(self):
+        corpus = _build_target_corpus("", ["cpe:2.3:a:vendor:web_server:1.0:*:*:*:*:*:*:*"])
+        assert "web server" in corpus
+
+
+# ===========================================================================
+# _score_deployment_archetype
+# ===========================================================================
+
+
+class TestScoreDeploymentArchetype:
+    def test_web_server_nginx(self):
+        score, label = _score_deployment_archetype("nginx web server")
+        assert score == 5
+        assert label == "web_server_or_api_gateway"
+
+    def test_apache(self):
+        score, label = _score_deployment_archetype("apache httpd")
+        assert score == 5
+
+    def test_wordpress(self):
+        score, label = _score_deployment_archetype("wordpress cms")
+        assert score == 5
+
+    def test_router_firmware(self):
+        score, label = _score_deployment_archetype("router firmware vpn")
+        assert score == 4
+        assert label == "network_device_or_iot"
+
+    def test_database_postgresql(self):
+        score, label = _score_deployment_archetype("postgresql database")
+        assert score == 3
+        assert label == "database_or_middleware"
+
+    def test_browser(self):
+        score, label = _score_deployment_archetype("firefox browser")
+        assert score == 2
+        assert label == "desktop_or_browser"
+
+    def test_cli_tool(self):
+        score, label = _score_deployment_archetype("cli command line tool")
+        assert score == 1
+        assert label == "cli_or_library"
+
+    def test_unknown_defaults_to_cli(self):
+        score, label = _score_deployment_archetype("xyzzy obscure_tool_123")
+        assert score == 1
+
+    def test_highest_tier_wins(self):
+        # corpus contains both cli and nginx — nginx (tier 5) should win
+        score, label = _score_deployment_archetype("nginx cli tool library")
+        assert score == 5
+
+
+# ===========================================================================
+# _archetype_label
+# ===========================================================================
+
+
+class TestArchetypeLabel:
+    def test_all_scores(self):
+        assert _archetype_label(5) == "web_server_or_api_gateway"
+        assert _archetype_label(4) == "network_device_or_iot"
+        assert _archetype_label(3) == "database_or_middleware"
+        assert _archetype_label(2) == "desktop_or_browser"
+        assert _archetype_label(1) == "cli_or_library"
+
+    def test_unknown(self):
+        assert _archetype_label(99) == "unknown"
+
+
+# ===========================================================================
+# _score_attack_vector
+# ===========================================================================
+
+
+class TestScoreAttackVector:
+    def test_network(self):
+        assert _score_attack_vector("NETWORK") == 5
+
+    def test_adjacent(self):
+        assert _score_attack_vector("ADJACENT") == 3
+
+    def test_local(self):
+        assert _score_attack_vector("LOCAL") == 2
+
+    def test_physical(self):
+        assert _score_attack_vector("PHYSICAL") == 1
+
+    def test_unknown_default(self):
+        assert _score_attack_vector("") == 3
+
+    def test_case_insensitive(self):
+        assert _score_attack_vector("network") == 5
+
+
+# ===========================================================================
+# _score_internet_prevalence
+# ===========================================================================
+
+
+class TestScoreInternetPrevalence:
+    def test_high_prevalence_apache(self):
+        assert _score_internet_prevalence("apache httpd") == 5
+
+    def test_high_prevalence_openssl(self):
+        assert _score_internet_prevalence("openssl library") == 5
+
+    def test_high_prevalence_log4j(self):
+        assert _score_internet_prevalence("log4j java") == 5
+
+    def test_medium_prevalence_server(self):
+        score = _score_internet_prevalence("some server application platform enterprise cloud service")
+        assert score >= 3
+
+    def test_low_prevalence(self):
+        score = _score_internet_prevalence("xyzzy_lib_unknown")
+        assert score == 2
+
+
+# ===========================================================================
+# _score_auth_scope
+# ===========================================================================
+
+
+class TestScoreAuthScope:
+    def test_none_changed(self):
+        assert _score_auth_scope("NONE", "CHANGED") == 5
+
+    def test_none_unchanged(self):
+        assert _score_auth_scope("NONE", "UNCHANGED") == 4
+
+    def test_low_privileges(self):
+        assert _score_auth_scope("LOW", "UNCHANGED") == 3
+
+    def test_high_privileges(self):
+        assert _score_auth_scope("HIGH", "UNCHANGED") == 2
+
+    def test_unknown_pr(self):
+        assert _score_auth_scope("", "") == 1
+
+    def test_case_insensitive(self):
+        assert _score_auth_scope("none", "changed") == 5
+
+
+# ===========================================================================
+# _score_public_facing
+# ===========================================================================
+
+
+class TestScorePublicFacing:
+    def test_remote_attacker_phrase(self):
+        assert _score_public_facing("remote attacker can execute arbitrary code", []) == 5
+
+    def test_unauthenticated_remote(self):
+        assert _score_public_facing("unauthenticated remote user", []) == 5
+
+    def test_rce_phrase(self):
+        assert _score_public_facing("allows remote code execution via a crafted request", []) == 5
+
+    def test_without_authentication(self):
+        assert _score_public_facing("exploitable without authentication", []) == 5
+
+    def test_public_facing_cwe(self):
+        assert _score_public_facing("generic description", ["CWE-79"]) == 5
+
+    def test_rce_cwe(self):
+        assert _score_public_facing("generic", ["CWE-94"]) == 5
+
+    def test_no_signal(self):
+        assert _score_public_facing("local privilege escalation", []) == 1
+
+    def test_no_signal_no_cwe(self):
+        assert _score_public_facing("requires local access", ["CWE-125"]) == 1
+
+    def test_pre_auth(self):
+        assert _score_public_facing("pre-auth heap overflow", []) == 5
+
+    def test_internet_facing(self):
+        assert _score_public_facing("internet-facing service is affected", []) == 5
+
+
+# ===========================================================================
+# _compute_overall
+# ===========================================================================
+
+
+class TestComputeOverall:
+    def test_all_fives(self):
+        dims = {k: 5 for k in _WEIGHTS}
+        score = _compute_overall(dims)
+        assert score == 5.0
+
+    def test_all_ones(self):
+        dims = {k: 1 for k in _WEIGHTS}
+        score = _compute_overall(dims)
+        assert score == 1.0
+
+    def test_mixed(self):
+        dims = {
+            "deployment_archetype": 5,
+            "attack_vector": 5,
+            "internet_prevalence": 3,
+            "auth_scope": 4,
+            "public_facing": 5,
+        }
+        score = _compute_overall(dims)
+        assert 1.0 <= score <= 5.0
+        # Weighted: 5*0.30 + 5*0.25 + 3*0.20 + 4*0.15 + 5*0.10
+        expected = round(5 * 0.30 + 5 * 0.25 + 3 * 0.20 + 4 * 0.15 + 5 * 0.10, 2)
+        assert score == expected
+
+    def test_weights_sum_to_one(self):
+        """Weights in _WEIGHTS must sum to 1.0 (floating-point tolerance)."""
+        assert abs(sum(_WEIGHTS.values()) - 1.0) < 1e-9
+
+
+# ===========================================================================
+# _exposure_label
+# ===========================================================================
+
+
+class TestExposureLabel:
+    def test_minimal(self):
+        assert _exposure_label(1.0) == "minimal"
+
+    def test_low(self):
+        assert _exposure_label(2.0) == "low"
+
+    def test_moderate(self):
+        assert _exposure_label(3.0) == "moderate"
+
+    def test_high(self):
+        assert _exposure_label(4.0) == "high"
+
+    def test_critical(self):
+        assert _exposure_label(5.0) == "critical"
+
+    def test_boundary_low_to_moderate(self):
+        assert _exposure_label(2.49) == "low"
+        assert _exposure_label(2.51) == "moderate"
+
+    def test_boundary_high_to_critical(self):
+        assert _exposure_label(4.49) == "high"
+        assert _exposure_label(4.51) == "critical"
+
+
+# ===========================================================================
+# _dimension_label
+# ===========================================================================
+
+
+class TestDimensionLabel:
+    def test_all_scores(self):
+        assert _dimension_label(1) == "minimal"
+        assert _dimension_label(2) == "low"
+        assert _dimension_label(3) == "moderate"
+        assert _dimension_label(4) == "high"
+        assert _dimension_label(5) == "critical"
+
+    def test_clamp_below(self):
+        assert _dimension_label(0) == "minimal"
+
+    def test_clamp_above(self):
+        assert _dimension_label(6) == "critical"
+
+
+# ===========================================================================
+# _build_rationale
+# ===========================================================================
+
+
+class TestBuildRationale:
+    def test_high_archetype(self):
+        r = _build_rationale(
+            {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "web_server_or_api_gateway",
+            "NETWORK",
+            "NONE",
+            "UNCHANGED",
+            "Remote code execution",
+        )
+        assert "web server or api gateway" in r.lower()
+        assert "high-exposure" in r.lower()
+
+    def test_low_archetype(self):
+        r = _build_rationale(
+            {
+                "deployment_archetype": 1,
+                "attack_vector": 2,
+                "internet_prevalence": 2,
+                "auth_scope": 2,
+                "public_facing": 1,
+            },
+            "cli_or_library",
+            "LOCAL",
+            "HIGH",
+            "UNCHANGED",
+            "Local privilege escalation",
+        )
+        assert "cli or library" in r.lower()
+        assert "low-exposure" in r.lower()
+
+    def test_no_auth_mentioned(self):
+        r = _build_rationale(
+            {
+                "deployment_archetype": 3,
+                "attack_vector": 5,
+                "internet_prevalence": 3,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "database_or_middleware",
+            "NETWORK",
+            "NONE",
+            "UNCHANGED",
+            "Remote attacker can access the database",
+        )
+        assert "no authentication" in r.lower()
+
+    def test_public_facing_signal(self):
+        r = _build_rationale(
+            {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 5,
+                "public_facing": 5,
+            },
+            "web_server_or_api_gateway",
+            "NETWORK",
+            "NONE",
+            "CHANGED",
+            "Remote code execution",
+        )
+        assert "public" in r.lower() or "internet" in r.lower()
+
+    def test_no_av_missing(self):
+        # Should not error when av is empty string
+        r = _build_rationale(
+            {
+                "deployment_archetype": 2,
+                "attack_vector": 3,
+                "internet_prevalence": 2,
+                "auth_scope": 1,
+                "public_facing": 1,
+            },
+            "desktop_or_browser",
+            "",
+            "",
+            "",
+            "Local overflow",
+        )
+        assert isinstance(r, str)
+
+
+# ===========================================================================
+# _render_text
+# ===========================================================================
+
+
+class TestRenderText:
+    def _sample_result(self, **overrides) -> dict:
+        base = {
+            "cve_id": "CVE-2021-44228",
+            "exposure_score": 4.85,
+            "exposure_label": "critical",
+            "archetype": "web_server_or_api_gateway",
+            "dimensions": {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "cvss_available": True,
+            "cpe_count": 3,
+            "cwes": ["CWE-502"],
+            "attack_vector": "NETWORK",
+            "privileges_required": "NONE",
+            "scope": "CHANGED",
+            "cvss_base_score": 10.0,
+            "rationale": "A web server component with NETWORK access and no auth required.",
+        }
+        base.update(overrides)
+        return base
+
+    def test_header(self):
+        text = _render_text(self._sample_result())
+        assert "CVE-2021-44228" in text
+        assert "Attack Surface Exposure Score" in text
+
+    def test_score_displayed(self):
+        text = _render_text(self._sample_result())
+        assert "4.85" in text
+        assert "CRITICAL" in text
+
+    def test_archetype_displayed(self):
+        text = _render_text(self._sample_result())
+        assert "web server or api gateway" in text
+
+    def test_dimensions_listed(self):
+        text = _render_text(self._sample_result())
+        assert "Deployment archetype" in text
+        assert "Authentication scope" in text
+
+    def test_rationale_present(self):
+        text = _render_text(self._sample_result())
+        assert "web server component" in text
+
+    def test_cpe_count(self):
+        text = _render_text(self._sample_result())
+        assert "3" in text
+
+    def test_cwes_listed(self):
+        text = _render_text(self._sample_result())
+        assert "CWE-502" in text
+
+    def test_no_cwes(self):
+        text = _render_text(self._sample_result(cwes=[]))
+        assert "none" in text
+
+    def test_no_cvss(self):
+        text = _render_text(self._sample_result(cvss_available=False, cvss_base_score=None))
+        assert "N/A" in text
+
+
+# ===========================================================================
+# _run_attack_surface  (full pipeline, mocked NVD)
+# ===========================================================================
+
+
+class TestRunAttackSurface:
+    def _mock_nvd(self, cve_data: dict[str, Any]):
+        """Return a context-manager mock for requests.get that returns cve_data."""
+        response = _make_nvd_response(cve_data)
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = response
+        return patch("manus_agent.tools.score_attack_surface.requests.get", return_value=mock_resp)
+
+    def test_log4shell_high_exposure(self):
+        cve_data = _make_nvd_cve(
+            av="NETWORK",
+            pr="NONE",
+            scope="CHANGED",
+            base_score=10.0,
+            description="Remote code execution in log4j via JNDI lookup",
+            cpe_strings=["cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*"],
+            cwes=["CWE-502"],
+        )
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        assert result["cve_id"] == "CVE-2021-44228"
+        assert result["exposure_score"] >= 4.0
+        assert result["exposure_label"] in ("high", "critical")
+        assert result["dimensions"]["attack_vector"] == 5
+        assert result["dimensions"]["auth_scope"] == 5  # NONE + CHANGED
+
+    def test_local_cli_low_exposure(self):
+        cve_data = _make_nvd_cve(
+            av="LOCAL",
+            pr="HIGH",
+            scope="UNCHANGED",
+            base_score=4.4,
+            description="Local privilege escalation in a CLI utility",
+            cpe_strings=["cpe:2.3:a:vendor:cli_tool:1.0:*:*:*:*:*:*:*"],
+            cwes=["CWE-125"],
+        )
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2024-9999")
+
+        assert result["exposure_score"] < 3.5
+        assert result["exposure_label"] in ("minimal", "low", "moderate")
+        assert result["dimensions"]["attack_vector"] == 2
+
+    def test_network_device_medium_exposure(self):
+        cve_data = _make_nvd_cve(
+            av="NETWORK",
+            pr="NONE",
+            scope="UNCHANGED",
+            base_score=9.1,
+            description="Remote attacker can exploit a VPN appliance",
+            cpe_strings=["cpe:2.3:a:fortinet:fortigate:7.0.0:*:*:*:*:*:*:*"],
+        )
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2023-1234")
+
+        assert result["dimensions"]["deployment_archetype"] >= 4
+
+    def test_nvd_unavailable_graceful(self):
+        import requests as _req
+
+        with patch(
+            "manus_agent.tools.score_attack_surface.requests.get",
+            side_effect=_req.RequestException("network error"),
+        ):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        assert result["cve_id"] == "CVE-2021-44228"
+        assert result["cvss_available"] is False
+        assert isinstance(result["exposure_score"], float)
+        assert 1.0 <= result["exposure_score"] <= 5.0
+
+    def test_output_fields_present(self):
+        cve_data = _make_nvd_cve()
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        required_keys = [
+            "cve_id",
+            "exposure_score",
+            "exposure_label",
+            "archetype",
+            "dimensions",
+            "cvss_available",
+            "cpe_count",
+            "cwes",
+            "attack_vector",
+            "privileges_required",
+            "scope",
+            "cvss_base_score",
+            "rationale",
+        ]
+        for key in required_keys:
+            assert key in result, f"Missing key: {key}"
+
+    def test_dimensions_all_present(self):
+        cve_data = _make_nvd_cve()
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        expected_dims = {
+            "deployment_archetype",
+            "attack_vector",
+            "internet_prevalence",
+            "auth_scope",
+            "public_facing",
+        }
+        assert set(result["dimensions"].keys()) == expected_dims
+
+    def test_dimensions_in_range(self):
+        cve_data = _make_nvd_cve()
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        for key, val in result["dimensions"].items():
+            assert 1 <= val <= 5, f"Dimension {key}={val} out of range"
+
+    def test_cpe_count_populated(self):
+        cve_data = _make_nvd_cve(
+            cpe_strings=[
+                "cpe:2.3:a:apache:httpd:2.4.50:*:*:*:*:*:*:*",
+                "cpe:2.3:a:apache:httpd:2.4.51:*:*:*:*:*:*:*",
+            ]
+        )
+        with self._mock_nvd(cve_data):
+            result = _run_attack_surface("CVE-2021-44228")
+
+        assert result["cpe_count"] == 2
+
+
+# ===========================================================================
+# score_attack_surface  (public @tool entry point)
+# ===========================================================================
+
+
+class TestScoreAttackSurface:
+    def _mock_run(self):
+        return {
+            "cve_id": "CVE-2021-44228",
+            "exposure_score": 4.85,
+            "exposure_label": "critical",
+            "archetype": "web_server_or_api_gateway",
+            "dimensions": {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "cvss_available": True,
+            "cpe_count": 2,
+            "cwes": ["CWE-502"],
+            "attack_vector": "NETWORK",
+            "privileges_required": "NONE",
+            "scope": "CHANGED",
+            "cvss_base_score": 10.0,
+            "rationale": "Log4Shell is a web-facing library with NETWORK access and no auth.",
+        }
+
+    def test_text_output_default(self):
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=self._mock_run(),
+        ):
+            result = score_attack_surface(cve_id="CVE-2021-44228")
+
+        assert "CVE-2021-44228" in result
+        assert "Attack Surface" in result
+
+    def test_json_output(self):
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=self._mock_run(),
+        ):
+            result = score_attack_surface(cve_id="CVE-2021-44228", output="json")
+
+        parsed = json.loads(result)
+        assert parsed["cve_id"] == "CVE-2021-44228"
+        assert parsed["exposure_score"] == 4.85
+
+    def test_invalid_cve_id(self):
+        result = score_attack_surface(cve_id="not-a-cve")
+        assert "Error" in result
+
+    def test_invalid_cve_id_empty(self):
+        result = score_attack_surface(cve_id="")
+        assert "Error" in result
+
+    def test_lowercase_cve_accepted(self):
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=self._mock_run(),
+        ) as mock_run:
+            score_attack_surface(cve_id="cve-2021-44228")
+        # The tool should pass through (regex is case-insensitive)
+        mock_run.assert_called_once()
+
+    def test_cve_id_whitespace_stripped(self):
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=self._mock_run(),
+        ) as mock_run:
+            score_attack_surface(cve_id="  CVE-2021-44228  ")
+        mock_run.assert_called_once()
+
+
+# ===========================================================================
+# CLI integration
+# ===========================================================================
+
+
+class TestAttackSurfaceCli:
+    def test_text_output(self, capsys):
+        from manus_agent.cli import _run_attack_surface as cli_run
+
+        mock_result = {
+            "cve_id": "CVE-2021-44228",
+            "exposure_score": 4.85,
+            "exposure_label": "critical",
+            "archetype": "web_server_or_api_gateway",
+            "dimensions": {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "cvss_available": True,
+            "cpe_count": 2,
+            "cwes": ["CWE-502"],
+            "attack_vector": "NETWORK",
+            "privileges_required": "NONE",
+            "scope": "CHANGED",
+            "cvss_base_score": 10.0,
+            "rationale": "Web server with NETWORK access and no authentication.",
+        }
+
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=mock_result,
+        ):
+            rc = cli_run(["CVE-2021-44228"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CVE-2021-44228" in out
+
+    def test_json_output(self, capsys):
+        from manus_agent.cli import _run_attack_surface as cli_run
+
+        mock_result = {
+            "cve_id": "CVE-2021-44228",
+            "exposure_score": 4.85,
+            "exposure_label": "critical",
+            "archetype": "web_server_or_api_gateway",
+            "dimensions": {
+                "deployment_archetype": 5,
+                "attack_vector": 5,
+                "internet_prevalence": 5,
+                "auth_scope": 4,
+                "public_facing": 5,
+            },
+            "cvss_available": True,
+            "cpe_count": 2,
+            "cwes": [],
+            "attack_vector": "NETWORK",
+            "privileges_required": "NONE",
+            "scope": "CHANGED",
+            "cvss_base_score": 10.0,
+            "rationale": "Web server with NETWORK access.",
+        }
+
+        with patch(
+            "manus_agent.tools.score_attack_surface._run_attack_surface",
+            return_value=mock_result,
+        ):
+            rc = cli_run(["CVE-2021-44228", "--output", "json"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        parsed = json.loads(out)
+        assert parsed["exposure_score"] == 4.85
+
+    def test_invalid_cve_exits_nonzero(self):
+        from manus_agent.cli import _run_attack_surface as cli_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_run(["not-a-cve"])
+        assert exc_info.value.code != 0
+
+    def test_attack_surface_in_known_subcommands(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "attack-surface" in _SUBCOMMANDS
+
+    def test_help_flag(self):
+        from manus_agent.cli import _run_attack_surface as cli_run
+
+        with pytest.raises(SystemExit) as exc_info:
+            cli_run(["--help"])
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Adds `score_attack_surface`, a Strands tool and CLI subcommand that estimates how *exposed* a vulnerable component is to potential attackers on a 1–5 scale.

## Motivation

CVSS and `score_exploit_complexity` answer two questions — *how severe?* and *how hard to exploit?* — but neither answers: **"how reachable is the target in a typical deployment?"** A CVSS 9.8 in an obscure CLI utility deserves very different urgency than the same score in an internet-facing web server. `score_attack_surface` fills this gap, completing a three-pillar attacker-perspective picture alongside `score_exploit_complexity` and `get_dependency_blast_radius`.

## Scoring model

Five weighted signals, each scored 1–5 (1 = minimal exposure, 5 = maximum):

| Dimension | Weight | Derivation |
|---|---|---|
| `deployment_archetype` | 30% | Keyword tiers from CPE/description: web-server/API-gateway=5, network-device/IoT=4, DB/middleware=3, desktop/browser=2, CLI/library=1 |
| `attack_vector` | 25% | CVSS: NETWORK=5, ADJACENT=3, LOCAL=2, PHYSICAL=1 |
| `internet_prevalence` | 20% | Known high-deployment stacks (nginx, log4j, openssl, wordpress…) score 5; heuristic signals otherwise |
| `auth_scope` | 15% | PR=NONE + SCOPE=CHANGED=5 → PR=HIGH=2 |
| `public_facing` | 10% | Regex match on description ("remote attacker", "pre-auth", "internet-facing") and public-facing CWEs (79, 89, 94, 502, 918…) |

Output: weighted `exposure_score` (1.0–5.0 float), `exposure_label` (minimal/low/moderate/high/critical), `archetype` string, and a one-paragraph `rationale`.

Graceful degradation: if NVD is unreachable, scores fall back to neutral defaults with `cvss_available=false`.

## CLI

```sh
manus-agent attack-surface CVE-2021-44228
manus-agent attack-surface CVE-2021-44228 --output json
```

## VI Agent integration

- `score_attack_surface` added to VI agent tool list.
- **Step 6b2** added to the system prompt — agent calls the tool and includes exposure score, archetype, dimensions, and rationale in reports.
- System prompt explicitly cross-references complexity vs exposure: *"critical exposure + trivial complexity = highest priority."*

## Tests

112 new unit tests (all HTTP mocked). Total: **1 014 passing**, 0 failures (was 902).

## Files changed

- `src/manus_agent/tools/score_attack_surface.py` — new tool (750 lines)
- `tests/test_attack_surface.py` — 112 unit tests
- `src/manus_agent/agents/vi_agent.py` — import + tool registration + Step 6b2
- `src/manus_agent/cli.py` — `attack-surface` subcommand + dispatch