### PR TITLE
feat(tools): composite contextual risk scorer — score_context_score tool + manus-agent risk-score CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -120,6 +120,15 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
   A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
 
+**Step 6d: Composite Contextual Risk Score**
+- Call `score_context_score` with the CVE ID. Include in the report:
+  - The composite score (0–100) and risk tier (CRITICAL ≥80 / HIGH ≥60 / MEDIUM ≥40 / LOW <40).
+  - The `dominant_factor` field — which dimension drove the score highest.
+  - The `kev_listed` flag — if True, the CVE is in the CISA KEV catalogue; flag this **prominently** as it indicates active in-the-wild exploitation with a hard +15 bonus.
+  - The per-dimension breakdown: EPSS, CVSS base, exploit complexity, EPSS spike, blast radius, KEV.
+  - The `confidence` level (HIGH / MEDIUM / LOW) based on how many data sources returned live data.
+  A composite score ≥80 (CRITICAL) should be escalated as the highest-priority finding in the report, superseding raw CVSS severity.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -217,6 +226,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_poc_week import get_poc_week
             from manus_agent.tools.get_trickest_pocs import get_trickest_pocs
             from manus_agent.tools.get_vulncheck_data import get_vulncheck_data
+            from manus_agent.tools.score_context_score import score_context_score
             from manus_agent.tools.score_exploit_complexity import score_exploit_complexity
             from manus_agent.tools.search_poc_sources import search_poc_sources
         except ImportError as exc:  # pragma: no cover - depends on env
@@ -274,6 +284,7 @@ class VulnerabilityIntelligenceAgent:
             get_vulncheck_data,
             search_poc_sources,
             get_dependency_blast_radius,
+            score_context_score,
         ]
         if use_browser is not None:
             tools.append(use_browser)

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1056,6 +1056,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "risk-score",
 }
 
 
@@ -1859,6 +1860,101 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# risk-score subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_risk_score_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent risk-score",
+        description=(
+            "Produce a composite contextual risk score (0–100) for a CVE.\n"
+            "Combines six weighted dimensions: EPSS probability, CVSS v3 base score,\n"
+            "exploit complexity (attacker-friendliness), EPSS spike detection (last 30d),\n"
+            "blast radius (CPE count), and CISA KEV listing (+15 hard bonus).\n"
+            "Outputs a risk tier (CRITICAL/HIGH/MEDIUM/LOW) and a dominant-factor field."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "cve_id",
+        metavar="CVE_ID",
+        help="CVE identifier to score (e.g. CVE-2021-44228)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    p.add_argument(
+        "--weights",
+        metavar="JSON",
+        default=None,
+        help=(
+            "Override dimension weights as a JSON object, e.g. "
+            '\'{"kev_listed":0.30,"epss":0.20}\'. Values are auto-normalised.'
+        ),
+    )
+    return p
+
+
+def _run_risk_score(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_risk_score_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.score_context_score import _render_text, _run_context_score
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: failed to import score_context_score: {exc}", file=sys.stderr)
+        return 1
+
+    weights: dict | None = None
+    if args.weights:
+        try:
+            weights = _json.loads(args.weights)
+            if not isinstance(weights, dict):
+                raise ValueError("--weights must be a JSON object")
+        except (ValueError, _json.JSONDecodeError) as exc:
+            print(f"Error: invalid --weights: {exc}", file=sys.stderr)
+            return 1
+
+    cve_id = args.cve_id.strip().upper()
+    import re as _re
+
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id):
+        print(f"Error: {cve_id!r} is not a valid CVE identifier (expected CVE-YYYY-NNNNN)", file=sys.stderr)
+        return 1
+
+    try:
+        from manus_agent.tools import score_context_score as _mod
+
+        if weights:
+            # Merge and normalise weights before scoring
+            merged = dict(_mod._WEIGHTS)
+            for k, v in weights.items():
+                if k in merged and isinstance(v, (int, float)) and v >= 0:
+                    merged[k] = float(v)
+            total = sum(merged.values())
+            if total > 0:
+                _mod._WEIGHTS = {k: v / total for k, v in merged.items()}
+
+        result = _run_context_score(cve_id)
+    except Exception as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+    else:
+        print(_render_text(result))
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -1901,6 +1997,11 @@ def _build_run_parser() -> argparse.ArgumentParser:
             "  # CVE remediation guidance\n"
             "  manus-agent remediate CVE-2024-3094\n"
             "  manus-agent remediate CVE-2024-3094 --output json\n"
+            "\n"
+            "  # Contextual risk score (composite 6-dimension scorer)\n"
+            "  manus-agent risk-score CVE-2021-44228\n"
+            "  manus-agent risk-score CVE-2024-3094 --output json\n"
+            "  manus-agent risk-score CVE-2024-3094 --weights '{\"kev_listed\":0.30}'\n"
             "\n"
             "  # Changelog and release notes\n"
             "  manus-agent changelog                           # show full CHANGELOG.md\n"
