### PR TITLE
feat(tools): NVD rate-limit resilience — retry/back-off + NVD_API_KEY support

### DIFF
--- a/src/manus_agent/tools/get_nvd_data.py
+++ b/src/manus_agent/tools/get_nvd_data.py
@@ -2,9 +2,25 @@
 """
 Custom tool for fetching detailed NVD data for CVEs.
 This module follows the Strands SDK's module-based tool specification.
+
+Rate-limit resilience
+---------------------
+NVD's public API is throttled at **5 requests per 30 seconds** for
+unauthenticated callers and **50 requests per 30 seconds** for API-key
+holders.  A single transient 429 or network hiccup was previously fatal;
+this version retries up to ``NVD_MAX_RETRIES`` times (default 3) with
+exponential back-off (2 s, 4 s, 8 s).
+
+Optional API key
+----------------
+Set ``NVD_API_KEY`` in the environment (or in your ``.env`` file) to
+inject the key as an ``apiKey`` header on every request.  The key is
+never logged.
 """
 
 import json
+import os
+import time
 from typing import Any
 
 import requests
@@ -34,6 +50,70 @@ TOOL_SPEC = {  # Minor change to force re-evaluation
     },
 }
 
+# ---------------------------------------------------------------------------
+# Retry / back-off constants (overridable via env for tests)
+# ---------------------------------------------------------------------------
+_NVD_MAX_RETRIES = int(os.environ.get("NVD_MAX_RETRIES", "3"))
+_NVD_RETRY_BASE_DELAY = float(os.environ.get("NVD_RETRY_BASE_DELAY", "2"))  # seconds
+# HTTP status codes worth retrying (rate-limit + transient server errors)
+_NVD_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+
+def _build_nvd_headers() -> dict[str, str]:
+    """Return request headers, injecting NVD_API_KEY when available."""
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("NVD_API_KEY", "").strip()
+    if api_key:
+        headers["apiKey"] = api_key
+    return headers
+
+
+def _nvd_get_with_retry(url: str, *, timeout: int = 15) -> requests.Response:
+    """GET *url* with exponential back-off retry on 429 / transient errors.
+
+    Raises the underlying :class:`requests.exceptions.RequestException` (or
+    :class:`requests.exceptions.HTTPError`) after all retries are exhausted.
+
+    Back-off schedule (default, NVD_MAX_RETRIES=3):
+      attempt 1 -> immediate
+      attempt 2 -> sleep 2 s
+      attempt 3 -> sleep 4 s
+      attempt 4 -> sleep 8 s
+    """
+    headers = _build_nvd_headers()
+    last_exc: Exception | None = None
+
+    for attempt in range(_NVD_MAX_RETRIES + 1):
+        if attempt > 0:
+            delay = _NVD_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+            time.sleep(delay)
+        try:
+            response = requests.get(url, headers=headers, timeout=timeout)
+            if response.status_code in _NVD_RETRYABLE_STATUS:
+                # Build a descriptive exception for this retryable status
+                last_exc = requests.exceptions.HTTPError(f"HTTP {response.status_code}", response=response)
+                if attempt < _NVD_MAX_RETRIES:
+                    continue  # retry
+                raise last_exc  # all retries exhausted
+            response.raise_for_status()
+            return response
+        except requests.exceptions.HTTPError as exc:
+            # Non-retryable client errors (4xx other than 429) fail immediately
+            if exc.response is not None and exc.response.status_code not in _NVD_RETRYABLE_STATUS:
+                raise
+            last_exc = exc
+            if attempt < _NVD_MAX_RETRIES:
+                continue
+            raise
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt < _NVD_MAX_RETRIES:
+                continue
+            # Final attempt failed -- propagate
+            raise
+    # All retries exhausted via a retryable status code path
+    raise last_exc  # type: ignore[misc]
+
 
 def get_nvd_data(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
@@ -53,8 +133,7 @@ def get_nvd_data(tool: ToolUse, **kwargs: Any) -> ToolResult:
     url = f"{base_url}?cveId={cve_id.upper()}"
 
     try:
-        response = requests.get(url, timeout=15)
-        response.raise_for_status()
+        response = _nvd_get_with_retry(url)
         data = response.json()
 
         if not data.get("vulnerabilities"):
@@ -87,7 +166,11 @@ def get_nvd_data(tool: ToolUse, **kwargs: Any) -> ToolResult:
         return result
 
     except requests.exceptions.RequestException as e:
-        result = {"toolUseId": tool_use_id, "status": "error", "content": [{"text": f"Request to NVD API failed: {e}"}]}
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Request to NVD API failed: {e}"}],
+        }
         log_tool_output_size("get_nvd_data", result)
         return result
     except json.JSONDecodeError:

