### PR TITLE
feat(tools): EPSS watchlist alert digest — watch_alert tool + manus-agent watch-alert CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -120,6 +120,11 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
   A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
 
+**Step 6d: EPSS Watchlist Alert (optional)**
+- If the user has an active EPSS watchlist, call `watch_alert` with `output_format="markdown"` to generate an alert digest.
+  - Include the digest in the report when any 🚨 Spike or ⚠️ Elevated CVEs are detected.
+  - If the watchlist is empty or unavailable, skip this step and proceed.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -219,6 +224,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
             from manus_agent.tools.score_exploit_complexity import score_exploit_complexity
             from manus_agent.tools.search_poc_sources import search_poc_sources
+            from manus_agent.tools.watch_alert import watch_alert
         except ImportError as exc:  # pragma: no cover - depends on env
             raise ImportError(
                 "VulnerabilityIntelligenceAgent requires the optional 'strands' "
@@ -274,6 +280,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            watch_alert,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "watch-alert",
 }
 
 
@@ -1859,6 +1860,103 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# watch-alert subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_watch_alert_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent watch-alert",
+        description=(
+            "Read the EPSS watchlist (~/.manus-agent/watchlist.jsonl), fetch current\n"
+            "EPSS scores and enrichment data (CVSS, KEV) for every tracked CVE, and\n"
+            "render an alert digest grouped into: 🚨 Spikes, ⚠️  Elevated, ✅ Stable.\n"
+            "Updated EPSS scores are persisted back to the watchlist."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "--threshold",
+        type=float,
+        default=0.10,
+        metavar="DELTA",
+        help="Minimum EPSS delta to flag as a spike (default: 0.10)",
+    )
+    p.add_argument(
+        "--floor",
+        type=float,
+        default=0.30,
+        metavar="EPSS",
+        help="EPSS score floor for the Elevated bucket (default: 0.30)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["markdown", "text", "json"],
+        default="markdown",
+        help="Output format: markdown (default), text, or json",
+    )
+    p.add_argument(
+        "--watchlist",
+        metavar="PATH",
+        default=None,
+        help="Override the watchlist file path (default: ~/.manus-agent/watchlist.jsonl)",
+    )
+    return p
+
+
+def _run_watch_alert(argv: list[str]) -> int:
+    parser = _build_watch_alert_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.watch_alert import (
+            _build_alert,
+            _load_watchlist,
+            _render_markdown,
+            _render_text,
+            _resolve_path,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import os
+
+    path = _resolve_path(args.watchlist or os.environ.get("MANUS_WATCHLIST_PATH"))
+    records = _load_watchlist(path)
+
+    if not records:
+        print(
+            "Watchlist is empty. Use 'manus-agent watch add CVE-XXXX-YYYY' to start tracking CVEs.",
+            file=sys.stderr,
+        )
+        return 0
+
+    try:
+        _updated, payload = _build_alert(
+            records,
+            path,
+            spike_threshold=args.threshold,
+            epss_alert_floor=args.floor,
+        )
+    except Exception as exc:
+        print(f"[error] watch-alert failed: {exc}", file=sys.stderr)
+        return 1
+
+    fmt = args.output
+    if fmt == "json":
+        import json as _json_mod
+
+        print(_json_mod.dumps(payload, indent=2))
+    elif fmt == "text":
+        print(_render_text(payload), end="")
+    else:
+        print(_render_markdown(payload), end="")
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2188,6 +2286,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "watch-alert":
+        idx = argv.index("watch-alert")
+        sys.exit(_run_watch_alert(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/watch_alert.py
+++ b/src/manus_agent/tools/watch_alert.py
@@ -1,0 +1,578 @@
+"""
+Tool: watch_alert
+
+Reads the persistent EPSS watchlist (``~/.manus-agent/watchlist.jsonl``),
+fetches current EPSS scores and enrichment data for every tracked CVE, and
+renders a Markdown alert digest.
+
+The digest groups CVEs into three severity bands:
+
+- 🚨 **EPSS Spike** — current EPSS rose ≥ ``spike_threshold`` (default 0.10)
+  since the last recorded score.
+- ⚠️  **Elevated** — current EPSS ≥ ``epss_alert_floor`` (default 0.30) but no
+  spike this cycle.
+- ✅  **Stable** — everything else (shown in the digest but not highlighted).
+
+Per-CVE enrichment (all gracefully degraded when APIs are unavailable):
+
+- CVSS base score + severity tier (fetched from NVD)
+- CISA KEV membership flag (fetched from CISA)
+- EPSS score delta (vs. ``last_epss`` stored in the watchlist)
+- Trend arrow: ↑ / ↓ / → based on delta magnitude
+
+The tool also persists the refreshed EPSS scores back to the watchlist file so
+the next ``watch check`` (or ``watch alert``) call starts from an up-to-date
+baseline — identical behaviour to ``watch_epss check``.
+
+Supported output formats (``output_format`` parameter):
+- ``"markdown"`` (default) — Markdown report suitable for piping to a file or
+  posting to a chat tool.
+- ``"text"`` — Plain-text version (no Markdown headings/bold).
+- ``"json"`` — Machine-readable JSON with the full per-CVE breakdown.
+
+CLI: ``manus-agent watch alert [--threshold DELTA] [--floor EPSS]
+         [--output markdown|text|json] [--watchlist PATH]``
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WATCHLIST_PATH = Path.home() / ".manus-agent" / "watchlist.jsonl"
+_DEFAULT_SPIKE_THRESHOLD = 0.10
+_DEFAULT_EPSS_FLOOR = 0.30
+
+TOOL_SPEC = {
+    "name": "watch_alert",
+    "description": (
+        "Read the EPSS watchlist (~/.manus-agent/watchlist.jsonl), fetch current EPSS scores "
+        "for every tracked CVE, enrich with CVSS base score and CISA KEV status, and render a "
+        "Markdown alert digest. CVEs are grouped into: 🚨 EPSS Spike (delta ≥ spike_threshold), "
+        "⚠️ Elevated (EPSS ≥ epss_alert_floor), and ✅ Stable. Updated scores are persisted back "
+        "to the watchlist. Use this to generate a periodic security digest or a notification-ready "
+        "summary of your tracked vulnerabilities."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "spike_threshold": {
+                    "type": "number",
+                    "description": (
+                        "Minimum EPSS delta (current − last) to classify a CVE as a spike. "
+                        "Default: 0.10 (10 percentage points)."
+                    ),
+                    "default": _DEFAULT_SPIKE_THRESHOLD,
+                },
+                "epss_alert_floor": {
+                    "type": "number",
+                    "description": (
+                        "CVEs with EPSS ≥ this value are highlighted as 'Elevated' even when "
+                        "there is no spike. Default: 0.30."
+                    ),
+                    "default": _DEFAULT_EPSS_FLOOR,
+                },
+                "output_format": {
+                    "type": "string",
+                    "enum": ["markdown", "text", "json"],
+                    "description": "Output format: 'markdown' (default), 'text', or 'json'.",
+                    "default": "markdown",
+                },
+                "watchlist_path": {
+                    "type": "string",
+                    "description": ("Override the watchlist file path. Defaults to ~/.manus-agent/watchlist.jsonl."),
+                },
+            },
+            "required": [],
+        }
+    },
+}
+
+# ---------------------------------------------------------------------------
+# EPSS fetcher (same logic as watch_epss to keep the two in sync)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_current_epss(cve_ids: list[str]) -> dict[str, float]:
+    """Fetch current EPSS scores from FIRST.org.  Returns cve_id → score."""
+    if not cve_ids:
+        return {}
+    scores: dict[str, float] = {}
+    chunk_size = 50
+    for i in range(0, len(cve_ids), chunk_size):
+        chunk = cve_ids[i : i + chunk_size]
+        params = [("cve", c.upper()) for c in chunk]
+        try:
+            resp = requests.get(
+                "https://api.first.org/data/v1/epss",
+                params=params,
+                timeout=20,
+            )
+            resp.raise_for_status()
+            for entry in resp.json().get("data", []):
+                cid = entry.get("cve", "").upper()
+                try:
+                    scores[cid] = float(entry.get("epss", -1))
+                except (TypeError, ValueError):
+                    scores[cid] = -1.0
+        except requests.exceptions.RequestException:
+            for c in chunk:
+                scores[c.upper()] = -1.0
+    for c in cve_ids:
+        scores.setdefault(c.upper(), -1.0)
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# NVD enrichment (CVSS base score)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_cvss(cve_ids: list[str]) -> dict[str, dict[str, Any]]:
+    """
+    Fetch CVSS base score + severity for each CVE from NVD.
+    Returns dict[cve_id] → {"base_score": float, "severity": str}.
+    Missing / errored CVEs get {"base_score": None, "severity": "UNKNOWN"}.
+    """
+    results: dict[str, dict[str, Any]] = {}
+    for cid in cve_ids:
+        default: dict[str, Any] = {"base_score": None, "severity": "UNKNOWN"}
+        try:
+            resp = requests.get(
+                "https://services.nvd.nist.gov/rest/json/cves/2.0",
+                params={"cveId": cid.upper()},
+                timeout=15,
+            )
+            resp.raise_for_status()
+            vulns = resp.json().get("vulnerabilities", [])
+            if not vulns:
+                results[cid.upper()] = default
+                continue
+            metrics = vulns[0].get("cve", {}).get("metrics", {})
+            # Prefer CVSSv3.1, fall back to v3.0, then v2
+            for key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+                entries = metrics.get(key, [])
+                if entries:
+                    cv = entries[0].get("cvssData", {})
+                    score = cv.get("baseScore")
+                    severity = cv.get("baseSeverity") or cv.get("baseMetricV2", {}).get("severity") or "UNKNOWN"
+                    results[cid.upper()] = {
+                        "base_score": float(score) if score is not None else None,
+                        "severity": str(severity).upper(),
+                    }
+                    break
+            else:
+                results[cid.upper()] = default
+        except requests.exceptions.RequestException:
+            results[cid.upper()] = default
+    return results
+
+
+# ---------------------------------------------------------------------------
+# CISA KEV enrichment
+# ---------------------------------------------------------------------------
+
+
+def _fetch_kev_set() -> set[str]:
+    """Return the set of CVE IDs in the CISA KEV catalog. Empty on error."""
+    try:
+        resp = requests.get(
+            "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+            timeout=20,
+        )
+        resp.raise_for_status()
+        vulns = resp.json().get("vulnerabilities", [])
+        return {v.get("cveID", "").upper() for v in vulns if v.get("cveID")}
+    except requests.exceptions.RequestException:
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Watchlist I/O
+# ---------------------------------------------------------------------------
+
+
+def _resolve_path(override: str | None) -> Path:
+    p = Path(override) if override else _DEFAULT_WATCHLIST_PATH
+    p.parent.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _load_watchlist(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    records: list[dict[str, Any]] = []
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if line:
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                pass
+    return records
+
+
+def _save_watchlist(path: Path, records: list[dict[str, Any]]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in records) + ("\n" if records else ""),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Trend arrow helper
+# ---------------------------------------------------------------------------
+
+
+def _trend_arrow(delta: float | None) -> str:
+    """Return ↑ / ↓ / → based on the EPSS delta."""
+    if delta is None:
+        return "→"
+    if delta >= 0.02:
+        return "↑"
+    if delta <= -0.02:
+        return "↓"
+    return "→"
+
+
+# ---------------------------------------------------------------------------
+# Core alert builder
+# ---------------------------------------------------------------------------
+
+
+def _build_alert(
+    records: list[dict[str, Any]],
+    path: Path,
+    spike_threshold: float,
+    epss_alert_floor: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """
+    Fetch enrichment data, update watchlist records, and return
+    (updated_records, alert_payload).
+
+    alert_payload keys:
+        generated_at  str  ISO-8601 UTC timestamp
+        watchlist_size  int
+        spike_threshold  float
+        epss_alert_floor  float
+        spikes  list[dict]
+        elevated  list[dict]
+        stable  list[dict]
+    """
+    today = date.today().isoformat()
+    generated_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    if not records:
+        return records, {
+            "generated_at": generated_at,
+            "watchlist_size": 0,
+            "spike_threshold": spike_threshold,
+            "epss_alert_floor": epss_alert_floor,
+            "spikes": [],
+            "elevated": [],
+            "stable": [],
+        }
+
+    cve_ids = [r["cve_id"].upper() for r in records]
+
+    # Parallel-ish enrichment (sequential; each request is independent)
+    epss_map = _fetch_current_epss(cve_ids)
+    nvd_map = _fetch_nvd_cvss(cve_ids)
+    kev_set = _fetch_kev_set()
+
+    spikes: list[dict[str, Any]] = []
+    elevated: list[dict[str, Any]] = []
+    stable: list[dict[str, Any]] = []
+    updated_records: list[dict[str, Any]] = []
+
+    for r in records:
+        cid = r["cve_id"].upper()
+        new_epss = epss_map.get(cid, -1.0)
+        prev_epss: float | None = r.get("last_epss")
+        baseline_epss: float | None = r.get("baseline_epss")
+
+        # Update the record
+        r = dict(r)
+        r["last_checked"] = today
+        if new_epss >= 0:
+            r["last_epss"] = new_epss
+            if r.get("baseline_epss") is None:
+                r["baseline_epss"] = new_epss
+            baseline_epss = r["baseline_epss"]
+
+        updated_records.append(r)
+
+        nvd_info = nvd_map.get(cid, {"base_score": None, "severity": "UNKNOWN"})
+        in_kev = cid in kev_set
+
+        # Compute delta vs. last_epss
+        delta: float | None = None
+        if new_epss >= 0 and prev_epss is not None and prev_epss >= 0:
+            delta = new_epss - prev_epss
+
+        # Compute delta vs. baseline (for context)
+        baseline_delta: float | None = None
+        if new_epss >= 0 and baseline_epss is not None and baseline_epss >= 0:
+            baseline_delta = new_epss - baseline_epss
+
+        entry: dict[str, Any] = {
+            "cve_id": cid,
+            "current_epss": new_epss if new_epss >= 0 else None,
+            "prev_epss": prev_epss,
+            "baseline_epss": baseline_epss,
+            "delta": delta,
+            "baseline_delta": baseline_delta,
+            "trend": _trend_arrow(delta),
+            "cvss_base_score": nvd_info["base_score"],
+            "cvss_severity": nvd_info["severity"],
+            "in_kev": in_kev,
+            "added_at": r.get("added_at"),
+            "epss_unavailable": new_epss < 0,
+        }
+
+        # Classify into bucket
+        if delta is not None and delta >= spike_threshold:
+            spikes.append(entry)
+        elif new_epss >= epss_alert_floor:
+            elevated.append(entry)
+        else:
+            stable.append(entry)
+
+    _save_watchlist(path, updated_records)
+
+    # Sort spikes by delta descending, others by current_epss descending
+    spikes.sort(key=lambda e: e["delta"] or 0, reverse=True)
+    elevated.sort(key=lambda e: e["current_epss"] or 0, reverse=True)
+    stable.sort(key=lambda e: e["current_epss"] or 0, reverse=True)
+
+    payload: dict[str, Any] = {
+        "generated_at": generated_at,
+        "watchlist_size": len(records),
+        "spike_threshold": spike_threshold,
+        "epss_alert_floor": epss_alert_floor,
+        "spikes": spikes,
+        "elevated": elevated,
+        "stable": stable,
+    }
+    return updated_records, payload
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+def _fmt_epss(v: float | None) -> str:
+    return f"{v:.4f}" if v is not None else "N/A"
+
+
+def _fmt_delta(v: float | None) -> str:
+    if v is None:
+        return "N/A"
+    sign = "+" if v >= 0 else ""
+    return f"{sign}{v:.4f}"
+
+
+def _fmt_cvss(score: float | None, severity: str) -> str:
+    if score is None:
+        return "N/A"
+    return f"{score:.1f} ({severity})"
+
+
+def _render_entry_md(e: dict[str, Any]) -> str:
+    kev_badge = " 🔴 **KEV**" if e["in_kev"] else ""
+    epss_str = _fmt_epss(e["current_epss"])
+    delta_str = _fmt_delta(e["delta"])
+    baseline_delta_str = _fmt_delta(e["baseline_delta"])
+    cvss_str = _fmt_cvss(e["cvss_base_score"], e["cvss_severity"])
+    arrow = e["trend"]
+    unavail = " *(EPSS unavailable)*" if e["epss_unavailable"] else ""
+    lines = [
+        f"- **{e['cve_id']}**{kev_badge}{unavail}",
+        f"  - EPSS: `{epss_str}` {arrow}  (Δ last: `{delta_str}`, Δ baseline: `{baseline_delta_str}`)",
+        f"  - CVSS: `{cvss_str}`",
+        f"  - Added: {e['added_at'] or 'unknown'}",
+    ]
+    return "\n".join(lines)
+
+
+def _render_entry_text(e: dict[str, Any]) -> str:
+    kev_str = " [KEV]" if e["in_kev"] else ""
+    epss_str = _fmt_epss(e["current_epss"])
+    delta_str = _fmt_delta(e["delta"])
+    baseline_delta_str = _fmt_delta(e["baseline_delta"])
+    cvss_str = _fmt_cvss(e["cvss_base_score"], e["cvss_severity"])
+    arrow = e["trend"]
+    unavail = " (EPSS unavailable)" if e["epss_unavailable"] else ""
+    return (
+        f"  {e['cve_id']}{kev_str}{unavail}\n"
+        f"    EPSS: {epss_str} {arrow}  (delta-last: {delta_str}, delta-baseline: {baseline_delta_str})\n"
+        f"    CVSS: {cvss_str}  |  Added: {e['added_at'] or 'unknown'}"
+    )
+
+
+def _render_markdown(payload: dict[str, Any]) -> str:
+    today_str = payload["generated_at"][:10]
+    lines: list[str] = [
+        f"## EPSS Alert Digest — {today_str}",
+        "",
+        f"> Generated: {payload['generated_at']}  "
+        f"| Watchlist: {payload['watchlist_size']} CVE(s)  "
+        f"| Spike threshold: Δ≥{payload['spike_threshold']:.2f}  "
+        f"| Elevated floor: ≥{payload['epss_alert_floor']:.2f}",
+        "",
+    ]
+
+    spikes = payload["spikes"]
+    elevated = payload["elevated"]
+    stable = payload["stable"]
+
+    if spikes:
+        lines.append(f"### 🚨 EPSS Spikes ({len(spikes)})")
+        lines.append("")
+        for e in spikes:
+            lines.append(_render_entry_md(e))
+            lines.append("")
+    else:
+        lines.append("### 🚨 EPSS Spikes")
+        lines.append("")
+        lines.append("_No spikes detected this cycle._")
+        lines.append("")
+
+    if elevated:
+        lines.append(f"### ⚠️  Elevated EPSS ({len(elevated)})")
+        lines.append("")
+        for e in elevated:
+            lines.append(_render_entry_md(e))
+            lines.append("")
+    else:
+        lines.append("### ⚠️  Elevated EPSS")
+        lines.append("")
+        lines.append(f"_No CVEs with EPSS ≥ {payload['epss_alert_floor']:.2f} detected._")
+        lines.append("")
+
+    if stable:
+        lines.append(f"### ✅ Stable ({len(stable)})")
+        lines.append("")
+        for e in stable:
+            lines.append(_render_entry_md(e))
+            lines.append("")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def _render_text(payload: dict[str, Any]) -> str:
+    today_str = payload["generated_at"][:10]
+    lines: list[str] = [
+        f"EPSS Alert Digest — {today_str}",
+        f"Generated: {payload['generated_at']}",
+        f"Watchlist: {payload['watchlist_size']} CVE(s)",
+        f"Spike threshold: delta >= {payload['spike_threshold']:.2f}  |  Elevated floor: >= {payload['epss_alert_floor']:.2f}",
+        "",
+    ]
+
+    spikes = payload["spikes"]
+    elevated = payload["elevated"]
+    stable = payload["stable"]
+
+    lines.append(f"=== EPSS Spikes ({len(spikes)}) ===")
+    if spikes:
+        for e in spikes:
+            lines.append(_render_entry_text(e))
+            lines.append("")
+    else:
+        lines.append("  No spikes detected this cycle.")
+    lines.append("")
+
+    lines.append(f"=== Elevated EPSS ({len(elevated)}) ===")
+    if elevated:
+        for e in elevated:
+            lines.append(_render_entry_text(e))
+            lines.append("")
+    else:
+        lines.append(f"  No CVEs with EPSS >= {payload['epss_alert_floor']:.2f}.")
+    lines.append("")
+
+    lines.append(f"=== Stable ({len(stable)}) ===")
+    if stable:
+        for e in stable:
+            lines.append(_render_entry_text(e))
+            lines.append("")
+    else:
+        lines.append("  None.")
+
+    return "\n".join(lines).rstrip() + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Tool entry-point
+# ---------------------------------------------------------------------------
+
+
+def watch_alert(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Read the EPSS watchlist and render a Markdown alert digest."""
+    tool_use_id = tool["toolUseId"]
+    inp = tool["input"]
+
+    spike_threshold = float(inp.get("spike_threshold") or _DEFAULT_SPIKE_THRESHOLD)
+    epss_alert_floor = float(inp.get("epss_alert_floor") or _DEFAULT_EPSS_FLOOR)
+    output_format = (inp.get("output_format") or "markdown").lower().strip()
+    watchlist_path_override = inp.get("watchlist_path") or os.environ.get("MANUS_WATCHLIST_PATH")
+
+    if output_format not in {"markdown", "text", "json"}:
+        output_format = "markdown"
+
+    path = _resolve_path(watchlist_path_override)
+    records = _load_watchlist(path)
+
+    if not records:
+        empty_msg = "Watchlist is empty. Use `manus-agent watch add CVE-XXXX-YYYY` to start tracking CVEs."
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"text": empty_msg}],
+        }
+        log_tool_output_size("watch_alert", result)
+        return result
+
+    try:
+        updated_records, payload = _build_alert(records, path, spike_threshold, epss_alert_floor)
+    except Exception as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"watch_alert failed: {exc}"}],
+        }
+        log_tool_output_size("watch_alert", result)
+        return result
+
+    if output_format == "json":
+        rendered = json.dumps(payload, indent=2, ensure_ascii=False)
+    elif output_format == "text":
+        rendered = _render_text(payload)
+    else:
+        rendered = _render_markdown(payload)
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": rendered},
+            {"json": payload},
+        ],
+    }
+    log_tool_output_size("watch_alert", result)
+    return result