@@ -2188,6 +2289,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "risk-score":
+        idx = argv.index("risk-score")
+        sys.exit(_run_risk_score(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/score_context_score.py
+++ b/src/manus_agent/tools/score_context_score.py
@@ -1,0 +1,483 @@
+"""
+Tool: score_context_score
+
+Produces a single composite **contextual risk score** (0–100) for a CVE by
+combining six independent signal dimensions:
+
+1. **epss**         — current EPSS probability from FIRST.org (0.0–1.0 → 0–25 pts)
+2. **cvss_base**    — NVD CVSS v3 base score (0–10 → 0–20 pts)
+3. **exploit_complexity** — NVD Attack Complexity / Privileges Required (→ 0–15 pts)
+4. **epss_spike**   — EPSS spike detected in the last 30 days (0 or 10 pts)
+5. **blast_radius** — downstream exposure from NVD CPE affected-version count (0–15 pts)
+6. **kev_listed**   — CISA KEV catalogue membership (0 or 15 pts hard bonus)
+
+A **KEV-listed CVE always receives +15** regardless of other scores, meaning
+an otherwise low-scoring CVE with active exploitation is never under-rated.
+
+Scores are bucketed into four risk tiers:
+
+  CRITICAL  ≥ 80   — drop everything, patch or mitigate now
+  HIGH      ≥ 60   — high urgency, schedule within hours/days
+  MEDIUM    ≥ 40   — elevated, schedule within your normal cadence
+  LOW       < 40   — monitor; address in next maintenance window
+
+The tool is useful as a *triage normaliser* when you have a queue of CVEs and
+need a single comparable number that goes beyond raw CVSS severity.
+
+All HTTP calls degrade gracefully: a failed data source contributes 0 to its
+dimension, so the scorer always returns a result.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["score_context_score"]
+
+# ---------------------------------------------------------------------------
+# Dimension weights — must sum to 1.0
+# ---------------------------------------------------------------------------
+
+_WEIGHTS: dict[str, float] = {
+    "epss": 0.25,
+    "cvss_base": 0.20,
+    "exploit_complexity": 0.15,
+    "epss_spike": 0.10,
+    "blast_radius": 0.15,
+    "kev_listed": 0.15,
+}
+
+assert abs(sum(_WEIGHTS.values()) - 1.0) < 1e-9, "Dimension weights must sum to 1.0"
+
+# Max raw points each dimension contributes BEFORE weighting
+_MAX_RAW: dict[str, float] = {
+    "epss": 100.0,  # epss probability × 100 → up to 100 pts
+    "cvss_base": 100.0,  # base_score / 10 × 100 → up to 100 pts
+    "exploit_complexity": 100.0,  # multi-factor NVD signal → up to 100 pts
+    "epss_spike": 100.0,  # binary: 100 if spike, else 0
+    "blast_radius": 100.0,  # CPE count-derived bucket → up to 100 pts
+    "kev_listed": 100.0,  # binary: 100 if on KEV, else 0
+}
+
+# KEV cache — same path convention as check_cisa_kev.py
+_KEV_CACHE_FILE = Path(__file__).parent / ".cisa_kev_cache.json"
+_KEV_CACHE_DURATION = 3600  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Data-fetch helpers (all tolerant of network failures)
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd(cve_id: str) -> dict[str, Any]:
+    """Return NVD CVE record dict (vulnerabilities[0].cve) or {}."""
+    url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?cveId={cve_id.upper()}"
+    try:
+        resp = requests.get(url, timeout=15)
+        resp.raise_for_status()
+        vulns = resp.json().get("vulnerabilities", [])
+        if vulns:
+            return vulns[0].get("cve", {})
+    except requests.RequestException:
+        pass
+    return {}
+
+
+def _fetch_epss(cve_id: str) -> dict[str, Any]:
+    """Return EPSS current score dict or {}."""
+    url = "https://api.first.org/data/v1/epss"
+    try:
+        resp = requests.get(url, params={"cve": cve_id.upper()}, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        rows = data.get("data", [])
+        if rows:
+            return rows[0]
+    except requests.RequestException:
+        pass
+    return {}
+
+
+def _fetch_epss_series(cve_id: str, days: int = 30) -> list[dict[str, Any]]:
+    """Return EPSS time-series list (oldest-first) for spike detection."""
+    url = "https://api.first.org/data/v1/epss"
+    try:
+        resp = requests.get(
+            url,
+            params={"cve": cve_id.upper(), "scope": "time-series", "limit": min(days, 365)},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        raw = resp.json().get("data", [])
+        # API returns rows with "epss", "percentile", "date"; sort oldest-first
+        return sorted(
+            [{"date": r["date"], "epss": float(r["epss"])} for r in raw if "epss" in r and "date" in r],
+            key=lambda x: x["date"],
+        )
+    except requests.RequestException:
+        pass
+    return []
+
+
+def _fetch_kev(cve_id: str) -> bool:
+    """Return True if *cve_id* is in the CISA KEV catalogue."""
+    # Try cache first
+    if _KEV_CACHE_FILE.exists():
+        try:
+            cached = json.loads(_KEV_CACHE_FILE.read_text())
+            if time.time() - cached.get("timestamp", 0) < _KEV_CACHE_DURATION:
+                vulns = cached.get("data", {}).get("vulnerabilities", [])
+                return any(v.get("cveID") == cve_id.upper() for v in vulns)
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    try:
+        resp = requests.get(
+            "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        try:
+            _KEV_CACHE_FILE.write_text(json.dumps({"timestamp": time.time(), "data": data}))
+        except OSError:
+            pass
+        return any(v.get("cveID") == cve_id.upper() for v in data.get("vulnerabilities", []))
+    except requests.RequestException:
+        pass
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Dimension scorers (each returns a raw value 0–100)
+# ---------------------------------------------------------------------------
+
+
+def _dim_epss(epss_row: dict[str, Any]) -> float:
+    """EPSS probability × 100 → 0–100."""
+    try:
+        return min(float(epss_row.get("epss", 0)) * 100.0, 100.0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _dim_cvss_base(nvd: dict[str, Any]) -> float:
+    """CVSS v3 base score / 10 × 100 → 0–100."""
+    metrics = nvd.get("metrics", {})
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            score = entries[0].get("cvssData", {}).get("baseScore")
+            if score is not None:
+                return min(float(score) / 10.0 * 100.0, 100.0)
+    return 0.0
+
+
+def _dim_exploit_complexity(nvd: dict[str, Any]) -> float:
+    """
+    Combine Attack Complexity (AC) + Privileges Required (PR) + User Interaction (UI)
+    into an attacker-friendliness signal.  Counter-intuitively: LOW complexity is
+    WORSE for defenders, so we invert the score.
+
+    Mapping (raw 0–100 before weighting, higher = more dangerous):
+      AC=LOW  → +40   AC=HIGH → +0
+      PR=NONE → +35   PR=LOW  → +20   PR=HIGH → +0
+      UI=NONE → +25   UI=REQUIRED → +0
+    Max = 100 (AC=LOW, PR=NONE, UI=NONE)
+    """
+    metrics = nvd.get("metrics", {})
+    cv: dict[str, Any] = {}
+    for key in ("cvssMetricV31", "cvssMetricV30"):
+        entries = metrics.get(key, [])
+        if entries:
+            cv = entries[0].get("cvssData", {})
+            break
+
+    ac = cv.get("attackComplexity", "").upper()
+    pr = cv.get("privilegesRequired", "").upper()
+    ui = cv.get("userInteraction", "").upper()
+
+    score = 0.0
+    score += 40.0 if ac == "LOW" else 0.0
+    score += {"NONE": 35.0, "LOW": 20.0, "HIGH": 0.0}.get(pr, 0.0)
+    score += 25.0 if ui == "NONE" else 0.0
+    return score
+
+
+def _dim_epss_spike(series: list[dict[str, Any]]) -> float:
+    """100 if a ≥0.10 EPSS jump detected in the last 30 days, else 0."""
+    if len(series) < 2:
+        return 0.0
+    scores = [p["epss"] for p in series]
+    # Largest 7-day rolling jump
+    for i in range(len(scores) - 1, max(0, len(scores) - 30), -1):
+        lo = max(0, i - 7)
+        if scores[i] - scores[lo] >= 0.10:
+            return 100.0
+    return 0.0
+
+
+def _dim_blast_radius(nvd: dict[str, Any]) -> float:
+    """
+    Estimate blast radius from the number of distinct CPE configurations
+    affected by this CVE.  More configurations → more exposure.
+
+    Buckets (raw 0–100):
+      0 CPEs      → 0
+      1–2 CPEs    → 20
+      3–9 CPEs    → 40
+      10–29 CPEs  → 60
+      30–99 CPEs  → 80
+      ≥100 CPEs   → 100
+    """
+    try:
+        configs = nvd.get("configurations", [])
+        cpe_count = sum(len(node.get("cpeMatch", [])) for cfg in configs for node in cfg.get("nodes", []))
+    except (TypeError, AttributeError):
+        cpe_count = 0
+
+    if cpe_count == 0:
+        return 0.0
+    if cpe_count <= 2:
+        return 20.0
+    if cpe_count <= 9:
+        return 40.0
+    if cpe_count <= 29:
+        return 60.0
+    if cpe_count <= 99:
+        return 80.0
+    return 100.0
+
+
+def _dim_kev(kev_listed: bool) -> float:
+    """100 if on CISA KEV, else 0."""
+    return 100.0 if kev_listed else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Composite calculation
+# ---------------------------------------------------------------------------
+
+
+def _risk_tier(score: float) -> str:
+    if score >= 80:
+        return "CRITICAL"
+    if score >= 60:
+        return "HIGH"
+    if score >= 40:
+        return "MEDIUM"
+    return "LOW"
+
+
+def _compute_composite(dims_raw: dict[str, float]) -> float:
+    """Weighted average of raw 0–100 dimension scores → composite 0–100."""
+    total = sum(_WEIGHTS[k] * dims_raw[k] for k in _WEIGHTS)
+    return round(total, 1)
+
+
+def _run_context_score(cve_id: str) -> dict[str, Any]:
+    """Execute the full scoring pipeline for *cve_id* and return a result dict."""
+    cve_id = cve_id.upper().strip()
+
+    # ── Fetch all data sources in parallel (sequentially for simplicity) ─────
+    nvd = _fetch_nvd(cve_id)
+    epss_row = _fetch_epss(cve_id)
+    epss_series = _fetch_epss_series(cve_id, days=30)
+    kev_listed = _fetch_kev(cve_id)
+
+    # ── Raw dimension scores (each 0–100) ─────────────────────────────────────
+    dims_raw: dict[str, float] = {
+        "epss": _dim_epss(epss_row),
+        "cvss_base": _dim_cvss_base(nvd),
+        "exploit_complexity": _dim_exploit_complexity(nvd),
+        "epss_spike": _dim_epss_spike(epss_series),
+        "blast_radius": _dim_blast_radius(nvd),
+        "kev_listed": _dim_kev(kev_listed),
+    }
+
+    # ── Weighted composite ────────────────────────────────────────────────────
+    composite = _compute_composite(dims_raw)
+    tier = _risk_tier(composite)
+
+    # ── Identify the dominant factor ─────────────────────────────────────────
+    weighted = {k: _WEIGHTS[k] * dims_raw[k] for k in _WEIGHTS}
+    dominant = max(weighted, key=lambda k: weighted[k])
+
+    # ── Confidence: how many dimensions returned non-zero data? ──────────────
+    live_dims = sum(1 for v in dims_raw.values() if v > 0)
+    if live_dims >= 4:
+        confidence = "HIGH"
+    elif live_dims >= 2:
+        confidence = "MEDIUM"
+    else:
+        confidence = "LOW"
+
+    # ── One-sentence natural-language verdict ─────────────────────────────────
+    kev_note = " Actively exploited in the wild (CISA KEV)." if kev_listed else ""
+    risk_summary = (
+        f"{cve_id} is rated {tier} (score {composite}/100) based on "
+        f"{'high' if dims_raw['epss'] >= 50 else 'low'} EPSS probability, "
+        f"{'available' if dims_raw['exploit_complexity'] >= 50 else 'limited'} exploit access, "
+        f"and {'wide' if dims_raw['blast_radius'] >= 60 else 'narrow'} blast radius.{kev_note}"
+    )
+
+    return {
+        "cve_id": cve_id,
+        "composite_score": composite,
+        "risk_tier": tier,
+        "dominant_factor": dominant,
+        "confidence": confidence,
+        "risk_summary": risk_summary,
+        "kev_listed": kev_listed,
+        "dimensions": {
+            k: {
+                "raw_score": dims_raw[k],
+                "weight": _WEIGHTS[k],
+                "weighted_contribution": round(_WEIGHTS[k] * dims_raw[k], 2),
+            }
+            for k in _WEIGHTS
+        },
+        "epss_current": float(epss_row.get("epss", 0)) if epss_row else None,
+        "epss_percentile": float(epss_row.get("percentile", 0)) if epss_row else None,
+        "nvd_available": bool(nvd),
+    }
+
+
+def _render_text(result: dict[str, Any]) -> str:
+    """Return a human-readable text report."""
+    cve = result["cve_id"]
+    tier = result["risk_tier"]
+    score = result["composite_score"]
+    kev = result["kev_listed"]
+    confidence = result["confidence"]
+
+    lines = [
+        f"Contextual Risk Score: {cve}",
+        "=" * 58,
+        f"  Composite score : {score}/100",
+        f"  Risk tier       : {tier}",
+        f"  Dominant factor : {result['dominant_factor']}",
+        f"  Confidence      : {confidence} ({sum(1 for d in result['dimensions'].values() if d['raw_score'] > 0)}/6 dimensions live)",
+    ]
+    if kev:
+        lines.append("  ⚠  CISA KEV      : YES — actively exploited in the wild")
+    else:
+        lines.append("  CISA KEV        : not listed")
+    lines += [
+        "",
+        result["risk_summary"],
+        "",
+        "Dimension breakdown",
+        "-" * 58,
+    ]
+    dim_labels = {
+        "epss": "EPSS probability",
+        "cvss_base": "CVSS v3 base score",
+        "exploit_complexity": "Exploit complexity (attacker-friendly)",
+        "epss_spike": "EPSS spike (last 30 days)",
+        "blast_radius": "Blast radius (CPE coverage)",
+        "kev_listed": "CISA KEV listing",
+    }
+    for key, label in dim_labels.items():
+        d = result["dimensions"][key]
+        raw = d["raw_score"]
+        wt = d["weighted_contribution"]
+        lines.append(f"  {label:<42}: raw {raw:5.1f}  → +{wt:4.1f} pts  (wt {_WEIGHTS[key]:.0%})")
+
+    lines += [
+        "",
+        "Risk tiers:  CRITICAL ≥80  |  HIGH ≥60  |  MEDIUM ≥40  |  LOW <40",
+    ]
+
+    if result.get("epss_current") is not None:
+        lines.append(f"EPSS current: {result['epss_current']:.4f}  (percentile {result['epss_percentile']:.4f})")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "score_context_score",
+    "description": (
+        "Produces a composite contextual risk score (0–100) for a CVE by combining six "
+        "independent signal dimensions: EPSS probability, CVSS v3 base score, exploit "
+        "complexity (attacker-friendliness from NVD CVSS vector), EPSS spike detection "
+        "(>0.10 jump in 30 days), blast radius (CPE configuration count), and CISA KEV "
+        "listing. A KEV-listed CVE receives a hard +15 bonus (weight 0.15) regardless of "
+        "other scores. Output is a risk tier (CRITICAL/HIGH/MEDIUM/LOW), a dominant-factor "
+        "field, a confidence level (HIGH/MEDIUM/LOW), and a one-sentence risk summary. "
+        "Use this to triage a queue of CVEs with a single comparable number that goes "
+        "beyond raw CVSS severity."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "CVE identifier to score (e.g., 'CVE-2021-44228').",
+                },
+                "output": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "description": "Output format: 'text' (default) or 'json'.",
+                },
+                "weights": {
+                    "type": "object",
+                    "description": (
+                        "Optional JSON object to override dimension weights. Keys: epss, cvss_base, "
+                        "exploit_complexity, epss_spike, blast_radius, kev_listed. "
+                        "Values are floats; they will be normalised to sum to 1.0."
+                    ),
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+@tool
+def score_context_score(cve_id: str, output: str = "text", weights: dict[str, float] | None = None) -> str:
+    """Produce a composite contextual risk score (0–100) for a CVE.
+
+    Combines six dimensions: EPSS probability, CVSS base, exploit complexity,
+    EPSS spike, blast radius, and CISA KEV listing (hard +15 bonus when listed).
+
+    Args:
+        cve_id:  CVE identifier (e.g. 'CVE-2021-44228').
+        output:  'text' (default) or 'json'.
+        weights: Optional dict to override dimension weights; auto-normalised.
+
+    Returns:
+        Formatted risk report string.
+    """
+    if not isinstance(cve_id, str) or not re.match(r"CVE-\d{4}-\d+", cve_id, re.IGNORECASE):
+        return "Error: cve_id must be a valid CVE identifier like 'CVE-2021-44228'."
+
+    # Apply weight overrides if provided
+    if weights:
+        global _WEIGHTS  # noqa: PLW0603
+        merged = dict(_WEIGHTS)
+        for k, v in weights.items():
+            if k in merged and isinstance(v, (int, float)) and v >= 0:
+                merged[k] = float(v)
+        total = sum(merged.values())
+        if total > 0:
+            _WEIGHTS = {k: v / total for k, v in merged.items()}
+
+    result = _run_context_score(cve_id)
+
+    if output == "json":
+        return json.dumps(result, indent=2)
+
+    return _render_text(result)

--- a/tests/test_score_context_score.py
+++ b/tests/test_score_context_score.py
@@ -1,0 +1,668 @@
+"""
+Tests for score_context_score — composite contextual risk scorer with KEV dimension.
+
+All HTTP calls are mocked with realistic payloads (CVE-2021-44228 / Log4Shell).
+No real network calls are made.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.score_context_score import (
+    _WEIGHTS,
+    _compute_composite,
+    _dim_blast_radius,
+    _dim_cvss_base,
+    _dim_epss,
+    _dim_epss_spike,
+    _dim_exploit_complexity,
+    _dim_kev,
+    _render_text,
+    _risk_tier,
+    _run_context_score,
+    score_context_score,
+)
+
+# ---------------------------------------------------------------------------
+# Realistic fixtures (CVE-2021-44228 / Log4Shell)
+# ---------------------------------------------------------------------------
+
+_NVD_CVE = {
+    "id": "CVE-2021-44228",
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "attackVector": "NETWORK",
+                    "attackComplexity": "LOW",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                    "scope": "CHANGED",
+                    "baseScore": 10.0,
+                }
+            }
+        ]
+    },
+    "configurations": [
+        {
+            "nodes": [
+                {
+                    "cpeMatch": [
+                        {"criteria": "cpe:2.3:a:apache:log4j:2.0:*:*:*:*:*:*:*"},
+                        {"criteria": "cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*"},
+                        {"criteria": "cpe:2.3:a:apache:log4j:2.15.0:*:*:*:*:*:*:*"},
+                        {"criteria": "cpe:2.3:a:apache:log4j:2.16.0:*:*:*:*:*:*:*"},
+                        {"criteria": "cpe:2.3:a:apache:log4j:2.17.0:*:*:*:*:*:*:*"},
+                    ]
+                }
+            ]
+        }
+    ],
+}
+
+_NVD_RESP = {"vulnerabilities": [{"cve": _NVD_CVE}]}
+
+_EPSS_ROW = {"cve": "CVE-2021-44228", "epss": "0.97478", "percentile": "0.99989", "date": "2024-01-15"}
+
+_EPSS_RESP = {"data": [_EPSS_ROW]}
+
+_EPSS_SERIES_RAW = [
+    {"date": f"2024-01-{i:02d}", "epss": str(round(0.90 + i * 0.001, 4)), "percentile": "0.999"} for i in range(1, 31)
+]
+
+_EPSS_SERIES_WITH_SPIKE = [
+    {"date": "2024-01-01", "epss": "0.05", "percentile": "0.60"},
+    {"date": "2024-01-02", "epss": "0.06", "percentile": "0.61"},
+    {"date": "2024-01-10", "epss": "0.18", "percentile": "0.75"},  # +0.12 jump from day 1
+    {"date": "2024-01-20", "epss": "0.20", "percentile": "0.80"},
+    {"date": "2024-01-30", "epss": "0.22", "percentile": "0.82"},
+]
+
+_KEV_DATA = {
+    "vulnerabilities": [
+        {"cveID": "CVE-2021-44228", "vendorProject": "Apache", "product": "Log4j"},
+        {"cveID": "CVE-2022-22965", "vendorProject": "VMware", "product": "Spring Framework"},
+    ]
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a mock requests.Response
+# ---------------------------------------------------------------------------
+
+
+def _mock_resp(payload: dict) -> MagicMock:
+    m = MagicMock()
+    m.raise_for_status.return_value = None
+    m.json.return_value = payload
+    return m
+
+
+# ---------------------------------------------------------------------------
+# Unit: weights
+# ---------------------------------------------------------------------------
+
+
+class TestWeights:
+    def test_weights_sum_to_one(self):
+        total = sum(_WEIGHTS.values())
+        assert abs(total - 1.0) < 1e-9
+
+    def test_all_six_dimensions_present(self):
+        expected = {"epss", "cvss_base", "exploit_complexity", "epss_spike", "blast_radius", "kev_listed"}
+        assert set(_WEIGHTS.keys()) == expected
+
+    def test_kev_weight_is_fifteen_percent(self):
+        assert abs(_WEIGHTS["kev_listed"] - 0.15) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Unit: dimension scorers
+# ---------------------------------------------------------------------------
+
+
+class TestDimEpss:
+    def test_high_epss(self):
+        assert _dim_epss({"epss": "0.97478"}) == pytest.approx(97.478, abs=0.01)
+
+    def test_zero_epss(self):
+        assert _dim_epss({"epss": "0.0"}) == 0.0
+
+    def test_missing_key(self):
+        assert _dim_epss({}) == 0.0
+
+    def test_capped_at_100(self):
+        assert _dim_epss({"epss": "1.5"}) == 100.0
+
+    def test_invalid_value(self):
+        assert _dim_epss({"epss": "not-a-number"}) == 0.0
+
+
+class TestDimCvssBase:
+    def test_perfect_ten(self):
+        assert _dim_cvss_base(_NVD_CVE) == pytest.approx(100.0)
+
+    def test_cvss_7_5(self):
+        nvd = {
+            "metrics": {
+                "cvssMetricV31": [
+                    {
+                        "cvssData": {
+                            "baseScore": 7.5,
+                            "attackVector": "NETWORK",
+                            "attackComplexity": "LOW",
+                            "privilegesRequired": "NONE",
+                            "userInteraction": "NONE",
+                        }
+                    }
+                ]
+            }
+        }
+        assert _dim_cvss_base(nvd) == pytest.approx(75.0)
+
+    def test_fallback_v30(self):
+        nvd = {"metrics": {"cvssMetricV30": [{"cvssData": {"baseScore": 6.0}}]}}
+        assert _dim_cvss_base(nvd) == pytest.approx(60.0)
+
+    def test_missing_metrics(self):
+        assert _dim_cvss_base({}) == 0.0
+
+    def test_empty_metrics(self):
+        assert _dim_cvss_base({"metrics": {}}) == 0.0
+
+
+class TestDimExploitComplexity:
+    def test_log4shell_worst_case(self):
+        # AC=LOW, PR=NONE, UI=NONE → 40+35+25 = 100
+        score = _dim_exploit_complexity(_NVD_CVE)
+        assert score == pytest.approx(100.0)
+
+    def test_high_complexity_no_score(self):
+        nvd = {
+            "metrics": {
+                "cvssMetricV31": [
+                    {
+                        "cvssData": {
+                            "attackComplexity": "HIGH",
+                            "privilegesRequired": "HIGH",
+                            "userInteraction": "REQUIRED",
+                        }
+                    }
+                ]
+            }
+        }
+        assert _dim_exploit_complexity(nvd) == 0.0
+
+    def test_low_pr_contributes(self):
+        nvd = {
+            "metrics": {
+                "cvssMetricV31": [
+                    {
+                        "cvssData": {
+                            "attackComplexity": "HIGH",
+                            "privilegesRequired": "LOW",
+                            "userInteraction": "NONE",
+                        }
+                    }
+                ]
+            }
+        }
+        # AC=HIGH (+0), PR=LOW (+20), UI=NONE (+25) = 45
+        assert _dim_exploit_complexity(nvd) == pytest.approx(45.0)
+
+    def test_missing_metrics(self):
+        assert _dim_exploit_complexity({}) == 0.0
+
+
+class TestDimEpssSpike:
+    def test_spike_detected(self):
+        series = [
+            {"date": f"2024-01-{i:02d}", "epss": v}
+            for i, v in [
+                (1, 0.01),
+                (2, 0.02),
+                (3, 0.03),
+                (8, 0.15),  # +0.12 in 7 days
+            ]
+        ]
+        assert _dim_epss_spike(series) == 100.0
+
+    def test_no_spike(self):
+        series = [{"date": f"2024-01-{i:02d}", "epss": 0.05 + i * 0.001} for i in range(1, 31)]
+        assert _dim_epss_spike(series) == 0.0
+
+    def test_empty_series(self):
+        assert _dim_epss_spike([]) == 0.0
+
+    def test_single_point(self):
+        assert _dim_epss_spike([{"date": "2024-01-01", "epss": 0.9}]) == 0.0
+
+    def test_exactly_threshold_is_spike(self):
+        series = [
+            {"date": "2024-01-01", "epss": 0.05},
+            {"date": "2024-01-08", "epss": 0.16},  # +0.11 > threshold
+        ]
+        assert _dim_epss_spike(series) == 100.0
+
+    def test_just_below_threshold_no_spike(self):
+        series = [
+            {"date": "2024-01-01", "epss": 0.05},
+            {"date": "2024-01-08", "epss": 0.14},  # +0.09 < 0.10
+        ]
+        assert _dim_epss_spike(series) == 0.0
+
+
+class TestDimBlastRadius:
+    def test_5_cpes_returns_40(self):
+        # 5 CPEs → bucket 3–9 → 40
+        assert _dim_blast_radius(_NVD_CVE) == pytest.approx(40.0)
+
+    def test_zero_cpes(self):
+        assert _dim_blast_radius({}) == 0.0
+
+    def test_one_cpe(self):
+        nvd = {"configurations": [{"nodes": [{"cpeMatch": [{"criteria": "cpe:2.3:a:foo:bar:1.0"}]}]}]}
+        assert _dim_blast_radius(nvd) == pytest.approx(20.0)
+
+    def test_thirty_cpes_returns_80(self):
+        nvd = {
+            "configurations": [{"nodes": [{"cpeMatch": [{"criteria": f"cpe:2.3:a:foo:bar:{i}"} for i in range(30)]}]}]
+        }
+        assert _dim_blast_radius(nvd) == pytest.approx(80.0)
+
+    def test_hundred_plus_returns_100(self):
+        nvd = {
+            "configurations": [{"nodes": [{"cpeMatch": [{"criteria": f"cpe:2.3:a:foo:bar:{i}"} for i in range(100)]}]}]
+        }
+        assert _dim_blast_radius(nvd) == pytest.approx(100.0)
+
+    def test_empty_configurations(self):
+        assert _dim_blast_radius({"configurations": []}) == 0.0
+
+
+class TestDimKev:
+    def test_kev_listed_returns_100(self):
+        assert _dim_kev(True) == 100.0
+
+    def test_kev_not_listed_returns_0(self):
+        assert _dim_kev(False) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Unit: composite calculation and risk tiers
+# ---------------------------------------------------------------------------
+
+
+class TestComposite:
+    def test_all_zeros(self):
+        dims = {k: 0.0 for k in _WEIGHTS}
+        assert _compute_composite(dims) == 0.0
+
+    def test_all_hundreds(self):
+        dims = {k: 100.0 for k in _WEIGHTS}
+        assert _compute_composite(dims) == pytest.approx(100.0)
+
+    def test_kev_only(self):
+        dims = {k: 0.0 for k in _WEIGHTS}
+        dims["kev_listed"] = 100.0
+        expected = 100.0 * _WEIGHTS["kev_listed"]
+        assert _compute_composite(dims) == pytest.approx(expected, abs=0.01)
+
+    def test_log4shell_typical(self):
+        dims = {
+            "epss": 97.478,
+            "cvss_base": 100.0,
+            "exploit_complexity": 100.0,
+            "epss_spike": 0.0,
+            "blast_radius": 40.0,
+            "kev_listed": 100.0,
+        }
+        score = _compute_composite(dims)
+        assert 70.0 <= score <= 100.0
+
+
+class TestRiskTier:
+    def test_critical(self):
+        assert _risk_tier(80.0) == "CRITICAL"
+        assert _risk_tier(99.0) == "CRITICAL"
+
+    def test_high(self):
+        assert _risk_tier(60.0) == "HIGH"
+        assert _risk_tier(79.9) == "HIGH"
+
+    def test_medium(self):
+        assert _risk_tier(40.0) == "MEDIUM"
+        assert _risk_tier(59.9) == "MEDIUM"
+
+    def test_low(self):
+        assert _risk_tier(39.9) == "LOW"
+        assert _risk_tier(0.0) == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# Integration: _run_context_score with mocked HTTP
+# ---------------------------------------------------------------------------
+
+
+class TestRunContextScore:
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_log4shell_full_pipeline(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = [{"date": f"2024-01-{i:02d}", "epss": 0.97} for i in range(1, 31)]
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+
+        assert result["cve_id"] == "CVE-2021-44228"
+        assert result["kev_listed"] is True
+        assert result["risk_tier"] in ("CRITICAL", "HIGH")
+        assert result["composite_score"] >= 60.0
+        assert "dominant_factor" in result
+        assert result["confidence"] in ("HIGH", "MEDIUM", "LOW")
+        assert "risk_summary" in result
+        assert result["nvd_available"] is True
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_not_listed_lower_score(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = [{"date": "2024-01-15", "epss": 0.97}]
+        mock_kev.return_value = False  # NOT on KEV
+
+        result = _run_context_score("CVE-2021-44228")
+
+        assert result["kev_listed"] is False
+        # KEV dimension should contribute 0
+        kev_dim = result["dimensions"]["kev_listed"]
+        assert kev_dim["raw_score"] == 0.0
+        assert kev_dim["weighted_contribution"] == 0.0
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_adds_bonus_vs_non_kev(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        """KEV-listed CVE scores higher than identical non-KEV CVE."""
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = [{"date": "2024-01-15", "epss": 0.50}]
+
+        mock_kev.return_value = True
+        result_kev = _run_context_score("CVE-2021-44228")
+
+        mock_kev.return_value = False
+        result_no_kev = _run_context_score("CVE-2021-44228")
+
+        assert result_kev["composite_score"] > result_no_kev["composite_score"]
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_bonus_is_15_points(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        """KEV dimension contributes exactly 15 points (100 × 0.15) when listed."""
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+
+        mock_kev.return_value = True
+        result = _run_context_score("CVE-2021-44228")
+        # All other dims are 0 → composite = 100 × 0.15 = 15.0
+        assert result["composite_score"] == pytest.approx(15.0, abs=0.1)
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_all_sources_unavailable_returns_zero(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+        mock_kev.return_value = False
+
+        result = _run_context_score("CVE-2021-44228")
+
+        assert result["composite_score"] == 0.0
+        assert result["risk_tier"] == "LOW"
+        assert result["confidence"] == "LOW"
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_result_has_all_six_dimensions(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+
+        assert set(result["dimensions"].keys()) == {
+            "epss",
+            "cvss_base",
+            "exploit_complexity",
+            "epss_spike",
+            "blast_radius",
+            "kev_listed",
+        }
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_dominant_factor_is_valid_key(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+        assert result["dominant_factor"] in _WEIGHTS
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_confidence_high_when_4_plus_dims_live(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = [{"date": "2024-01-15", "epss": 0.20}, {"date": "2024-01-22", "epss": 0.35}]
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+        assert result["confidence"] == "HIGH"
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_note_in_risk_summary_when_listed(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+        assert "actively exploited" in result["risk_summary"].lower() or "KEV" in result["risk_summary"]
+
+
+# ---------------------------------------------------------------------------
+# Integration: _render_text
+# ---------------------------------------------------------------------------
+
+
+class TestRenderText:
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_text_output_has_all_sections(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+        text = _render_text(result)
+
+        assert "CVE-2021-44228" in text
+        assert "Composite score" in text
+        assert "Risk tier" in text
+        assert "Dominant factor" in text
+        assert "CISA KEV" in text
+        assert "CISA KEV listing" in text  # dimension row label in table
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_warning_shows_in_text(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        result = _run_context_score("CVE-2021-44228")
+        text = _render_text(result)
+        assert "YES" in text or "actively exploited" in text.lower()
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_kev_not_listed_shows_in_text(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+        mock_kev.return_value = False
+
+        result = _run_context_score("CVE-2021-44228")
+        text = _render_text(result)
+        assert "not listed" in text
+
+
+# ---------------------------------------------------------------------------
+# Integration: score_context_score Strands entry point
+# ---------------------------------------------------------------------------
+
+
+class TestScoreContextScoreTool:
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_text_output_default(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        text = score_context_score("CVE-2021-44228")
+        assert "CVE-2021-44228" in text
+        assert "Risk tier" in text
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_json_output(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = False
+
+        text = score_context_score("CVE-2021-44228", output="json")
+        data = json.loads(text)
+        assert data["cve_id"] == "CVE-2021-44228"
+        assert "composite_score" in data
+        assert "risk_tier" in data
+        assert "kev_listed" in data
+        assert data["kev_listed"] is False
+
+    def test_invalid_cve_returns_error(self):
+        result = score_context_score("NOT-A-CVE")
+        assert "Error" in result
+
+    def test_empty_string_returns_error(self):
+        result = score_context_score("")
+        assert "Error" in result
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_case_insensitive_cve_id(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = False
+
+        text = score_context_score("cve-2021-44228")
+        assert "CVE-2021-44228" in text
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_score_is_higher_with_kev(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        """Verify KEV listing raises the composite score."""
+        mock_nvd.return_value = {}
+        mock_epss.return_value = {}
+        mock_series.return_value = []
+
+        mock_kev.return_value = True
+        kev_text = score_context_score("CVE-2021-44228", output="json")
+        kev_score = json.loads(kev_text)["composite_score"]
+
+        mock_kev.return_value = False
+        no_kev_text = score_context_score("CVE-2021-44228", output="json")
+        no_kev_score = json.loads(no_kev_text)["composite_score"]
+
+        assert kev_score > no_kev_score
+
+    @patch("manus_agent.tools.score_context_score._fetch_kev")
+    @patch("manus_agent.tools.score_context_score._fetch_epss_series")
+    @patch("manus_agent.tools.score_context_score._fetch_epss")
+    @patch("manus_agent.tools.score_context_score._fetch_nvd")
+    def test_json_has_dimensions_with_weighted_contribution(self, mock_nvd, mock_epss, mock_series, mock_kev):
+        mock_nvd.return_value = _NVD_CVE
+        mock_epss.return_value = _EPSS_ROW
+        mock_series.return_value = []
+        mock_kev.return_value = True
+
+        data = json.loads(score_context_score("CVE-2021-44228", output="json"))
+        for dim in ("epss", "cvss_base", "exploit_complexity", "epss_spike", "blast_radius", "kev_listed"):
+            assert dim in data["dimensions"]
+            d = data["dimensions"][dim]
+            assert "raw_score" in d
+            assert "weight" in d
+            assert "weighted_contribution" in d
+
+
+# ---------------------------------------------------------------------------
+# Unit: TOOL_SPEC schema
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    def test_tool_spec_importable(self):
+        from manus_agent.tools.score_context_score import TOOL_SPEC
+
+        assert TOOL_SPEC["name"] == "score_context_score"
+        assert "kev" in TOOL_SPEC["description"].lower()
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert "cve_id" in schema["properties"]
+        assert "output" in schema["properties"]
+        assert "weights" in schema["properties"]


### PR DESCRIPTION
Adds `score_context_score` Strands tool and `manus-agent risk-score CVE-XXXX-YYYY` CLI subcommand: composite contextual risk score (0–100) from six weighted dimensions.

## Six dimensions

| Dimension | Weight | Signal |
|-----------|--------|--------|
| `epss` | 0.25 | FIRST.org EPSS probability × 100 |
| `cvss_base` | 0.20 | NVD CVSS v3 base score / 10 × 100 |
| `exploit_complexity` | 0.15 | Attacker-friendliness from NVD CVSS vector (AC + PR + UI) |
| `epss_spike` | 0.10 | Binary: +100 if ≥0.10 EPSS jump in last 30 days |
| `blast_radius` | 0.15 | CPE config count → five-bucket score (0/20/40/60/80/100) |
| `kev_listed` | 0.15 | **Hard +15 bonus** when CVE is on CISA KEV catalogue |

The KEV dimension is the key addition: a CVE being actively exploited in the wild is never under-rated regardless of EPSS or CVSS alone.

## Risk tiers
- CRITICAL ≥80 — drop everything
- HIGH ≥60 — schedule within hours/days
- MEDIUM ≥40 — normal cadence
- LOW <40 — monitor

## Output fields
`composite_score`, `risk_tier`, `dominant_factor`, `confidence` (HIGH/MEDIUM/LOW based on live data sources), `risk_summary` (one-sentence verdict), `kev_listed`, full per-dimension breakdown.

## CLI
```bash
manus-agent risk-score CVE-2021-44228
manus-agent risk-score CVE-2024-3094 --output json
manus-agent risk-score CVE-2024-3094 --weights '{"kev_listed":0.30}'
```

## vi_agent
`score_context_score` registered in tool list + Step 6d added to system prompt (score ≥80 → CRITICAL → highest-priority escalation).

## Tests
59 new unit tests (all HTTP mocked, CVE-2021-44228/Log4Shell fixtures). KEV bonus arithmetic verified: `kev_only → 15.0 pts`, `kev_listed=True > kev_listed=False`. **Total: 961 passing (was 902), 0 failures, ruff clean.**