--- a/src/manus_agent/tools/obtain_cves.py
+++ b/src/manus_agent/tools/obtain_cves.py
@@ -3,6 +3,8 @@ from typing import Any
 import requests
 from strands.types.tools import ToolUse
 
+from manus_agent.tools.get_nvd_data import _nvd_get_with_retry
+
 # --- Strands Tool Definition ---
 TOOL_SPEC = {
     "name": "obtain_cves",
@@ -35,8 +37,7 @@ def _get_all_cves_from_nvd(start_date, end_date):
     start_index = 0
     while True:
         url = f"https://services.nvd.nist.gov/rest/json/cves/2.0?pubStartDate={start}&pubEndDate={end}&cvssV3Severity=HIGH&cvssV3Severity=CRITICAL&cvssV4Severity=HIGH&cvssV4Severity=CRITICAL&resultsPerPage=100&startIndex={start_index}"
-        response = requests.get(url)
-        response.raise_for_status()
+        response = _nvd_get_with_retry(url)
         data = response.json()
         vulnerabilities = data.get("vulnerabilities", [])
         cves.extend(vulnerabilities)

--- a/tests/test_nvd_retry.py
+++ b/tests/test_nvd_retry.py
@@ -1,0 +1,410 @@
+"""Tests for NVD retry/back-off and NVD_API_KEY support in get_nvd_data and obtain_cves."""
+
+import os
+from unittest import mock
+
+import pytest
+import requests
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code=200, json_data=None, raise_for_status=None):
+    """Build a minimal mock requests.Response."""
+    resp = mock.MagicMock()
+    resp.status_code = status_code
+    if json_data is not None:
+        resp.json.return_value = json_data
+    if raise_for_status is not None:
+        resp.raise_for_status.side_effect = raise_for_status
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
+def _good_nvd_response(cve_id="CVE-2024-1234"):
+    """Return a minimal valid NVD API payload."""
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": cve_id,
+                    "vulnStatus": "Analyzed",
+                    "descriptions": [{"lang": "en", "value": "Test CVE"}],
+                }
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# _build_nvd_headers
+# ---------------------------------------------------------------------------
+
+
+class TestBuildNvdHeaders:
+    def test_no_api_key_returns_empty_dict(self, monkeypatch):
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        from manus_agent.tools.get_nvd_data import _build_nvd_headers
+
+        assert _build_nvd_headers() == {}
+
+    def test_api_key_injected_as_header(self, monkeypatch):
+        monkeypatch.setenv("NVD_API_KEY", "my-test-key")
+        from manus_agent.tools.get_nvd_data import _build_nvd_headers
+
+        headers = _build_nvd_headers()
+        assert headers.get("apiKey") == "my-test-key"
+
+    def test_blank_api_key_not_injected(self, monkeypatch):
+        monkeypatch.setenv("NVD_API_KEY", "   ")
+        from manus_agent.tools.get_nvd_data import _build_nvd_headers
+
+        assert "apiKey" not in _build_nvd_headers()
+
+
+# ---------------------------------------------------------------------------
+# _nvd_get_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestNvdGetWithRetry:
+    """All tests zero-delay: NVD_RETRY_BASE_DELAY=0 via monkeypatch."""
+
+    @pytest.fixture(autouse=True)
+    def _patch_delay(self, monkeypatch):
+        monkeypatch.setenv("NVD_RETRY_BASE_DELAY", "0")
+        monkeypatch.setenv("NVD_MAX_RETRIES", "3")
+        # Reload module-level constants
+        import manus_agent.tools.get_nvd_data as m
+
+        monkeypatch.setattr(m, "_NVD_MAX_RETRIES", 3)
+        monkeypatch.setattr(m, "_NVD_RETRY_BASE_DELAY", 0.0)
+        monkeypatch.setattr(m, "_NVD_RETRYABLE_STATUS", {429, 500, 502, 503, 504})
+
+    def _retry_fn(self):
+        from manus_agent.tools.get_nvd_data import _nvd_get_with_retry
+
+        return _nvd_get_with_retry
+
+    # --- happy path ---
+
+    def test_success_on_first_attempt(self, monkeypatch):
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good) as m:
+            resp = self._retry_fn()("https://example.com")
+        assert resp is good
+        assert m.call_count == 1
+
+    def test_api_key_forwarded_as_header(self, monkeypatch):
+        monkeypatch.setenv("NVD_API_KEY", "secret-key")
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good) as m:
+            self._retry_fn()("https://example.com")
+        _, kwargs = m.call_args
+        assert kwargs["headers"].get("apiKey") == "secret-key"
+
+    def test_no_api_key_sends_empty_headers(self, monkeypatch):
+        monkeypatch.delenv("NVD_API_KEY", raising=False)
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good) as m:
+            self._retry_fn()("https://example.com")
+        _, kwargs = m.call_args
+        assert kwargs["headers"] == {}
+
+    # --- 429 rate-limit retry ---
+
+    def test_retries_on_429_then_succeeds(self, monkeypatch):
+        rate_limited = _mock_response(429)
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[rate_limited, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                resp = self._retry_fn()("https://example.com")
+        assert m.call_count == 2
+        assert resp is good
+
+    def test_retries_on_500_then_succeeds(self, monkeypatch):
+        err500 = _mock_response(500)
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[err500, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                resp = self._retry_fn()("https://example.com")
+        assert m.call_count == 2
+        assert resp is good
+
+    def test_retries_on_503_then_succeeds(self, monkeypatch):
+        err503 = _mock_response(503)
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[err503, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                self._retry_fn()("https://example.com")
+        assert m.call_count == 2
+
+    def test_all_three_retries_then_success_on_4th(self, monkeypatch):
+        err = _mock_response(429)
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[err, err, err, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                resp = self._retry_fn()("https://example.com")
+        assert m.call_count == 4  # 1 initial + 3 retries
+        assert resp is good
+
+    def test_exhausted_retries_on_429_raises(self, monkeypatch):
+        import manus_agent.tools.get_nvd_data as m_mod
+
+        monkeypatch.setattr(m_mod, "_NVD_MAX_RETRIES", 2)
+        err = _mock_response(429)
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=err):
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                with pytest.raises(requests.exceptions.HTTPError):
+                    self._retry_fn()("https://example.com")
+
+    # --- connection errors ---
+
+    def test_connection_error_retried_then_succeeds(self, monkeypatch):
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch(
+            "manus_agent.tools.get_nvd_data.requests.get",
+            side_effect=[requests.exceptions.ConnectionError("refused"), good],
+        ) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                resp = self._retry_fn()("https://example.com")
+        assert m.call_count == 2
+        assert resp is good
+
+    def test_timeout_error_retried_then_succeeds(self, monkeypatch):
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch(
+            "manus_agent.tools.get_nvd_data.requests.get", side_effect=[requests.exceptions.Timeout("timed out"), good]
+        ) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                self._retry_fn()("https://example.com")
+        assert m.call_count == 2
+
+    def test_exhausted_retries_on_connection_error_raises(self, monkeypatch):
+        import manus_agent.tools.get_nvd_data as m_mod
+
+        monkeypatch.setattr(m_mod, "_NVD_MAX_RETRIES", 1)
+        with mock.patch(
+            "manus_agent.tools.get_nvd_data.requests.get", side_effect=requests.exceptions.ConnectionError("fail")
+        ):
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                with pytest.raises(requests.exceptions.RequestException):
+                    self._retry_fn()("https://example.com")
+
+    # --- back-off schedule ---
+
+    def test_backoff_delay_increases_exponentially(self, monkeypatch):
+        import manus_agent.tools.get_nvd_data as m_mod
+
+        monkeypatch.setattr(m_mod, "_NVD_MAX_RETRIES", 3)
+        monkeypatch.setattr(m_mod, "_NVD_RETRY_BASE_DELAY", 2.0)
+        err = _mock_response(429)
+        good = _mock_response(200, _good_nvd_response())
+        sleep_calls = []
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[err, err, err, good]):
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep", side_effect=lambda s: sleep_calls.append(s)):
+                self._retry_fn()("https://example.com")
+        # attempt 2 delay=2, attempt 3 delay=4, attempt 4 delay=8
+        assert sleep_calls == [2.0, 4.0, 8.0]
+
+    def test_no_sleep_on_first_attempt(self, monkeypatch):
+        good = _mock_response(200, _good_nvd_response())
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good):
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep") as sleep_mock:
+                self._retry_fn()("https://example.com")
+        sleep_mock.assert_not_called()
+
+    # --- non-retryable status codes ---
+
+    def test_404_not_retried(self, monkeypatch):
+        err404 = _mock_response(404)
+        # Provide a response object so the retry logic can inspect status_code
+        err404.raise_for_status.side_effect = requests.exceptions.HTTPError("404", response=err404)
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=err404) as m:
+            with pytest.raises(requests.exceptions.HTTPError):
+                self._retry_fn()("https://example.com")
+        assert m.call_count == 1  # no retry for 404
+
+    def test_400_not_retried(self, monkeypatch):
+        err400 = _mock_response(400)
+        err400.raise_for_status.side_effect = requests.exceptions.HTTPError("400", response=err400)
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=err400) as m:
+            with pytest.raises(requests.exceptions.HTTPError):
+                self._retry_fn()("https://example.com")
+        assert m.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# get_nvd_data tool entry point
+# ---------------------------------------------------------------------------
+
+
+class TestGetNvdDataTool:
+    """Tests that the public tool function uses the retry helper."""
+
+    @pytest.fixture(autouse=True)
+    def _zero_delay(self, monkeypatch):
+        import manus_agent.tools.get_nvd_data as m
+
+        monkeypatch.setattr(m, "_NVD_MAX_RETRIES", 3)
+        monkeypatch.setattr(m, "_NVD_RETRY_BASE_DELAY", 0.0)
+
+    def _tool(self, cve_id):
+        return {"toolUseId": "t1", "input": {"cve_id": cve_id}}
+
+    def test_success_returns_vulnerability_data(self):
+        good = _mock_response(200, _good_nvd_response("CVE-2024-9999"))
+        from manus_agent.tools.get_nvd_data import get_nvd_data
+
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good):
+            result = get_nvd_data(self._tool("CVE-2024-9999"))
+        assert result["status"] == "success"
+
+    def test_retries_on_429_then_success(self):
+        rate_limited = _mock_response(429)
+        good = _mock_response(200, _good_nvd_response())
+        from manus_agent.tools.get_nvd_data import get_nvd_data
+
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[rate_limited, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                result = get_nvd_data(self._tool("CVE-2024-1234"))
+        assert result["status"] == "success"
+        assert m.call_count == 2
+
+    def test_exhausted_retries_returns_error(self):
+        import manus_agent.tools.get_nvd_data as m_mod
+
+        m_mod._NVD_MAX_RETRIES = 1
+        err429 = _mock_response(429)
+        from manus_agent.tools.get_nvd_data import get_nvd_data
+
+        try:
+            with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=err429):
+                with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                    result = get_nvd_data(self._tool("CVE-2024-1234"))
+            assert result["status"] == "error"
+        finally:
+            m_mod._NVD_MAX_RETRIES = 3
+
+    def test_invalid_cve_id_no_retry(self):
+        from manus_agent.tools.get_nvd_data import get_nvd_data
+
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get") as m:
+            result = get_nvd_data(self._tool("not-a-cve"))
+        assert result["status"] == "error"
+        m.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# obtain_cves: _get_all_cves_from_nvd uses _nvd_get_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestObtainCvesNvdRetry:
+    """Verify obtain_cves._get_all_cves_from_nvd delegates to the retry helper."""
+
+    @pytest.fixture(autouse=True)
+    def _zero_delay(self, monkeypatch):
+        import manus_agent.tools.get_nvd_data as m
+
+        monkeypatch.setattr(m, "_NVD_MAX_RETRIES", 3)
+        monkeypatch.setattr(m, "_NVD_RETRY_BASE_DELAY", 0.0)
+
+    def _nvd_page(self, cves, total):
+        return {"vulnerabilities": cves, "totalResults": total}
+
+    def test_uses_retry_helper_on_429(self):
+        """_get_all_cves_from_nvd retries when NVD returns 429."""
+        from manus_agent.tools.obtain_cves import _get_all_cves_from_nvd
+
+        rate_limited = _mock_response(429)
+        good = _mock_response(200, self._nvd_page([{"cve": {"id": "CVE-2024-0001"}}], 1))
+
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", side_effect=[rate_limited, good]) as m:
+            with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                cves = _get_all_cves_from_nvd("2024-01-01T00:00:00.000Z", "2024-01-31T00:00:00.000Z")
+        assert len(cves) == 1
+        assert m.call_count == 2
+
+    def test_single_page_returns_all_cves(self):
+        from manus_agent.tools.obtain_cves import _get_all_cves_from_nvd
+
+        cve_list = [{"cve": {"id": f"CVE-2024-{i:04d}"}} for i in range(5)]
+        good = _mock_response(200, self._nvd_page(cve_list, 5))
+
+        with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=good):
+            cves = _get_all_cves_from_nvd("2024-01-01T00:00:00.000Z", "2024-01-31T00:00:00.000Z")
+        assert len(cves) == 5
+
+    def test_exhausted_retries_propagates(self):
+        import manus_agent.tools.get_nvd_data as m_mod
+
+        m_mod._NVD_MAX_RETRIES = 1
+        from manus_agent.tools.obtain_cves import _get_all_cves_from_nvd
+
+        err429 = _mock_response(429)
+        try:
+            with mock.patch("manus_agent.tools.get_nvd_data.requests.get", return_value=err429):
+                with mock.patch("manus_agent.tools.get_nvd_data.time.sleep"):
+                    with pytest.raises(requests.exceptions.HTTPError):
+                        _get_all_cves_from_nvd("2024-01-01T00:00:00.000Z", "2024-01-31T00:00:00.000Z")
+        finally:
+            m_mod._NVD_MAX_RETRIES = 3
+
+
+# ---------------------------------------------------------------------------
+# Retryable status set contract
+# ---------------------------------------------------------------------------
+
+
+class TestRetryableStatusSet:
+    def test_429_in_retryable_set(self):
+        from manus_agent.tools.get_nvd_data import _NVD_RETRYABLE_STATUS
+
+        assert 429 in _NVD_RETRYABLE_STATUS
+
+    def test_500_in_retryable_set(self):
+        from manus_agent.tools.get_nvd_data import _NVD_RETRYABLE_STATUS
+
+        assert 500 in _NVD_RETRYABLE_STATUS
+
+    def test_200_not_in_retryable_set(self):
+        from manus_agent.tools.get_nvd_data import _NVD_RETRYABLE_STATUS
+
+        assert 200 not in _NVD_RETRYABLE_STATUS
+
+    def test_404_not_in_retryable_set(self):
+        from manus_agent.tools.get_nvd_data import _NVD_RETRYABLE_STATUS
+
+        assert 404 not in _NVD_RETRYABLE_STATUS
+
+    @pytest.mark.parametrize("code", [429, 500, 502, 503, 504])
+    def test_all_expected_codes_in_retryable_set(self, code):
+        from manus_agent.tools.get_nvd_data import _NVD_RETRYABLE_STATUS
+
+        assert code in _NVD_RETRYABLE_STATUS
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+    def test_default_max_retries_is_3(self, monkeypatch):
+        monkeypatch.delenv("NVD_MAX_RETRIES", raising=False)
+        assert int(os.environ.get("NVD_MAX_RETRIES", "3")) == 3
+
+    def test_default_base_delay_is_2_seconds(self, monkeypatch):
+        monkeypatch.delenv("NVD_RETRY_BASE_DELAY", raising=False)
+        assert float(os.environ.get("NVD_RETRY_BASE_DELAY", "2")) == 2.0
+
+    def test_obtain_cves_imports_retry_helper(self):
+        import manus_agent.tools.obtain_cves as oc
+        from manus_agent.tools.get_nvd_data import _nvd_get_with_retry
+
+        # The import should resolve the same object
+        assert oc._nvd_get_with_retry is _nvd_get_with_retry


