### PR TITLE
feat(tools): patch status checker — get_patch_status tool + manus-agent patch-status CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -120,6 +120,14 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
   A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
 
+**Step 6d: Patch Status**
+- Call `get_patch_status` with the CVE ID. Include in the report:
+  - Whether a patch is available for each affected package.
+  - The first patched version and its release date.
+  - The patch lag in days and its label (FAST ≤7 d, NORMAL 8–30 d, SLOW >30 d, MISSING).
+  Use this to answer: *"how quickly did the ecosystem respond?"*
+  A SLOW or MISSING patch lag (>30 days or no patch) should be flagged prominently as it extends the exposure window.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -214,6 +222,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_epss_trend import get_epss_trend
             from manus_agent.tools.get_github_advisory import get_github_advisory
             from manus_agent.tools.get_patch_diff import get_patch_diff
+            from manus_agent.tools.get_patch_status import get_patch_status
             from manus_agent.tools.get_poc_week import get_poc_week
             from manus_agent.tools.get_trickest_pocs import get_trickest_pocs
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
@@ -274,6 +283,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            get_patch_status,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "patch-status",
 }
 
 
@@ -2122,6 +2123,99 @@ def _cmd_history(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# patch-status subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_patch_status_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent patch-status",
+        description=(
+            "Report patch availability and patch-lag for a CVE.\n"
+            "Shows the first patched version per affected package, the date it was\n"
+            "released to the package registry (PyPI / npm / Maven), the lag in days\n"
+            "between CVE disclosure and patch release, and a lag label:\n"
+            "  FAST  = patch released within 7 days\n"
+            "  NORMAL = patch released within 30 days\n"
+            "  SLOW   = patch took more than 30 days\n"
+            "  MISSING = no patch available"
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "cve_id",
+        metavar="CVE_ID",
+        help="CVE identifier (e.g. CVE-2021-44228)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_patch_status(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_patch_status_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.get_patch_status import _run_patch_status as _core
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    cve_id = args.cve_id.strip()
+
+    try:
+        result = _core(cve_id)
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if "error" in result:
+        print(result["error"], file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    # Text output
+    packages = result.get("packages", [])
+    print(f"Patch Status — {result['cve_id']}")
+    print("=" * 50)
+    print(f"CVE Published : {result.get('cve_published', 'unknown')}")
+    print(f"Severity      : {result.get('severity', 'UNKNOWN')}")
+    print(f"Summary       : {result.get('summary', '')}")
+
+    if not packages:
+        return 0
+
+    print()
+    for pkg in packages:
+        lag_days = pkg.get("patch_lag_days")
+        lag_str = f"{lag_days} days" if lag_days is not None else "N/A"
+        label = pkg.get("patch_lag_label", "MISSING")
+        lag_display = f"{lag_str}  [{label}]"
+        print(f"  Package   : {pkg['name']} ({pkg.get('ecosystem', 'unknown')})")
+        print(f"  Patched   : {pkg.get('patched_version', 'unknown')}")
+        print(f"  Released  : {pkg.get('patch_release_date', 'unknown')}")
+        print(f"  Lag       : {lag_display}")
+        if pkg.get("advisory_id"):
+            print(f"  Advisory  : {pkg['advisory_id']}")
+        print()
+
+    # Determine exit code: non-zero if any MISSING
+    if any(p.get("patch_lag_label") == "MISSING" for p in packages):
+        return 2  # advisory exit: unpatched packages present
+    return 0
+
+
 def main() -> None:
     """Main CLI entry point."""
     argv = sys.argv[1:]
@@ -2188,6 +2282,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "patch-status":
+        idx = argv.index("patch-status")
+        sys.exit(_run_patch_status(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_patch_status.py
+++ b/src/manus_agent/tools/get_patch_status.py
@@ -1,0 +1,477 @@
+"""
+Tool: get_patch_status
+
+Given a CVE ID, reports the patch availability status for each affected package:
+  - First patched version (from GitHub Advisory DB or OSV.dev)
+  - CVE disclosure date (from NVD)
+  - Patch release date (from the package registry: PyPI, npm, or Maven Central)
+  - Patch lag in days (disclosure → patch release)
+  - Patch lag label: FAST (<7 d), NORMAL (7–30 d), SLOW (>30 d), MISSING (no patch)
+
+Data sources (all free, no API key required):
+  1. NVD CVE 2.0 API  — CVE disclosure date + CVSS severity
+  2. GitHub Advisory DB (api.github.com/advisories) — first_patched_version per package
+  3. OSV.dev API      — cross-ecosystem fix version (fallback / cross-check)
+  4. PyPI JSON API    — upload_time for the patched version
+  5. npm registry API — time map for the patched version
+  6. Maven Central    — release date approximation via search API
+
+CLI: ``manus-agent patch-status CVE-2021-44228``
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from strands import tool
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+__all__ = ["get_patch_status"]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d+$", re.IGNORECASE)
+_TIMEOUT = 20
+
+_NVD_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_GHSA_API_URL = "https://api.github.com/advisories"
+_OSV_QUERY_URL = "https://api.osv.dev/v1/query"
+_OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{}"
+_PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
+_NPM_PKG_URL = "https://registry.npmjs.org/{}"
+_MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+
+# Patch lag thresholds (days)
+_FAST_DAYS = 7
+_NORMAL_DAYS = 30
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get(url: str, params: dict | None = None, headers: dict | None = None) -> Any:
+    """GET with timeout; returns parsed JSON or raises."""
+    r = requests.get(url, params=params or {}, headers=headers or {}, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _post(url: str, payload: dict) -> Any:
+    """POST JSON with timeout; returns parsed JSON or raises."""
+    r = requests.post(url, json=payload, timeout=_TIMEOUT)
+    r.raise_for_status()
+    return r.json()
+
+
+def _github_headers() -> dict[str, str]:
+    token = os.environ.get("GITHUB_TOKEN", "")
+    h: dict[str, str] = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    if token:
+        h["Authorization"] = f"Bearer {token}"
+    return h
+
+
+def _parse_iso(dt_str: str | None) -> datetime | None:
+    """Parse an ISO-8601 timestamp into a timezone-aware datetime or None."""
+    if not dt_str:
+        return None
+    # Handle both 'Z' suffix and '+00:00'
+    dt_str = dt_str.rstrip("Z")
+    for fmt in ("%Y-%m-%dT%H:%M:%S.%f", "%Y-%m-%dT%H:%M:%S", "%Y-%m-%dT%H:%M"):
+        try:
+            return datetime.strptime(dt_str, fmt).replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+    return None
+
+
+def _patch_lag_label(days: int | None) -> str:
+    """Convert days-to-patch into a human-readable label."""
+    if days is None:
+        return "MISSING"
+    if days < 0:
+        # Patch released before disclosure (coordinated disclosure)
+        return "FAST"
+    if days <= _FAST_DAYS:
+        return "FAST"
+    if days <= _NORMAL_DAYS:
+        return "NORMAL"
+    return "SLOW"
+
+
+# ---------------------------------------------------------------------------
+# Data fetchers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_cve(cve_id: str) -> dict[str, Any]:
+    """Return NVD CVE record or empty dict."""
+    try:
+        data = _get(_NVD_URL, params={"cveId": cve_id.upper()})
+        vulns = data.get("vulnerabilities", [])
+        if vulns:
+            return vulns[0].get("cve", {})
+    except Exception as exc:
+        logger.debug("NVD fetch failed for %s: %s", cve_id, exc)
+    return {}
+
+
+def _fetch_ghsa_vulns(cve_id: str) -> list[dict[str, Any]]:
+    """
+    Query GitHub Advisory DB for the CVE.
+    Returns list of vulnerability records: {package, ecosystem, patched_version, advisory_id}.
+    """
+    results: list[dict[str, Any]] = []
+    try:
+        advisories = _get(_GHSA_API_URL, params={"cve_id": cve_id.upper(), "per_page": 10}, headers=_github_headers())
+        if not isinstance(advisories, list):
+            return results
+        for adv in advisories:
+            adv_id = adv.get("ghsa_id", "")
+            for vuln in adv.get("vulnerabilities", []):
+                pkg = vuln.get("package", {})
+                patched = vuln.get("first_patched_version")
+                if pkg.get("name"):
+                    results.append(
+                        {
+                            "advisory_id": adv_id,
+                            "name": pkg["name"],
+                            "ecosystem": (pkg.get("ecosystem") or "").lower(),
+                            "patched_version": patched,
+                            "vulnerable_range": vuln.get("vulnerable_version_range", ""),
+                        }
+                    )
+    except Exception as exc:
+        logger.debug("GHSA fetch failed for %s: %s", cve_id, exc)
+    return results
+
+
+def _fetch_osv_vulns(cve_id: str) -> list[dict[str, Any]]:
+    """
+    Query OSV.dev for the CVE.
+    Returns list of {name, ecosystem, patched_version} dicts.
+    """
+    results: list[dict[str, Any]] = []
+    try:
+        data = _post(_OSV_QUERY_URL, {"id": cve_id.upper()})
+        for vuln in data.get("vulns", []):
+            vid = vuln.get("id", "")
+            try:
+                full = _get(_OSV_VULN_URL.format(vid))
+            except Exception:
+                continue
+            for affected in full.get("affected", []):
+                pkg = affected.get("package", {})
+                name = pkg.get("name", "")
+                ecosystem = (pkg.get("ecosystem") or "").lower()
+                if not name:
+                    continue
+                # Extract first "fixed" event from ranges
+                patched_ver: str | None = None
+                for rng in affected.get("ranges", []):
+                    for evt in rng.get("events", []):
+                        if "fixed" in evt:
+                            patched_ver = evt["fixed"]
+                            break
+                    if patched_ver:
+                        break
+                results.append(
+                    {"advisory_id": vid, "name": name, "ecosystem": ecosystem, "patched_version": patched_ver}
+                )
+    except Exception as exc:
+        logger.debug("OSV fetch failed for %s: %s", cve_id, exc)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Registry: patch release date lookup
+# ---------------------------------------------------------------------------
+
+
+def _pypi_release_date(package: str, version: str) -> datetime | None:
+    """Return the upload_time of *version* on PyPI."""
+    try:
+        data = _get(_PYPI_JSON_URL.format(package))
+        files = data.get("releases", {}).get(version, [])
+        if files:
+            return _parse_iso(files[0].get("upload_time"))
+    except Exception as exc:
+        logger.debug("PyPI release lookup failed %s@%s: %s", package, version, exc)
+    return None
+
+
+def _npm_release_date(package: str, version: str) -> datetime | None:
+    """Return the publish time of *version* on npm."""
+    try:
+        data = _get(_NPM_PKG_URL.format(package))
+        time_map = data.get("time", {})
+        ts = time_map.get(version)
+        return _parse_iso(ts) if ts else None
+    except Exception as exc:
+        logger.debug("npm release lookup failed %s@%s: %s", package, version, exc)
+    return None
+
+
+def _maven_release_date(package: str, version: str) -> datetime | None:
+    """
+    Approximate Maven release date via Maven Central search.
+    Maven Central doesn't expose upload timestamps directly, so we return None
+    and let the caller fall back to the advisory published date.
+    """
+    # Maven Central Solr search returns `timestamp` (ms epoch) for the *latest*
+    # version only; for a specific version we'd need the API to be queried differently.
+    # group:artifact format expected in package.
+    try:
+        if ":" in package:
+            group_id, artifact_id = package.split(":", 1)
+        else:
+            artifact_id = package
+            group_id = ""
+        query = f"g:{group_id} AND a:{artifact_id} AND v:{version}" if group_id else f"a:{artifact_id} AND v:{version}"
+        data = _get(_MAVEN_SEARCH_URL, params={"q": query, "rows": 1, "wt": "json"})
+        docs = data.get("response", {}).get("docs", [])
+        if docs:
+            ts_ms = docs[0].get("timestamp")
+            if ts_ms:
+                return datetime.fromtimestamp(ts_ms / 1000, tz=timezone.utc)
+    except Exception as exc:
+        logger.debug("Maven release lookup failed %s@%s: %s", package, version, exc)
+    return None
+
+
+def _registry_release_date(name: str, ecosystem: str, version: str) -> datetime | None:
+    """Dispatch to the correct registry by ecosystem."""
+    eco = ecosystem.lower()
+    if eco == "pypi":
+        return _pypi_release_date(name, version)
+    if eco in ("npm", "node", "nodejs"):
+        return _npm_release_date(name, version)
+    if eco in ("maven", "java"):
+        return _maven_release_date(name, version)
+    # For other ecosystems (Go, Rust, Ruby, etc.) we don't have a simple
+    # release-date API; fall back to None.
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Merging / deduplication
+# ---------------------------------------------------------------------------
+
+
+def _merge_vulns(ghsa: list[dict], osv: list[dict]) -> list[dict]:
+    """
+    Merge GHSA and OSV records, preferring GHSA (it has structured patched_version).
+    Deduplicate by (name.lower(), ecosystem).
+    """
+    seen: dict[tuple[str, str], dict] = {}
+    for rec in ghsa + osv:
+        key = (rec["name"].lower(), rec.get("ecosystem", "").lower())
+        if key not in seen:
+            seen[key] = rec
+        else:
+            # Upgrade if the existing record has no patched_version
+            if not seen[key].get("patched_version") and rec.get("patched_version"):
+                seen[key] = rec
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Core logic
+# ---------------------------------------------------------------------------
+
+
+def _run_patch_status(cve_id: str) -> dict[str, Any]:
+    """
+    Compute patch status for *cve_id*.
+
+    Returns a dict with keys:
+      cve_id, cve_published, severity, packages, summary
+    where each package entry has:
+      name, ecosystem, patched_version, patch_release_date,
+      patch_lag_days, patch_lag_label, advisory_id
+    """
+    cve_id = cve_id.strip().upper()
+    if not _CVE_RE.match(cve_id):
+        return {"error": f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN"}
+
+    # 1. CVE disclosure date from NVD
+    nvd = _fetch_nvd_cve(cve_id)
+    cve_published_str = nvd.get("published")
+    cve_published = _parse_iso(cve_published_str)
+    severity = "UNKNOWN"
+    if nvd.get("metrics"):
+        for metric_key in ("cvssMetricV31", "cvssMetricV30", "cvssMetricV2"):
+            metrics = nvd["metrics"].get(metric_key, [])
+            if metrics:
+                severity = metrics[0].get("cvssData", {}).get("baseSeverity") or metrics[0].get(
+                    "baseSeverity", "UNKNOWN"
+                )
+                break
+
+    # 2. Affected packages + first patched version
+    ghsa_vulns = _fetch_ghsa_vulns(cve_id)
+    osv_vulns = _fetch_osv_vulns(cve_id)
+    merged = _merge_vulns(ghsa_vulns, osv_vulns)
+
+    if not merged:
+        return {
+            "cve_id": cve_id,
+            "cve_published": cve_published_str or "unknown",
+            "severity": severity,
+            "packages": [],
+            "summary": (
+                f"No affected package records found for {cve_id} in the GitHub Advisory DB or OSV.dev. "
+                "The CVE may be an infrastructure/OS issue (no named package), too recent to be indexed, "
+                "or may use CPE-style records only."
+            ),
+        }
+
+    # 3. For each package: look up the patch release date
+    package_results: list[dict[str, Any]] = []
+    for rec in merged:
+        name = rec["name"]
+        ecosystem = rec.get("ecosystem", "unknown")
+        patched_ver = rec.get("patched_version")
+        advisory_id = rec.get("advisory_id", "")
+
+        patch_release_date: datetime | None = None
+        patch_release_str: str | None = None
+        patch_lag_days: int | None = None
+
+        if patched_ver:
+            patch_release_date = _registry_release_date(name, ecosystem, patched_ver)
+            if patch_release_date:
+                patch_release_str = patch_release_date.strftime("%Y-%m-%d")
+                if cve_published:
+                    delta = patch_release_date - cve_published
+                    patch_lag_days = delta.days
+
+        lag_label = _patch_lag_label(patch_lag_days)
+
+        package_results.append(
+            {
+                "name": name,
+                "ecosystem": ecosystem,
+                "patched_version": patched_ver or "unknown",
+                "patch_release_date": patch_release_str or "unknown",
+                "patch_lag_days": patch_lag_days,
+                "patch_lag_label": lag_label,
+                "advisory_id": advisory_id,
+            }
+        )
+
+    # 4. Build summary
+    patched_count = sum(1 for p in package_results if p["patched_version"] != "unknown")
+    missing_count = len(package_results) - patched_count
+    labels = [p["patch_lag_label"] for p in package_results if p["patch_lag_label"] != "MISSING"]
+    dominant_label = max(set(labels), key=labels.count) if labels else "MISSING"
+
+    summary_parts = [f"{cve_id} affects {len(package_results)} package(s)."]
+    if patched_count:
+        summary_parts.append(f"{patched_count} patched.")
+    if missing_count:
+        summary_parts.append(f"{missing_count} unpatched (no fix version available).")
+    summary_parts.append(f"Overall patch lag: {dominant_label}.")
+
+    return {
+        "cve_id": cve_id,
+        "cve_published": cve_published_str or "unknown",
+        "severity": severity,
+        "packages": package_results,
+        "summary": " ".join(summary_parts),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool
+# ---------------------------------------------------------------------------
+
+_TOOL_SPEC = {
+    "name": "get_patch_status",
+    "description": (
+        "Reports patch availability and patch-lag for a CVE: first patched version "
+        "per affected package (from GitHub Advisory DB and OSV.dev), the date the "
+        "patched version was released to the package registry (PyPI, npm, Maven), "
+        "the number of days between CVE disclosure and patch release, and a "
+        "patch_lag_label — FAST (≤7 days), NORMAL (8–30 days), SLOW (>30 days), "
+        "or MISSING (no patch available). Use this after get_nvd_data to understand "
+        "how quickly the affected ecosystem responded to the vulnerability."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier to check (e.g. CVE-2021-44228).",
+                }
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+@tool
+def get_patch_status(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Report patch availability, release date, and patch-lag label for a CVE."""
+    params = tool.get("input", {})
+    cve_id = params.get("cve_id", "").strip()
+
+    if not cve_id:
+        return {
+            "toolUseId": tool["toolUseId"],
+            "status": "error",
+            "content": [{"text": "cve_id is required."}],
+        }
+
+    result = _run_patch_status(cve_id)
+
+    if "error" in result:
+        return {
+            "toolUseId": tool["toolUseId"],
+            "status": "error",
+            "content": [{"text": result["error"]}],
+        }
+
+    # Format text output
+    lines: list[str] = [
+        f"Patch Status — {result['cve_id']}",
+        "=" * 50,
+        f"CVE Published : {result['cve_published']}",
+        f"Severity      : {result['severity']}",
+        f"Summary       : {result['summary']}",
+        "",
+    ]
+
+    for pkg in result["packages"]:
+        lag_str = f"{pkg['patch_lag_days']} days" if pkg["patch_lag_days"] is not None else "N/A"
+        lines += [
+            f"  Package   : {pkg['name']} ({pkg['ecosystem']})",
+            f"  Patched   : {pkg['patched_version']}",
+            f"  Released  : {pkg['patch_release_date']}",
+            f"  Lag       : {lag_str}  [{pkg['patch_lag_label']}]",
+            f"  Advisory  : {pkg['advisory_id']}",
+            "",
+        ]
+
+    text_output = "\n".join(lines)
+    log_tool_output_size("get_patch_status", text_output)
+
+    return {
+        "toolUseId": tool["toolUseId"],
+        "status": "success",
+        "content": [{"text": text_output}],
+    }

--- a/tests/test_patch_status.py
+++ b/tests/test_patch_status.py
@@ -1,0 +1,1067 @@
+"""
+Tests for get_patch_status tool.
+
+All HTTP calls are mocked; no real network requests.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CVE_LOG4SHELL = "CVE-2021-44228"
+
+# Realistic NVD response fragment for Log4Shell
+_NVD_RESPONSE = {
+    "vulnerabilities": [
+        {
+            "cve": {
+                "id": CVE_LOG4SHELL,
+                "published": "2021-12-10T10:15:09.143",
+                "lastModified": "2024-01-15T00:00:00.000",
+                "metrics": {
+                    "cvssMetricV31": [
+                        {
+                            "cvssData": {
+                                "baseScore": 10.0,
+                                "baseSeverity": "CRITICAL",
+                            }
+                        }
+                    ]
+                },
+            }
+        }
+    ]
+}
+
+# Realistic GHSA response for Log4Shell (GitHub Advisory API)
+_GHSA_RESPONSE = [
+    {
+        "ghsa_id": "GHSA-jfh8-c2jp-5v3q",
+        "published_at": "2021-12-10T00:40:56Z",
+        "vulnerabilities": [
+            {
+                "package": {"ecosystem": "maven", "name": "org.apache.logging.log4j:log4j-core"},
+                "vulnerable_version_range": ">= 2.13.0, < 2.15.0",
+                "first_patched_version": "2.15.0",
+            }
+        ],
+    }
+]
+
+# OSV response (alias for the same CVE)
+_OSV_QUERY_RESPONSE = {"vulns": [{"id": "GHSA-jfh8-c2jp-5v3q"}]}
+
+_OSV_VULN_FULL = {
+    "id": "GHSA-jfh8-c2jp-5v3q",
+    "published": "2021-12-10T00:40:56Z",
+    "aliases": [CVE_LOG4SHELL],
+    "affected": [
+        {
+            "package": {
+                "name": "org.apache.logging.log4j:log4j-core",
+                "ecosystem": "Maven",
+            },
+            "ranges": [
+                {
+                    "type": "ECOSYSTEM",
+                    "events": [
+                        {"introduced": "2.13.0"},
+                        {"fixed": "2.15.0"},
+                    ],
+                }
+            ],
+        }
+    ],
+}
+
+# Maven Central search response
+_MAVEN_SEARCH_RESPONSE = {
+    "response": {
+        "docs": [
+            {
+                "id": "org.apache.logging.log4j:log4j-core:2.15.0",
+                "timestamp": 1639167600000,  # ~2021-12-10T21:00:00Z
+            }
+        ]
+    }
+}
+
+# PyPI JSON response (requests package)
+_PYPI_REQUESTS_RESPONSE = {
+    "info": {"name": "requests", "version": "2.32.4"},
+    "releases": {
+        "2.32.4": [
+            {
+                "upload_time": "2024-06-09T16:43:05",
+                "filename": "requests-2.32.4-py3-none-any.whl",
+            }
+        ]
+    },
+}
+
+# npm registry response (lodash)
+_NPM_LODASH_RESPONSE = {
+    "name": "lodash",
+    "time": {
+        "4.17.21": "2021-02-20T15:42:16.891Z",
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: helpers
+# ---------------------------------------------------------------------------
+
+
+class TestPatchLagLabel:
+    """Tests for _patch_lag_label helper."""
+
+    def test_fast_zero(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(0) == "FAST"
+
+    def test_fast_boundary(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(7) == "FAST"
+
+    def test_normal_eight_days(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(8) == "NORMAL"
+
+    def test_normal_thirty_days(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(30) == "NORMAL"
+
+    def test_slow(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(31) == "SLOW"
+
+    def test_very_slow(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(365) == "SLOW"
+
+    def test_none_returns_missing(self) -> None:
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(None) == "MISSING"
+
+    def test_negative_coordinated_disclosure(self) -> None:
+        # Patch released before public disclosure
+        from manus_agent.tools.get_patch_status import _patch_lag_label
+
+        assert _patch_lag_label(-3) == "FAST"
+
+
+class TestParseIso:
+    """Tests for _parse_iso helper."""
+
+    def test_with_milliseconds(self) -> None:
+        from manus_agent.tools.get_patch_status import _parse_iso
+
+        dt = _parse_iso("2021-12-10T10:15:09.143")
+        assert dt is not None
+        assert dt.year == 2021
+        assert dt.month == 12
+        assert dt.day == 10
+        assert dt.tzinfo == timezone.utc
+
+    def test_with_z_suffix(self) -> None:
+        from manus_agent.tools.get_patch_status import _parse_iso
+
+        dt = _parse_iso("2021-12-10T00:40:56Z")
+        assert dt is not None
+        assert dt.year == 2021
+
+    def test_without_seconds(self) -> None:
+        from manus_agent.tools.get_patch_status import _parse_iso
+
+        dt = _parse_iso("2021-12-10T10:15")
+        assert dt is not None
+
+    def test_none_input(self) -> None:
+        from manus_agent.tools.get_patch_status import _parse_iso
+
+        assert _parse_iso(None) is None
+
+    def test_empty_string(self) -> None:
+        from manus_agent.tools.get_patch_status import _parse_iso
+
+        assert _parse_iso("") is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: NVD fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdCve:
+    """Tests for _fetch_nvd_cve."""
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_returns_cve_record(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _NVD_RESPONSE
+        from manus_agent.tools.get_patch_status import _fetch_nvd_cve
+
+        result = _fetch_nvd_cve(CVE_LOG4SHELL)
+        assert result["id"] == CVE_LOG4SHELL
+        assert result["published"] == "2021-12-10T10:15:09.143"
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_empty_vulnerabilities(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = {"vulnerabilities": []}
+        from manus_agent.tools.get_patch_status import _fetch_nvd_cve
+
+        result = _fetch_nvd_cve(CVE_LOG4SHELL)
+        assert result == {}
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_network_error_returns_empty(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("network error")
+        from manus_agent.tools.get_patch_status import _fetch_nvd_cve
+
+        result = _fetch_nvd_cve(CVE_LOG4SHELL)
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: GHSA fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGhsaVulns:
+    """Tests for _fetch_ghsa_vulns."""
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_returns_vuln_records(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _GHSA_RESPONSE
+        from manus_agent.tools.get_patch_status import _fetch_ghsa_vulns
+
+        vulns = _fetch_ghsa_vulns(CVE_LOG4SHELL)
+        assert len(vulns) == 1
+        assert vulns[0]["name"] == "org.apache.logging.log4j:log4j-core"
+        assert vulns[0]["patched_version"] == "2.15.0"
+        assert vulns[0]["ecosystem"] == "maven"
+        assert vulns[0]["advisory_id"] == "GHSA-jfh8-c2jp-5v3q"
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_multiple_packages(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = [
+            {
+                "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+                "vulnerabilities": [
+                    {
+                        "package": {"ecosystem": "PyPI", "name": "requests"},
+                        "vulnerable_version_range": "< 2.32.0",
+                        "first_patched_version": "2.32.0",
+                    },
+                    {
+                        "package": {"ecosystem": "npm", "name": "axios"},
+                        "vulnerable_version_range": "< 1.7.0",
+                        "first_patched_version": "1.7.0",
+                    },
+                ],
+            }
+        ]
+        from manus_agent.tools.get_patch_status import _fetch_ghsa_vulns
+
+        vulns = _fetch_ghsa_vulns("CVE-2024-12345")
+        assert len(vulns) == 2
+        names = {v["name"] for v in vulns}
+        assert "requests" in names
+        assert "axios" in names
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_no_patched_version(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = [
+            {
+                "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+                "vulnerabilities": [
+                    {
+                        "package": {"ecosystem": "PyPI", "name": "example-pkg"},
+                        "vulnerable_version_range": ">= 1.0.0",
+                        "first_patched_version": None,
+                    }
+                ],
+            }
+        ]
+        from manus_agent.tools.get_patch_status import _fetch_ghsa_vulns
+
+        vulns = _fetch_ghsa_vulns("CVE-2024-99999")
+        assert len(vulns) == 1
+        assert vulns[0]["patched_version"] is None
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_non_list_response_returns_empty(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = {"message": "Not found"}
+        from manus_agent.tools.get_patch_status import _fetch_ghsa_vulns
+
+        vulns = _fetch_ghsa_vulns("CVE-2024-00001")
+        assert vulns == []
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_network_error_returns_empty(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("timeout")
+        from manus_agent.tools.get_patch_status import _fetch_ghsa_vulns
+
+        vulns = _fetch_ghsa_vulns(CVE_LOG4SHELL)
+        assert vulns == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: OSV fetch
+# ---------------------------------------------------------------------------
+
+
+class TestFetchOsvVulns:
+    """Tests for _fetch_osv_vulns."""
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    @patch("manus_agent.tools.get_patch_status._post")
+    def test_returns_fixed_version(self, mock_post: MagicMock, mock_get: MagicMock) -> None:
+        mock_post.return_value = _OSV_QUERY_RESPONSE
+        mock_get.return_value = _OSV_VULN_FULL
+        from manus_agent.tools.get_patch_status import _fetch_osv_vulns
+
+        vulns = _fetch_osv_vulns(CVE_LOG4SHELL)
+        assert len(vulns) == 1
+        assert vulns[0]["patched_version"] == "2.15.0"
+        assert vulns[0]["ecosystem"] == "maven"
+
+    @patch("manus_agent.tools.get_patch_status._post")
+    def test_no_vulns_returns_empty(self, mock_post: MagicMock) -> None:
+        mock_post.return_value = {"vulns": []}
+        from manus_agent.tools.get_patch_status import _fetch_osv_vulns
+
+        vulns = _fetch_osv_vulns("CVE-2099-99999")
+        assert vulns == []
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    @patch("manus_agent.tools.get_patch_status._post")
+    def test_missing_fixed_event(self, mock_post: MagicMock, mock_get: MagicMock) -> None:
+        mock_post.return_value = {"vulns": [{"id": "OSV-2021-1"}]}
+        mock_get.return_value = {
+            "id": "OSV-2021-1",
+            "affected": [
+                {
+                    "package": {"name": "some-pkg", "ecosystem": "PyPI"},
+                    "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "1.0"}]}],
+                }
+            ],
+        }
+        from manus_agent.tools.get_patch_status import _fetch_osv_vulns
+
+        vulns = _fetch_osv_vulns("CVE-2021-99999")
+        assert len(vulns) == 1
+        assert vulns[0]["patched_version"] is None
+
+    @patch("manus_agent.tools.get_patch_status._post")
+    def test_network_error_returns_empty(self, mock_post: MagicMock) -> None:
+        mock_post.side_effect = Exception("connection refused")
+        from manus_agent.tools.get_patch_status import _fetch_osv_vulns
+
+        vulns = _fetch_osv_vulns(CVE_LOG4SHELL)
+        assert vulns == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: registry date lookups
+# ---------------------------------------------------------------------------
+
+
+class TestPypiReleaseDate:
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_known_version(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _PYPI_REQUESTS_RESPONSE
+        from manus_agent.tools.get_patch_status import _pypi_release_date
+
+        dt = _pypi_release_date("requests", "2.32.4")
+        assert dt is not None
+        assert dt.year == 2024
+        assert dt.month == 6
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_unknown_version_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _PYPI_REQUESTS_RESPONSE
+        from manus_agent.tools.get_patch_status import _pypi_release_date
+
+        dt = _pypi_release_date("requests", "99.99.99")
+        assert dt is None
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_network_error_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("404")
+        from manus_agent.tools.get_patch_status import _pypi_release_date
+
+        dt = _pypi_release_date("nonexistent-pkg", "1.0.0")
+        assert dt is None
+
+
+class TestNpmReleaseDate:
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_known_version(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _NPM_LODASH_RESPONSE
+        from manus_agent.tools.get_patch_status import _npm_release_date
+
+        dt = _npm_release_date("lodash", "4.17.21")
+        assert dt is not None
+        assert dt.year == 2021
+        assert dt.month == 2
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_unknown_version_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _NPM_LODASH_RESPONSE
+        from manus_agent.tools.get_patch_status import _npm_release_date
+
+        dt = _npm_release_date("lodash", "99.99.99")
+        assert dt is None
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_network_error_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("timeout")
+        from manus_agent.tools.get_patch_status import _npm_release_date
+
+        dt = _npm_release_date("nonexistent", "1.0.0")
+        assert dt is None
+
+
+class TestMavenReleaseDate:
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_known_artifact(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _MAVEN_SEARCH_RESPONSE
+        from manus_agent.tools.get_patch_status import _maven_release_date
+
+        dt = _maven_release_date("org.apache.logging.log4j:log4j-core", "2.15.0")
+        assert dt is not None
+        # Timestamp 1639167600000 ms ≈ 2021-12-10
+        assert dt.year == 2021
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_no_docs_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = {"response": {"docs": []}}
+        from manus_agent.tools.get_patch_status import _maven_release_date
+
+        dt = _maven_release_date("org.example:some-lib", "1.0.0")
+        assert dt is None
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_network_error_returns_none(self, mock_get: MagicMock) -> None:
+        mock_get.side_effect = Exception("503")
+        from manus_agent.tools.get_patch_status import _maven_release_date
+
+        dt = _maven_release_date("org.example:lib", "1.0.0")
+        assert dt is None
+
+    @patch("manus_agent.tools.get_patch_status._get")
+    def test_artifact_without_group(self, mock_get: MagicMock) -> None:
+        mock_get.return_value = _MAVEN_SEARCH_RESPONSE
+        from manus_agent.tools.get_patch_status import _maven_release_date
+
+        # No ":" in name — should still call through without crashing
+        dt = _maven_release_date("log4j-core", "2.15.0")
+        assert dt is not None
+
+
+class TestRegistryReleaseDate:
+    """Tests for the dispatcher _registry_release_date."""
+
+    @patch("manus_agent.tools.get_patch_status._pypi_release_date")
+    def test_pypi_dispatch(self, mock_pypi: MagicMock) -> None:
+        mock_pypi.return_value = datetime(2024, 6, 9, tzinfo=timezone.utc)
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        dt = _registry_release_date("requests", "pypi", "2.32.4")
+        mock_pypi.assert_called_once_with("requests", "2.32.4")
+        assert dt is not None
+
+    @patch("manus_agent.tools.get_patch_status._npm_release_date")
+    def test_npm_dispatch(self, mock_npm: MagicMock) -> None:
+        mock_npm.return_value = datetime(2021, 2, 20, tzinfo=timezone.utc)
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        dt = _registry_release_date("lodash", "npm", "4.17.21")
+        mock_npm.assert_called_once_with("lodash", "4.17.21")
+        assert dt is not None
+
+    @patch("manus_agent.tools.get_patch_status._npm_release_date")
+    def test_nodejs_alias_dispatch(self, mock_npm: MagicMock) -> None:
+        mock_npm.return_value = None
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        _registry_release_date("express", "node", "4.18.0")
+        mock_npm.assert_called_once()
+
+    @patch("manus_agent.tools.get_patch_status._maven_release_date")
+    def test_maven_dispatch(self, mock_maven: MagicMock) -> None:
+        mock_maven.return_value = datetime(2021, 12, 10, tzinfo=timezone.utc)
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        dt = _registry_release_date("org.example:lib", "maven", "2.15.0")
+        mock_maven.assert_called_once_with("org.example:lib", "2.15.0")
+        assert dt is not None
+
+    def test_unknown_ecosystem_returns_none(self) -> None:
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        dt = _registry_release_date("some-crate", "crates.io", "1.0.0")
+        assert dt is None
+
+    def test_go_ecosystem_returns_none(self) -> None:
+        from manus_agent.tools.get_patch_status import _registry_release_date
+
+        dt = _registry_release_date("github.com/some/pkg", "go", "v1.2.3")
+        assert dt is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: merge_vulns
+# ---------------------------------------------------------------------------
+
+
+class TestMergeVulns:
+    def test_deduplication(self) -> None:
+        from manus_agent.tools.get_patch_status import _merge_vulns
+
+        ghsa = [{"name": "log4j-core", "ecosystem": "maven", "patched_version": "2.15.0", "advisory_id": "GHSA-1"}]
+        osv = [{"name": "log4j-core", "ecosystem": "maven", "patched_version": "2.15.0", "advisory_id": "OSV-1"}]
+        merged = _merge_vulns(ghsa, osv)
+        assert len(merged) == 1
+        assert merged[0]["advisory_id"] == "GHSA-1"  # GHSA wins (first)
+
+    def test_osv_fills_missing_patched_version(self) -> None:
+        from manus_agent.tools.get_patch_status import _merge_vulns
+
+        ghsa = [{"name": "log4j-core", "ecosystem": "maven", "patched_version": None, "advisory_id": "GHSA-1"}]
+        osv = [{"name": "log4j-core", "ecosystem": "maven", "patched_version": "2.15.0", "advisory_id": "OSV-1"}]
+        merged = _merge_vulns(ghsa, osv)
+        assert len(merged) == 1
+        # OSV version should be used because GHSA had None
+        assert merged[0]["patched_version"] == "2.15.0"
+
+    def test_different_packages_both_kept(self) -> None:
+        from manus_agent.tools.get_patch_status import _merge_vulns
+
+        ghsa = [{"name": "requests", "ecosystem": "pypi", "patched_version": "2.32.0", "advisory_id": "GHSA-1"}]
+        osv = [{"name": "axios", "ecosystem": "npm", "patched_version": "1.7.0", "advisory_id": "OSV-1"}]
+        merged = _merge_vulns(ghsa, osv)
+        assert len(merged) == 2
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests: _run_patch_status
+# ---------------------------------------------------------------------------
+
+
+class TestRunPatchStatus:
+    """Tests for the core _run_patch_status function."""
+
+    def _mock_maven_date_response(self) -> MagicMock:
+        m = MagicMock()
+        m.return_value = _MAVEN_SEARCH_RESPONSE
+        return m
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_log4shell_full_flow(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = _NVD_RESPONSE["vulnerabilities"][0]["cve"]
+        mock_ghsa.return_value = [
+            {
+                "advisory_id": "GHSA-jfh8-c2jp-5v3q",
+                "name": "org.apache.logging.log4j:log4j-core",
+                "ecosystem": "maven",
+                "patched_version": "2.15.0",
+                "vulnerable_range": ">= 2.13.0, < 2.15.0",
+            }
+        ]
+        mock_osv.return_value = []
+        # Patch release: Dec 10 2021 → 0 days lag (same day as CVE disclosure)
+        mock_reg.return_value = datetime(2021, 12, 10, 21, 0, 0, tzinfo=timezone.utc)
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status(CVE_LOG4SHELL)
+
+        assert result["cve_id"] == CVE_LOG4SHELL
+        assert result["severity"] == "CRITICAL"
+        assert len(result["packages"]) == 1
+
+        pkg = result["packages"][0]
+        assert pkg["patched_version"] == "2.15.0"
+        assert pkg["patch_release_date"] == "2021-12-10"
+        assert pkg["patch_lag_label"] == "FAST"
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_slow_patch_lag(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = {
+            "id": "CVE-2023-00001",
+            "published": "2023-01-01T00:00:00.000",
+            "metrics": {},
+        }
+        mock_ghsa.return_value = [
+            {
+                "advisory_id": "GHSA-slow-slow-slow",
+                "name": "slowpkg",
+                "ecosystem": "pypi",
+                "patched_version": "2.0.0",
+                "vulnerable_range": "< 2.0.0",
+            }
+        ]
+        mock_osv.return_value = []
+        # 45 days after disclosure
+        mock_reg.return_value = datetime(2023, 2, 15, tzinfo=timezone.utc)
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("CVE-2023-00001")
+        pkg = result["packages"][0]
+        assert pkg["patch_lag_days"] == 45
+        assert pkg["patch_lag_label"] == "SLOW"
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_missing_patch(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = {
+            "id": "CVE-2024-00001",
+            "published": "2024-01-01T00:00:00.000",
+            "metrics": {},
+        }
+        mock_ghsa.return_value = [
+            {
+                "advisory_id": "GHSA-no-fix-here",
+                "name": "unpatched-pkg",
+                "ecosystem": "pypi",
+                "patched_version": None,
+                "vulnerable_range": ">= 1.0.0",
+            }
+        ]
+        mock_osv.return_value = []
+        mock_reg.return_value = None
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("CVE-2024-00001")
+        pkg = result["packages"][0]
+        assert pkg["patched_version"] == "unknown"
+        assert pkg["patch_lag_label"] == "MISSING"
+        assert "MISSING" in result["summary"] or "unpatched" in result["summary"].lower()
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_no_packages_found(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = {
+            "id": "CVE-2024-00002",
+            "published": "2024-01-01T00:00:00.000",
+            "metrics": {},
+        }
+        mock_ghsa.return_value = []
+        mock_osv.return_value = []
+        mock_reg.return_value = None
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("CVE-2024-00002")
+        assert result["packages"] == []
+        assert "No affected package records" in result["summary"]
+
+    def test_invalid_cve_id(self) -> None:
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("NOT-A-CVE")
+        assert "error" in result
+        assert "Invalid CVE ID" in result["error"]
+
+    def test_invalid_cve_id_whitespace_stripped(self) -> None:
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("   NOT-A-CVE   ")
+        assert "error" in result
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_registry_returns_none_lag_is_none(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = {
+            "id": "CVE-2023-11111",
+            "published": "2023-06-01T00:00:00.000",
+            "metrics": {},
+        }
+        mock_ghsa.return_value = [
+            {
+                "advisory_id": "GHSA-rust-rust-rust",
+                "name": "some-crate",
+                "ecosystem": "crates.io",
+                "patched_version": "2.0.0",
+                "vulnerable_range": "< 2.0.0",
+            }
+        ]
+        mock_osv.return_value = []
+        mock_reg.return_value = None  # crates.io not supported → no date
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("CVE-2023-11111")
+        pkg = result["packages"][0]
+        assert pkg["patch_release_date"] == "unknown"
+        assert pkg["patch_lag_days"] is None
+        assert pkg["patch_lag_label"] == "MISSING"
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_normal_patch_lag(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        mock_nvd.return_value = {
+            "id": "CVE-2022-00001",
+            "published": "2022-03-01T00:00:00.000",
+            "metrics": {"cvssMetricV31": [{"cvssData": {"baseSeverity": "HIGH"}}]},
+        }
+        mock_ghsa.return_value = [
+            {
+                "advisory_id": "GHSA-norm-norm-norm",
+                "name": "my-lib",
+                "ecosystem": "pypi",
+                "patched_version": "3.1.0",
+                "vulnerable_range": "< 3.1.0",
+            }
+        ]
+        mock_osv.return_value = []
+        # 15 days → NORMAL
+        mock_reg.return_value = datetime(2022, 3, 16, tzinfo=timezone.utc)
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("CVE-2022-00001")
+        pkg = result["packages"][0]
+        assert pkg["patch_lag_days"] == 15
+        assert pkg["patch_lag_label"] == "NORMAL"
+        assert result["severity"] == "HIGH"
+
+    @patch("manus_agent.tools.get_patch_status._registry_release_date")
+    @patch("manus_agent.tools.get_patch_status._fetch_osv_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_ghsa_vulns")
+    @patch("manus_agent.tools.get_patch_status._fetch_nvd_cve")
+    def test_case_insensitive_cve_id(
+        self,
+        mock_nvd: MagicMock,
+        mock_ghsa: MagicMock,
+        mock_osv: MagicMock,
+        mock_reg: MagicMock,
+    ) -> None:
+        """Lower-case or mixed-case CVE IDs should be accepted."""
+        mock_nvd.return_value = {
+            "id": "CVE-2021-44228",
+            "published": "2021-12-10T10:15:09.143",
+            "metrics": {},
+        }
+        mock_ghsa.return_value = []
+        mock_osv.return_value = []
+        mock_reg.return_value = None
+
+        from manus_agent.tools.get_patch_status import _run_patch_status
+
+        result = _run_patch_status("cve-2021-44228")
+        assert result["cve_id"] == "CVE-2021-44228"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: Strands tool wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestGetPatchStatusTool:
+    """Tests for the @tool-decorated get_patch_status function."""
+
+    def _make_tool_use(self, cve_id: str) -> dict:
+        return {"toolUseId": "test-tool-use-id-001", "input": {"cve_id": cve_id}}
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_success_path(self, mock_core: MagicMock) -> None:
+        mock_core.return_value = {
+            "cve_id": CVE_LOG4SHELL,
+            "cve_published": "2021-12-10T10:15:09.143",
+            "severity": "CRITICAL",
+            "packages": [
+                {
+                    "name": "org.apache.logging.log4j:log4j-core",
+                    "ecosystem": "maven",
+                    "patched_version": "2.15.0",
+                    "patch_release_date": "2021-12-10",
+                    "patch_lag_days": 0,
+                    "patch_lag_label": "FAST",
+                    "advisory_id": "GHSA-jfh8-c2jp-5v3q",
+                }
+            ],
+            "summary": "CVE-2021-44228 affects 1 package(s). 1 patched. Overall patch lag: FAST.",
+        }
+
+        from manus_agent.tools.get_patch_status import get_patch_status
+
+        result = get_patch_status(self._make_tool_use(CVE_LOG4SHELL))
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-tool-use-id-001"
+        text = result["content"][0]["text"]
+        assert "CVE-2021-44228" in text
+        assert "CRITICAL" in text
+        assert "FAST" in text
+        assert "2.15.0" in text
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_error_path(self, mock_core: MagicMock) -> None:
+        mock_core.return_value = {"error": "Invalid CVE ID: 'BAD-ID'."}
+        from manus_agent.tools.get_patch_status import get_patch_status
+
+        result = get_patch_status(self._make_tool_use("BAD-ID"))
+        assert result["status"] == "error"
+        assert "Invalid CVE ID" in result["content"][0]["text"]
+
+    def test_missing_cve_id(self) -> None:
+        from manus_agent.tools.get_patch_status import get_patch_status
+
+        tool_use = {"toolUseId": "test-002", "input": {}}
+        result = get_patch_status(tool_use)
+        assert result["status"] == "error"
+        assert "cve_id is required" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_package_with_no_lag_date(self, mock_core: MagicMock) -> None:
+        """Verify text output handles None patch_lag_days gracefully."""
+        mock_core.return_value = {
+            "cve_id": CVE_LOG4SHELL,
+            "cve_published": "2021-12-10T10:15:09.143",
+            "severity": "CRITICAL",
+            "packages": [
+                {
+                    "name": "some-crate",
+                    "ecosystem": "crates.io",
+                    "patched_version": "2.0.0",
+                    "patch_release_date": "unknown",
+                    "patch_lag_days": None,
+                    "patch_lag_label": "MISSING",
+                    "advisory_id": "GHSA-xxxx-yyyy-zzzz",
+                }
+            ],
+            "summary": "CVE-2021-44228 affects 1 package(s). 1 patched. Overall patch lag: MISSING.",
+        }
+        from manus_agent.tools.get_patch_status import get_patch_status
+
+        result = get_patch_status(self._make_tool_use(CVE_LOG4SHELL))
+        assert result["status"] == "success"
+        text = result["content"][0]["text"]
+        assert "N/A" in text  # lag_str fallback
+        assert "MISSING" in text
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TestPatchStatusCli:
+    """Tests for _build_patch_status_parser and _run_patch_status (CLI)."""
+
+    def test_parser_defaults(self) -> None:
+        from manus_agent.cli import _build_patch_status_parser
+
+        p = _build_patch_status_parser()
+        args = p.parse_args([CVE_LOG4SHELL])
+        assert args.cve_id == CVE_LOG4SHELL
+        assert args.output == "text"
+
+    def test_parser_json_output(self) -> None:
+        from manus_agent.cli import _build_patch_status_parser
+
+        p = _build_patch_status_parser()
+        args = p.parse_args([CVE_LOG4SHELL, "--output", "json"])
+        assert args.output == "json"
+
+    @patch("manus_agent.cli._run_patch_status")
+    def test_dispatch_in_main(self, mock_run: MagicMock) -> None:
+        """Verify 'patch-status' is recognised in main() dispatch."""
+
+        mock_run.return_value = None  # _run_patch_status (CLI fn) returns int
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "patch-status" in _SUBCOMMANDS
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_text_output_exit_zero(self, mock_core: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        mock_core.return_value = {
+            "cve_id": CVE_LOG4SHELL,
+            "cve_published": "2021-12-10T10:15:09.143",
+            "severity": "CRITICAL",
+            "packages": [
+                {
+                    "name": "org.apache.logging.log4j:log4j-core",
+                    "ecosystem": "maven",
+                    "patched_version": "2.15.0",
+                    "patch_release_date": "2021-12-10",
+                    "patch_lag_days": 0,
+                    "patch_lag_label": "FAST",
+                    "advisory_id": "GHSA-jfh8-c2jp-5v3q",
+                }
+            ],
+            "summary": "CVE-2021-44228 affects 1 package(s). 1 patched. Overall patch lag: FAST.",
+        }
+
+        from manus_agent.cli import _run_patch_status as _cli_run
+
+        exit_code = _cli_run([CVE_LOG4SHELL])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        assert "CVE-2021-44228" in captured.out
+        assert "FAST" in captured.out
+        assert "2.15.0" in captured.out
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_json_output(self, mock_core: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        mock_core.return_value = {
+            "cve_id": CVE_LOG4SHELL,
+            "cve_published": "2021-12-10T10:15:09.143",
+            "severity": "CRITICAL",
+            "packages": [],
+            "summary": "No packages.",
+        }
+
+        from manus_agent.cli import _run_patch_status as _cli_run
+
+        exit_code = _cli_run([CVE_LOG4SHELL, "--output", "json"])
+        captured = capsys.readouterr()
+        assert exit_code == 0
+        parsed = json.loads(captured.out)
+        assert parsed["cve_id"] == CVE_LOG4SHELL
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_missing_patch_exits_two(self, mock_core: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        """Exit code 2 when any package has MISSING patch_lag_label."""
+        mock_core.return_value = {
+            "cve_id": "CVE-2024-00001",
+            "cve_published": "2024-01-01T00:00:00.000",
+            "severity": "HIGH",
+            "packages": [
+                {
+                    "name": "unpatched-pkg",
+                    "ecosystem": "pypi",
+                    "patched_version": "unknown",
+                    "patch_release_date": "unknown",
+                    "patch_lag_days": None,
+                    "patch_lag_label": "MISSING",
+                    "advisory_id": "GHSA-no-fix",
+                }
+            ],
+            "summary": "CVE-2024-00001 affects 1 package(s). 1 unpatched.",
+        }
+
+        from manus_agent.cli import _run_patch_status as _cli_run
+
+        exit_code = _cli_run(["CVE-2024-00001"])
+        assert exit_code == 2
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_error_result_exits_one(self, mock_core: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        mock_core.return_value = {"error": "Invalid CVE ID: 'BAD'."}
+
+        from manus_agent.cli import _run_patch_status as _cli_run
+
+        exit_code = _cli_run(["BAD"])
+        assert exit_code == 1
+
+    @patch("manus_agent.tools.get_patch_status._run_patch_status")
+    def test_no_packages_exits_zero(self, mock_core: MagicMock, capsys: pytest.CaptureFixture) -> None:
+        mock_core.return_value = {
+            "cve_id": "CVE-2024-00002",
+            "cve_published": "2024-01-01T00:00:00.000",
+            "severity": "UNKNOWN",
+            "packages": [],
+            "summary": "No affected package records found.",
+        }
+
+        from manus_agent.cli import _run_patch_status as _cli_run
+
+        exit_code = _cli_run(["CVE-2024-00002"])
+        assert exit_code == 0
+
+    def test_advisory_id_omitted_when_empty(self, capsys: pytest.CaptureFixture) -> None:
+        """Advisory line should not appear when advisory_id is empty string."""
+        with patch("manus_agent.tools.get_patch_status._run_patch_status") as mock_core:
+            mock_core.return_value = {
+                "cve_id": CVE_LOG4SHELL,
+                "cve_published": "2021-12-10T10:15:09.143",
+                "severity": "CRITICAL",
+                "packages": [
+                    {
+                        "name": "log4j-core",
+                        "ecosystem": "maven",
+                        "patched_version": "2.15.0",
+                        "patch_release_date": "2021-12-10",
+                        "patch_lag_days": 0,
+                        "patch_lag_label": "FAST",
+                        "advisory_id": "",  # empty
+                    }
+                ],
+                "summary": "1 package, FAST.",
+            }
+
+            from manus_agent.cli import _run_patch_status as _cli_run
+
+            _cli_run([CVE_LOG4SHELL])
+            out = capsys.readouterr().out
+            assert "Advisory" not in out


### PR DESCRIPTION
Adds `get_patch_status`, a new Strands tool + CLI subcommand that answers **"how quickly did the ecosystem respond to this CVE?"** for any CVE ID.

## What this adds

### Tool: `get_patch_status`

- Queries **GitHub Advisory DB** (`first_patched_version` per package) and **OSV.dev** (cross-ecosystem fix ranges)
- Looks up the actual **patch release date** from the package registry:
  - PyPI → `/pypi/{pkg}/json` (`upload_time`)
  - npm → `registry.npmjs.org/{pkg}` (time map)
  - Maven → Maven Central Solr search (`timestamp` field)
- Computes **patch lag**: days between NVD CVE disclosure and registry release
- Emits **`patch_lag_label`**: `FAST` (≤7 d) / `NORMAL` (8–30 d) / `SLOW` (>30 d) / `MISSING` (no patch)
- Graceful degradation: unsupported ecosystems (Go, Rust, Ruby…) report `patch_release_date=unknown` and `patch_lag_label=MISSING` rather than raising

### CLI: `manus-agent patch-status CVE-XXXX-YYYY [--output text|json]`

```
$ manus-agent patch-status CVE-2021-44228
Patch Status — CVE-2021-44228
==================================================
CVE Published : 2021-12-10T10:15:09.143
Severity      : CRITICAL
Summary       : CVE-2021-44228 affects 1 package(s). 1 patched. Overall patch lag: FAST.

  Package   : org.apache.logging.log4j:log4j-core (maven)
  Patched   : 2.15.0
  Released  : 2021-12-10
  Lag       : 0 days  [FAST]
  Advisory  : GHSA-jfh8-c2jp-5v3q
```

**Exit codes:**
- `0` — all packages patched
- `2` — at least one `MISSING` package (suitable for CI alerting)
- `1` — invalid CVE ID or import failure

### VI agent integration

`get_patch_status` is added to the VI agent tool list. The system prompt gains **Step 6d: Patch Status** after the Dependency Blast Radius step, instructing the agent to report patched versions, release dates, lag days, and flag `SLOW`/`MISSING` patch lag prominently.

## Tests

66 new unit tests (all HTTP mocked). Total suite: **968 passing** (was 902), 0 failures.

## No new dependencies

Uses only `requests` and `strands` (already in `[dev]` extras).