--- a/tests/test_watch_alert.py
+++ b/tests/test_watch_alert.py
@@ -1,0 +1,1124 @@
+"""
+Unit tests for watch_alert tool.
+
+All HTTP calls are mocked — no real network requests.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers & fixtures
+# ---------------------------------------------------------------------------
+
+_SAMPLE_RECORDS = [
+    {
+        "cve_id": "CVE-2024-3094",
+        "added_at": "2026-06-01",
+        "last_checked": "2026-06-30",
+        "last_epss": 0.70,
+        "baseline_epss": 0.60,
+    },
+    {
+        "cve_id": "CVE-2021-44228",
+        "added_at": "2026-06-01",
+        "last_checked": "2026-06-30",
+        "last_epss": 0.95,
+        "baseline_epss": 0.90,
+    },
+    {
+        "cve_id": "CVE-2023-12345",
+        "added_at": "2026-06-01",
+        "last_checked": "2026-06-30",
+        "last_epss": 0.05,
+        "baseline_epss": 0.05,
+    },
+]
+
+# New EPSS values: CVE-2024-3094 spikes (+0.20), Log4j stays high, the last stays low
+_MOCK_EPSS_RESPONSE = {
+    "data": [
+        {"cve": "CVE-2024-3094", "epss": "0.90", "percentile": "0.99"},
+        {"cve": "CVE-2021-44228", "epss": "0.97", "percentile": "0.999"},
+        {"cve": "CVE-2023-12345", "epss": "0.04", "percentile": "0.20"},
+    ]
+}
+
+_MOCK_NVD_RESPONSE_3094 = {
+    "vulnerabilities": [
+        {
+            "cve": {
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 10.0,
+                                "baseSeverity": "CRITICAL",
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
+_MOCK_NVD_RESPONSE_44228 = {
+    "vulnerabilities": [
+        {
+            "cve": {
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 10.0,
+                                "baseSeverity": "CRITICAL",
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
+_MOCK_NVD_RESPONSE_12345 = {
+    "vulnerabilities": [
+        {
+            "cve": {
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 5.3,
+                                "baseSeverity": "MEDIUM",
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    ]
+}
+
+_MOCK_KEV = {
+    "vulnerabilities": [
+        {"cveID": "CVE-2024-3094"},
+        {"cveID": "CVE-2021-44228"},
+    ]
+}
+
+
+def _write_watchlist(tmp_path: Path, records: list[dict[str, Any]]) -> Path:
+    p = tmp_path / "watchlist.jsonl"
+    p.write_text(
+        "\n".join(json.dumps(r) for r in records) + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _make_nvd_side_effect(mapping: dict[str, dict[str, Any]]):
+    """Return a side_effect fn that returns different NVD responses per CVE."""
+
+    def _side_effect(url: str, params=None, timeout=None):
+        cve_id = None
+        if params and hasattr(params, "items"):
+            cve_id = params.get("cveId", "").upper()
+        elif isinstance(params, list):
+            cve_id = dict(params).get("cveId", "").upper()
+        elif params is None and "cveId=" in url:
+            cve_id = url.split("cveId=")[1].split("&")[0].upper()
+        resp = MagicMock()
+        resp.raise_for_status = MagicMock()
+        resp.json.return_value = mapping.get(cve_id, {"vulnerabilities": []})
+        return resp
+
+    return _side_effect
+
+
+# ---------------------------------------------------------------------------
+# _fetch_current_epss
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCurrentEpss:
+    def test_returns_scores(self):
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _MOCK_EPSS_RESPONSE
+
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp):
+            scores = _fetch_current_epss(["CVE-2024-3094", "CVE-2021-44228"])
+
+        assert scores["CVE-2024-3094"] == pytest.approx(0.90)
+        assert scores["CVE-2021-44228"] == pytest.approx(0.97)
+
+    def test_empty_input(self):
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        scores = _fetch_current_epss([])
+        assert scores == {}
+
+    def test_network_error_returns_minus_one(self):
+        import requests
+
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        with patch(
+            "manus_agent.tools.watch_alert.requests.get",
+            side_effect=requests.exceptions.ConnectionError("timeout"),
+        ):
+            scores = _fetch_current_epss(["CVE-2024-3094"])
+
+        assert scores["CVE-2024-3094"] == -1.0
+
+    def test_chunks_large_input(self):
+        """Input > 50 CVEs should be batched into multiple requests."""
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        cve_ids = [f"CVE-2024-{i:04d}" for i in range(120)]
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp) as mock_get:
+            _fetch_current_epss(cve_ids)
+
+        # 120 CVEs / 50 per chunk = 3 calls
+        assert mock_get.call_count == 3
+
+    def test_malformed_epss_value(self):
+        """Malformed float should fall back to -1.0."""
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"cve": "CVE-2024-3094", "epss": "not-a-number"}]}
+
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp):
+            scores = _fetch_current_epss(["CVE-2024-3094"])
+
+        assert scores["CVE-2024-3094"] == -1.0
+
+    def test_missing_cve_in_response(self):
+        """CVE absent from API response should default to -1.0."""
+        from manus_agent.tools.watch_alert import _fetch_current_epss
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp):
+            scores = _fetch_current_epss(["CVE-9999-9999"])
+
+        assert scores["CVE-9999-9999"] == -1.0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_nvd_cvss
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdCvss:
+    def _make_mock_get(self, cve_responses: dict[str, Any]):
+        def _side_effect(url, params=None, timeout=None):
+            cve_id = (params or {}).get("cveId", "").upper()
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = cve_responses.get(cve_id, {"vulnerabilities": []})
+            return resp
+
+        return _side_effect
+
+    def test_returns_cvss_v31(self):
+        from manus_agent.tools.watch_alert import _fetch_nvd_cvss
+
+        side_effect = self._make_mock_get({"CVE-2024-3094": _MOCK_NVD_RESPONSE_3094})
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=side_effect):
+            result = _fetch_nvd_cvss(["CVE-2024-3094"])
+
+        assert result["CVE-2024-3094"]["base_score"] == pytest.approx(10.0)
+        assert result["CVE-2024-3094"]["severity"] == "CRITICAL"
+
+    def test_empty_vulnerabilities(self):
+        from manus_agent.tools.watch_alert import _fetch_nvd_cvss
+
+        side_effect = self._make_mock_get({"CVE-9999-0001": {"vulnerabilities": []}})
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=side_effect):
+            result = _fetch_nvd_cvss(["CVE-9999-0001"])
+
+        assert result["CVE-9999-0001"]["base_score"] is None
+        assert result["CVE-9999-0001"]["severity"] == "UNKNOWN"
+
+    def test_network_error(self):
+        import requests
+
+        from manus_agent.tools.watch_alert import _fetch_nvd_cvss
+
+        with patch(
+            "manus_agent.tools.watch_alert.requests.get",
+            side_effect=requests.exceptions.ConnectionError(),
+        ):
+            result = _fetch_nvd_cvss(["CVE-2024-3094"])
+
+        assert result["CVE-2024-3094"]["base_score"] is None
+
+    def test_falls_back_to_cvss_v2(self):
+        from manus_agent.tools.watch_alert import _fetch_nvd_cvss
+
+        v2_response = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {
+                            "cvssMetricV2": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 7.5,
+                                        "baseSeverity": "HIGH",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        side_effect = self._make_mock_get({"CVE-2021-1234": v2_response})
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=side_effect):
+            result = _fetch_nvd_cvss(["CVE-2021-1234"])
+
+        assert result["CVE-2021-1234"]["base_score"] == pytest.approx(7.5)
+
+    def test_multiple_cves(self):
+        from manus_agent.tools.watch_alert import _fetch_nvd_cvss
+
+        side_effect = self._make_mock_get(
+            {
+                "CVE-2024-3094": _MOCK_NVD_RESPONSE_3094,
+                "CVE-2021-44228": _MOCK_NVD_RESPONSE_44228,
+                "CVE-2023-12345": _MOCK_NVD_RESPONSE_12345,
+            }
+        )
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=side_effect):
+            result = _fetch_nvd_cvss(["CVE-2024-3094", "CVE-2021-44228", "CVE-2023-12345"])
+
+        assert result["CVE-2024-3094"]["severity"] == "CRITICAL"
+        assert result["CVE-2021-44228"]["severity"] == "CRITICAL"
+        assert result["CVE-2023-12345"]["severity"] == "MEDIUM"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_kev_set
+# ---------------------------------------------------------------------------
+
+
+class TestFetchKevSet:
+    def test_returns_set(self):
+        from manus_agent.tools.watch_alert import _fetch_kev_set
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = _MOCK_KEV
+
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp):
+            kev = _fetch_kev_set()
+
+        assert "CVE-2024-3094" in kev
+        assert "CVE-2021-44228" in kev
+        assert "CVE-2023-12345" not in kev
+
+    def test_network_error_returns_empty(self):
+        import requests
+
+        from manus_agent.tools.watch_alert import _fetch_kev_set
+
+        with patch(
+            "manus_agent.tools.watch_alert.requests.get",
+            side_effect=requests.exceptions.ConnectionError(),
+        ):
+            kev = _fetch_kev_set()
+
+        assert kev == set()
+
+    def test_uppercase_normalisation(self):
+        from manus_agent.tools.watch_alert import _fetch_kev_set
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [{"cveID": "cve-2024-3094"}]  # lowercase
+        }
+        with patch("manus_agent.tools.watch_alert.requests.get", return_value=mock_resp):
+            kev = _fetch_kev_set()
+
+        assert "CVE-2024-3094" in kev
+
+
+# ---------------------------------------------------------------------------
+# Watchlist I/O
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistIO:
+    def test_load_empty(self, tmp_path):
+        from manus_agent.tools.watch_alert import _load_watchlist
+
+        p = tmp_path / "watchlist.jsonl"
+        assert _load_watchlist(p) == []
+
+    def test_load_records(self, tmp_path):
+        from manus_agent.tools.watch_alert import _load_watchlist
+
+        p = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        loaded = _load_watchlist(p)
+        assert len(loaded) == 3
+        assert loaded[0]["cve_id"] == "CVE-2024-3094"
+
+    def test_load_skips_corrupt_lines(self, tmp_path):
+        from manus_agent.tools.watch_alert import _load_watchlist
+
+        p = tmp_path / "watchlist.jsonl"
+        p.write_text('{"cve_id": "CVE-2024-0001"}\nnot-json\n{"cve_id": "CVE-2024-0002"}\n')
+        records = _load_watchlist(p)
+        assert len(records) == 2
+
+    def test_save_roundtrip(self, tmp_path):
+        from manus_agent.tools.watch_alert import _load_watchlist, _save_watchlist
+
+        p = tmp_path / "watchlist.jsonl"
+        _save_watchlist(p, _SAMPLE_RECORDS)
+        loaded = _load_watchlist(p)
+        assert len(loaded) == len(_SAMPLE_RECORDS)
+        assert loaded[0]["cve_id"] == "CVE-2024-3094"
+
+    def test_resolve_path_creates_parents(self, tmp_path):
+        from manus_agent.tools.watch_alert import _resolve_path
+
+        override = str(tmp_path / "subdir" / "watchlist.jsonl")
+        path = _resolve_path(override)
+        assert path.parent.exists()
+
+
+# ---------------------------------------------------------------------------
+# _trend_arrow
+# ---------------------------------------------------------------------------
+
+
+class TestTrendArrow:
+    @pytest.mark.parametrize(
+        "delta, expected",
+        [
+            (0.10, "↑"),
+            (0.02, "↑"),
+            (-0.10, "↓"),
+            (-0.02, "↓"),
+            (0.01, "→"),
+            (-0.01, "→"),
+            (0.0, "→"),
+            (None, "→"),
+        ],
+    )
+    def test_trend_arrow(self, delta, expected):
+        from manus_agent.tools.watch_alert import _trend_arrow
+
+        assert _trend_arrow(delta) == expected
+
+
+# ---------------------------------------------------------------------------
+# _build_alert
+# ---------------------------------------------------------------------------
+
+
+class TestBuildAlert:
+    def _patch_all(self, tmp_path):
+        """Return a context-manager stack that mocks all HTTP calls."""
+        epss_resp = MagicMock()
+        epss_resp.raise_for_status = MagicMock()
+        epss_resp.json.return_value = _MOCK_EPSS_RESPONSE
+
+        kev_resp = MagicMock()
+        kev_resp.raise_for_status = MagicMock()
+        kev_resp.json.return_value = _MOCK_KEV
+
+        nvd_mapping = {
+            "CVE-2024-3094": _MOCK_NVD_RESPONSE_3094,
+            "CVE-2021-44228": _MOCK_NVD_RESPONSE_44228,
+            "CVE-2023-12345": _MOCK_NVD_RESPONSE_12345,
+        }
+
+        def _get_side_effect(url, params=None, timeout=None):
+            if "first.org" in url:
+                return epss_resp
+            if "cisa.gov" in url:
+                return kev_resp
+            if "nvd.nist.gov" in url:
+                cve_id = (params or {}).get("cveId", "").upper()
+                resp = MagicMock()
+                resp.raise_for_status = MagicMock()
+                resp.json.return_value = nvd_mapping.get(cve_id, {"vulnerabilities": []})
+                return resp
+            raise ValueError(f"Unexpected URL: {url}")
+
+        return patch("manus_agent.tools.watch_alert.requests.get", side_effect=_get_side_effect)
+
+    def test_spike_detected(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        # CVE-2024-3094 went 0.70 → 0.90 (delta +0.20 ≥ 0.10 threshold)
+        spike_ids = [e["cve_id"] for e in payload["spikes"]]
+        assert "CVE-2024-3094" in spike_ids
+
+    def test_elevated_detected(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        # CVE-2021-44228 went 0.95 → 0.97, delta = 0.02 (< spike threshold)
+        # but EPSS ≥ 0.30 → Elevated
+        elevated_ids = [e["cve_id"] for e in payload["elevated"]]
+        assert "CVE-2021-44228" in elevated_ids
+
+    def test_stable_detected(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        stable_ids = [e["cve_id"] for e in payload["stable"]]
+        assert "CVE-2023-12345" in stable_ids
+
+    def test_kev_flag_set(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        all_entries = payload["spikes"] + payload["elevated"] + payload["stable"]
+        kev_map = {e["cve_id"]: e["in_kev"] for e in all_entries}
+        assert kev_map["CVE-2024-3094"] is True
+        assert kev_map["CVE-2021-44228"] is True
+        assert kev_map["CVE-2023-12345"] is False
+
+    def test_watchlist_persisted(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert, _load_watchlist
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            _updated, _payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        # Reload the file — scores should be updated
+        reloaded = _load_watchlist(path)
+        by_id = {r["cve_id"]: r for r in reloaded}
+        assert by_id["CVE-2024-3094"]["last_epss"] == pytest.approx(0.90)
+        assert by_id["CVE-2021-44228"]["last_epss"] == pytest.approx(0.97)
+
+    def test_empty_watchlist(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = tmp_path / "watchlist.jsonl"
+        path.write_text("")
+
+        _updated, payload = _build_alert([], path, spike_threshold=0.10, epss_alert_floor=0.30)
+        assert payload["watchlist_size"] == 0
+        assert payload["spikes"] == []
+        assert payload["elevated"] == []
+        assert payload["stable"] == []
+
+    def test_epss_unavailable(self, tmp_path):
+        """When EPSS API fails, CVEs should not be classified as spikes."""
+        import requests as _requests
+
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        records = [_SAMPLE_RECORDS[0]]
+
+        def _fail_epss(url, params=None, timeout=None):
+            if "first.org" in url:
+                raise _requests.exceptions.ConnectionError("mocked failure")
+            resp = MagicMock()
+            resp.raise_for_status = MagicMock()
+            resp.json.return_value = {"vulnerabilities": [], "data": []}
+            return resp
+
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=_fail_epss):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        assert payload["spikes"] == []
+        all_entries = payload["spikes"] + payload["elevated"] + payload["stable"]
+        unavail = [e for e in all_entries if e["epss_unavailable"]]
+        assert len(unavail) == 1
+
+    def test_baseline_delta_computed(self, tmp_path):
+        from manus_agent.tools.watch_alert import _build_alert
+
+        path = _write_watchlist(tmp_path, _SAMPLE_RECORDS)
+        records = _SAMPLE_RECORDS[:]
+
+        with self._patch_all(tmp_path):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        # CVE-2024-3094 baseline=0.60, new=0.90 → baseline_delta ≈ 0.30
+        spike_entry = next(e for e in payload["spikes"] if e["cve_id"] == "CVE-2024-3094")
+        assert spike_entry["baseline_delta"] == pytest.approx(0.30, abs=1e-6)
+
+    def test_first_check_sets_baseline(self, tmp_path):
+        """When baseline_epss is None (first check), it should be set to current score."""
+        from manus_agent.tools.watch_alert import _build_alert
+
+        records_no_baseline = [
+            {
+                "cve_id": "CVE-2024-9999",
+                "added_at": "2026-07-01",
+                "last_checked": None,
+                "last_epss": None,
+                "baseline_epss": None,
+            }
+        ]
+        path = _write_watchlist(tmp_path, records_no_baseline)
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"cve": "CVE-2024-9999", "epss": "0.55"}]}
+
+        def _side(url, params=None, timeout=None):
+            if "first.org" in url:
+                return mock_resp
+            r = MagicMock()
+            r.raise_for_status = MagicMock()
+            r.json.return_value = {"vulnerabilities": [], "data": []}
+            return r
+
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=_side):
+            updated, _payload = _build_alert(records_no_baseline, path, spike_threshold=0.10, epss_alert_floor=0.30)
+
+        by_id = {r["cve_id"]: r for r in updated}
+        assert by_id["CVE-2024-9999"]["baseline_epss"] == pytest.approx(0.55)
+
+    def test_spikes_sorted_by_delta(self, tmp_path):
+        """Spikes list should be sorted delta-descending."""
+        from manus_agent.tools.watch_alert import _build_alert
+
+        # Two records that will both spike
+        records = [
+            {
+                "cve_id": "CVE-2024-0001",
+                "added_at": "2026-07-01",
+                "last_checked": "2026-07-01",
+                "last_epss": 0.10,
+                "baseline_epss": 0.10,
+            },
+            {
+                "cve_id": "CVE-2024-0002",
+                "added_at": "2026-07-01",
+                "last_checked": "2026-07-01",
+                "last_epss": 0.10,
+                "baseline_epss": 0.10,
+            },
+        ]
+        path = _write_watchlist(tmp_path, records)
+
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status = MagicMock()
+        # CVE-0001 gets a bigger spike (+0.50) than CVE-0002 (+0.20)
+        mock_resp.json.return_value = {
+            "data": [
+                {"cve": "CVE-2024-0001", "epss": "0.60"},
+                {"cve": "CVE-2024-0002", "epss": "0.30"},
+            ]
+        }
+
+        def _side(url, params=None, timeout=None):
+            if "first.org" in url:
+                return mock_resp
+            r = MagicMock()
+            r.raise_for_status = MagicMock()
+            r.json.return_value = {"vulnerabilities": [], "data": []}
+            return r
+
+        with patch("manus_agent.tools.watch_alert.requests.get", side_effect=_side):
+            _updated, payload = _build_alert(records, path, spike_threshold=0.10, epss_alert_floor=0.80)
+
+        spikes = payload["spikes"]
+        assert len(spikes) == 2
+        assert spikes[0]["cve_id"] == "CVE-2024-0001"  # bigger spike first
+        assert spikes[1]["cve_id"] == "CVE-2024-0002"
+
+
+# ---------------------------------------------------------------------------
+# Renderers
+# ---------------------------------------------------------------------------
+
+
+class TestRenderMarkdown:
+    def _make_payload(
+        self,
+        spikes=None,
+        elevated=None,
+        stable=None,
+    ) -> dict:
+        return {
+            "generated_at": "2026-07-01T12:00:00Z",
+            "watchlist_size": 3,
+            "spike_threshold": 0.10,
+            "epss_alert_floor": 0.30,
+            "spikes": spikes or [],
+            "elevated": elevated or [],
+            "stable": stable or [],
+        }
+
+    def _sample_entry(self, cve_id="CVE-2024-3094", in_kev=True, delta=0.20) -> dict:
+        return {
+            "cve_id": cve_id,
+            "current_epss": 0.90,
+            "prev_epss": 0.70,
+            "baseline_epss": 0.60,
+            "delta": delta,
+            "baseline_delta": 0.30,
+            "trend": "↑",
+            "cvss_base_score": 10.0,
+            "cvss_severity": "CRITICAL",
+            "in_kev": in_kev,
+            "added_at": "2026-06-01",
+            "epss_unavailable": False,
+        }
+
+    def test_contains_header(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        md = _render_markdown(self._make_payload())
+        assert "## EPSS Alert Digest" in md
+        assert "2026-07-01" in md
+
+    def test_spike_section_present(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        payload = self._make_payload(spikes=[self._sample_entry()])
+        md = _render_markdown(payload)
+        assert "🚨" in md
+        assert "CVE-2024-3094" in md
+
+    def test_kev_badge_shown(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        payload = self._make_payload(spikes=[self._sample_entry(in_kev=True)])
+        md = _render_markdown(payload)
+        assert "KEV" in md
+
+    def test_no_kev_no_badge(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        payload = self._make_payload(elevated=[self._sample_entry(in_kev=False, delta=0.01)])
+        md = _render_markdown(payload)
+        assert "KEV" not in md
+
+    def test_no_spikes_message(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        md = _render_markdown(self._make_payload())
+        assert "No spikes detected" in md
+
+    def test_elevated_section(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        payload = self._make_payload(elevated=[self._sample_entry(delta=0.01)])
+        md = _render_markdown(payload)
+        assert "⚠️" in md
+
+    def test_stable_section(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        payload = self._make_payload(stable=[self._sample_entry(delta=0.01)])
+        md = _render_markdown(payload)
+        assert "✅" in md
+
+    def test_epss_unavailable_note(self):
+        from manus_agent.tools.watch_alert import _render_markdown
+
+        entry = self._sample_entry()
+        entry["epss_unavailable"] = True
+        entry["current_epss"] = None
+        payload = self._make_payload(stable=[entry])
+        md = _render_markdown(payload)
+        assert "EPSS unavailable" in md
+
+
+class TestRenderText:
+    def _make_payload(self) -> dict:
+        return {
+            "generated_at": "2026-07-01T12:00:00Z",
+            "watchlist_size": 2,
+            "spike_threshold": 0.10,
+            "epss_alert_floor": 0.30,
+            "spikes": [
+                {
+                    "cve_id": "CVE-2024-3094",
+                    "current_epss": 0.90,
+                    "prev_epss": 0.70,
+                    "baseline_epss": 0.60,
+                    "delta": 0.20,
+                    "baseline_delta": 0.30,
+                    "trend": "↑",
+                    "cvss_base_score": 10.0,
+                    "cvss_severity": "CRITICAL",
+                    "in_kev": True,
+                    "added_at": "2026-06-01",
+                    "epss_unavailable": False,
+                }
+            ],
+            "elevated": [],
+            "stable": [],
+        }
+
+    def test_plain_text_output(self):
+        from manus_agent.tools.watch_alert import _render_text
+
+        text = _render_text(self._make_payload())
+        assert "CVE-2024-3094" in text
+        assert "[KEV]" in text
+        assert "0.9000" in text
+
+    def test_no_markdown_headings(self):
+        from manus_agent.tools.watch_alert import _render_text
+
+        text = _render_text(self._make_payload())
+        assert "##" not in text
+        assert "**" not in text
+
+
+# ---------------------------------------------------------------------------
+# watch_alert tool entry-point
+# ---------------------------------------------------------------------------
+
+
+class TestWatchAlertTool:
+    def _make_tool_use(self, **kwargs) -> dict:
+        return {"toolUseId": "test-use-id-001", "input": kwargs}
+
+    def _patch_build_alert(self, payload_override=None):
+        """Patch _build_alert to return a controllable payload."""
+        default_payload = {
+            "generated_at": "2026-07-01T12:00:00Z",
+            "watchlist_size": 1,
+            "spike_threshold": 0.10,
+            "epss_alert_floor": 0.30,
+            "spikes": [],
+            "elevated": [],
+            "stable": [],
+        }
+        payload = payload_override or default_payload
+
+        def _fake_build_alert(records, path, spike_threshold, epss_alert_floor):
+            return records, payload
+
+        return patch("manus_agent.tools.watch_alert._build_alert", side_effect=_fake_build_alert)
+
+    def test_empty_watchlist_returns_success(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = tmp_path / "wl.jsonl"
+        wl.write_text("")
+        tool = self._make_tool_use(watchlist_path=str(wl))
+        result = watch_alert(tool)
+        assert result["status"] == "success"
+        assert "empty" in result["content"][0]["text"].lower()
+
+    def test_markdown_output(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl), output_format="markdown")
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+        assert result["status"] == "success"
+        assert "## EPSS Alert Digest" in result["content"][0]["text"]
+
+    def test_text_output(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl), output_format="text")
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+        assert result["status"] == "success"
+        assert "##" not in result["content"][0]["text"]
+
+    def test_json_output(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl), output_format="json")
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+        assert result["status"] == "success"
+        parsed = json.loads(result["content"][0]["text"])
+        assert "generated_at" in parsed
+
+    def test_invalid_output_format_falls_back_to_markdown(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl), output_format="bogus")
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+        assert "## EPSS Alert Digest" in result["content"][0]["text"]
+
+    def test_build_alert_exception_returns_error(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl))
+
+        with patch(
+            "manus_agent.tools.watch_alert._build_alert",
+            side_effect=RuntimeError("mocked failure"),
+        ):
+            result = watch_alert(tool)
+
+        assert result["status"] == "error"
+        assert "mocked failure" in result["content"][0]["text"]
+
+    def test_json_content_block_present(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl))
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+        content_kinds = [list(c.keys())[0] for c in result["content"]]
+        assert "json" in content_kinds
+
+    def test_default_spike_threshold(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(watchlist_path=str(wl))
+
+        calls: list[dict] = []
+
+        def _capture(records, path, spike_threshold, epss_alert_floor):
+            calls.append({"spike_threshold": spike_threshold, "epss_alert_floor": epss_alert_floor})
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_capture):
+            watch_alert(tool)
+
+        assert calls[0]["spike_threshold"] == pytest.approx(0.10)
+        assert calls[0]["epss_alert_floor"] == pytest.approx(0.30)
+
+    def test_custom_thresholds(self, tmp_path):
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        tool = self._make_tool_use(
+            watchlist_path=str(wl),
+            spike_threshold=0.05,
+            epss_alert_floor=0.50,
+        )
+
+        calls: list[dict] = []
+
+        def _capture(records, path, spike_threshold, epss_alert_floor):
+            calls.append({"spike_threshold": spike_threshold, "epss_alert_floor": epss_alert_floor})
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_capture):
+            watch_alert(tool)
+
+        assert calls[0]["spike_threshold"] == pytest.approx(0.05)
+        assert calls[0]["epss_alert_floor"] == pytest.approx(0.50)
+
+    def test_manus_watchlist_path_env(self, tmp_path, monkeypatch):
+        """MANUS_WATCHLIST_PATH env var should be respected when no override in input."""
+        from manus_agent.tools.watch_alert import watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        monkeypatch.setenv("MANUS_WATCHLIST_PATH", str(wl))
+
+        tool = self._make_tool_use()  # no watchlist_path in input
+        with self._patch_build_alert():
+            result = watch_alert(tool)
+
+        assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# CLI: _run_watch_alert
+# ---------------------------------------------------------------------------
+
+
+class TestRunWatchAlertCli:
+    def test_empty_watchlist_exits_zero(self, tmp_path):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = tmp_path / "wl.jsonl"
+        wl.write_text("")
+        exit_code = _run_watch_alert(["--watchlist", str(wl)])
+        assert exit_code == 0
+
+    def test_markdown_output_to_stdout(self, tmp_path, capsys):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+
+        def _fake_build_alert(records, path, spike_threshold, epss_alert_floor):
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_fake_build_alert):
+            exit_code = _run_watch_alert(["--watchlist", str(wl), "--output", "markdown"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "## EPSS Alert Digest" in captured.out
+
+    def test_text_output_to_stdout(self, tmp_path, capsys):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+
+        def _fake_build_alert(records, path, spike_threshold, epss_alert_floor):
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_fake_build_alert):
+            exit_code = _run_watch_alert(["--watchlist", str(wl), "--output", "text"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "##" not in captured.out
+
+    def test_json_output_to_stdout(self, tmp_path, capsys):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+
+        def _fake_build_alert(records, path, spike_threshold, epss_alert_floor):
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_fake_build_alert):
+            exit_code = _run_watch_alert(["--watchlist", str(wl), "--output", "json"])
+
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert "generated_at" in parsed
+
+    def test_build_alert_exception_returns_one(self, tmp_path):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+
+        with patch(
+            "manus_agent.tools.watch_alert._build_alert",
+            side_effect=RuntimeError("cli failure"),
+        ):
+            exit_code = _run_watch_alert(["--watchlist", str(wl)])
+
+        assert exit_code == 1
+
+    def test_custom_threshold_arg(self, tmp_path):
+        from manus_agent.cli import _run_watch_alert
+
+        wl = _write_watchlist(tmp_path, [_SAMPLE_RECORDS[0]])
+        calls: list[dict] = []
+
+        def _capture(records, path, spike_threshold, epss_alert_floor):
+            calls.append({"spike_threshold": spike_threshold, "epss_alert_floor": epss_alert_floor})
+            return records, {
+                "generated_at": "2026-07-01T12:00:00Z",
+                "watchlist_size": 1,
+                "spike_threshold": spike_threshold,
+                "epss_alert_floor": epss_alert_floor,
+                "spikes": [],
+                "elevated": [],
+                "stable": [],
+            }
+
+        with patch("manus_agent.tools.watch_alert._build_alert", side_effect=_capture):
+            _run_watch_alert(["--watchlist", str(wl), "--threshold", "0.05", "--floor", "0.50"])
+
+        assert calls[0]["spike_threshold"] == pytest.approx(0.05)
+        assert calls[0]["epss_alert_floor"] == pytest.approx(0.50)
+
+    def test_main_dispatch_watch_alert(self, tmp_path, capsys):
+        """main() should route 'watch-alert' to _run_watch_alert."""
+        import sys
+
+        from manus_agent.cli import main
+
+        wl = tmp_path / "wl.jsonl"
+        wl.write_text("")
+
+        with patch.object(sys, "argv", ["manus-agent", "watch-alert", "--watchlist", str(wl)]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0


### PR DESCRIPTION
Adds watch_alert Strands tool + manus-agent watch-alert CLI. Reads ~/.manus-agent/watchlist.jsonl, fetches EPSS/CVSS/KEV enrichment, and renders a Markdown digest grouped into Spike/Elevated/Stable. 64 new tests (all mocked). 966 passing, 0 failures.