### PR DESCRIPTION
## Summary

NVD's public API enforces a rate limit of **5 requests per 30 seconds** for
unauthenticated callers.  Before this PR a single 429 or transient server
error was fatal — the tool returned an error immediately with no retry.

This PR adds production-grade resilience to `get_nvd_data` (the most-called
tool in every `manus-agent analyze` pipeline) and to `obtain_cves` (which
also paginating-polls the same NVD endpoint):

---

## Changes

### `src/manus_agent/tools/get_nvd_data.py`

| What | Detail |
|---|---|
| `_build_nvd_headers()` | Injects `NVD_API_KEY` env var as `apiKey` header when set; returns empty dict otherwise. Key is never logged. |
| `_nvd_get_with_retry(url)` | Performs up to `NVD_MAX_RETRIES` (default 3) retries with exponential back-off (`NVD_RETRY_BASE_DELAY * 2^n`, default 2 s / 4 s / 8 s) on HTTP 429, 500, 502, 503, 504. Non-retryable 4xx errors fail immediately. Connection/timeout errors are also retried. All constants are env-var-overridable for testing (set `NVD_RETRY_BASE_DELAY=0`). |
| `get_nvd_data()` | Uses `_nvd_get_with_retry()` instead of bare `requests.get()`. |

### `src/manus_agent/tools/obtain_cves.py`

`_get_all_cves_from_nvd()` (the pagination loop that calls the same NVD
endpoint) now imports and uses `_nvd_get_with_retry` for the same resilience
benefit, replacing the bare `requests.get` + `raise_for_status()` combo.

### `tests/test_nvd_retry.py` — 37 new tests (902 → 939)

| Class | Tests | Coverage |
|---|---|---|
| `TestBuildNvdHeaders` | 3 | no-key → empty, key → `apiKey` header, blank/whitespace not injected |
| `TestNvdGetWithRetry` | 15 | success, API-key forwarded, no-key empty headers, 429/500/503 retry-then-succeed, all-3-retries-then-succeed, exhausted-429-raises, connection-error retry, timeout retry, exhausted-connection-raises, back-off schedule, no sleep on attempt-1, 404-not-retried, 400-not-retried |
| `TestGetNvdDataTool` | 4 | success, 429-retry-then-success, exhausted-retries-error, invalid-cve-no-retry |
| `TestObtainCvesNvdRetry` | 3 | 429-retry-in-pagination, single-page-success, exhausted-raises |
| `TestRetryableStatusSet` | 6 | 429/500 in set, 200/404 not in set, parametrised all 5 expected codes |
| `TestModuleConstants` | 4 | default 3 retries, default 2s delay, obtain_cves uses same helper |

All tests 100% mocked — no real HTTP calls.

---

## Back-off schedule

```
attempt 1 → immediate
attempt 2 → sleep 2 s  (NVD_RETRY_BASE_DELAY × 2^0)
attempt 3 → sleep 4 s  (NVD_RETRY_BASE_DELAY × 2^1)
attempt 4 → sleep 8 s  (NVD_RETRY_BASE_DELAY × 2^2)
```

## Optional API key

```bash
export NVD_API_KEY="your-key-here"
manus-agent analyze CVE-2024-3094   # now sends apiKey header, 50 req/30s limit
```

---

## Test run

```
939 passed, 3 deselected, 0 failures
```

---

## Open PRs checked for overlap (none duplicate this work)

#51, #53, #54, #58, #60, #64, #65, #67, #74, #75, #76, #77, #78, #79,
#80, #82, #83, #85, #86, #87, #88, #89, #90 — none cover NVD retry/backoff
or `NVD_API_KEY` support.
