### PR TITLE
feat(tools): add first_release_date to _enrich_maven via Maven Central GAV index

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -13,7 +13,8 @@ Data sources (all free, no API key required):
   4. npm registry API  — dependents count + weekly download stats (npm only)
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
-  6. Maven Central     — artifact metadata + version count (Maven only)
+  6. Maven Central     — artifact metadata + version count + first-release date
+                         (Maven only; age-of-library risk signal via GAV core)
 
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
@@ -24,6 +25,7 @@ CLI: ``manus-agent blast-radius requests@2.28.0``
 
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 from typing import Any
@@ -51,6 +53,7 @@ _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+_MAVEN_GAV_URL = "https://search.maven.org/solrsearch/select"  # same endpoint, GAV core
 
 _TIMEOUT = 20
 
@@ -348,15 +351,58 @@ def _enrich_pypi(name: str) -> dict[str, Any]:
     return result
 
 
+def _fetch_maven_first_release(group_id: str, artifact_id: str) -> dict[str, Any]:
+    """
+    Fetch the earliest-published version of a Maven artifact from Maven Central.
+
+    Uses the ``gav`` (group-artifact-version) core to retrieve per-version
+    timestamps, then returns the version with the smallest timestamp together
+    with a formatted date string and the library's age in years.
+
+    Returns a dict with keys ``first_version``, ``first_release_date``, and
+    ``age_years``, or an empty dict on failure / no data.
+    """
+    try:
+        query = f"g:{group_id} AND a:{artifact_id}"
+        # Fetch up to 200 versions — enough for any real artifact
+        data = _get(
+            _MAVEN_GAV_URL,
+            params={"q": query, "core": "gav", "rows": 200, "wt": "json"},
+        )
+        docs = data.get("response", {}).get("docs", [])
+        if not docs:
+            return {}
+        # Find the doc with the smallest timestamp
+        oldest = min(docs, key=lambda d: d.get("timestamp", float("inf")))
+        ts_ms = oldest.get("timestamp")
+        if ts_ms is None:
+            return {}
+        ts_s = int(ts_ms) // 1000
+        dt = datetime.datetime.fromtimestamp(ts_s, tz=datetime.timezone.utc)
+        age_days = (datetime.datetime.now(tz=datetime.timezone.utc) - dt).days
+        age_years = round(age_days / 365.25, 1)
+        return {
+            "first_version": oldest.get("v", ""),
+            "first_release_date": dt.strftime("%Y-%m-%d"),
+            "age_years": age_years,
+        }
+    except Exception as exc:
+        logger.debug("Maven first-release lookup failed for %s:%s: %s", group_id, artifact_id, exc)
+        return {}
+
+
 def _enrich_maven(name: str) -> dict[str, Any]:
-    """Fetch Maven Central artifact metadata."""
+    """Fetch Maven Central artifact metadata including first-release date."""
     result: dict[str, Any] = {"ecosystem": "Maven", "package_name": name}
+    group_id = ""
+    artifact_id = ""
     try:
         # Accept both 'groupId:artifactId' and plain 'artifactId' forms
         if ":" in name:
             g, a = name.split(":", 1)
             query = f"g:{g} AND a:{a}"
         else:
+            g, a = "", name
             query = f"a:{name}"
         data = _get(_MAVEN_SEARCH_URL, params={"q": query, "rows": 5, "wt": "json"})
         docs = data.get("response", {}).get("docs", [])
@@ -364,12 +410,20 @@ def _enrich_maven(name: str) -> dict[str, Any]:
             doc = docs[0]
             result["latest_version"] = doc.get("latestVersion", "")
             result["version_count"] = doc.get("versionCount", 0)
-            result["group_id"] = doc.get("g", "")
-            result["artifact_id"] = doc.get("a", "")
+            group_id = doc.get("g", g)
+            artifact_id = doc.get("a", a)
+            result["group_id"] = group_id
+            result["artifact_id"] = artifact_id
             result["full_id"] = doc.get("id", name)
         result["total_artifacts_found"] = data.get("response", {}).get("numFound", 0)
     except Exception as exc:
         logger.debug("Maven enrich failed for %s: %s", name, exc)
+
+    # Fetch first-release date when we have both group and artifact IDs
+    if group_id and artifact_id:
+        first = _fetch_maven_first_release(group_id, artifact_id)
+        result.update(first)
+
     return result
 
 
@@ -432,7 +486,8 @@ def get_dependency_blast_radius(  # noqa: C901
     2. For each affected package, fetches downstream exposure metrics:
        - **npm**: dependent package count + weekly/monthly download stats
        - **PyPI**: package metadata + download stats (when pypistats is available)
-       - **Maven**: artifact metadata from Maven Central
+       - **Maven**: artifact metadata, version count, and first-release date
+         (age-of-library signal from Maven Central GAV index)
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
 
     Use after ``get_nvd_data`` to understand *how many projects are exposed*
@@ -558,6 +613,11 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("version_count"):
                 lines.append(f"    Version count:    {r['version_count']}")
+            if r.get("first_release_date"):
+                age_str = f"  ({r['age_years']} yrs old)" if r.get("age_years") is not None else ""
+                lines.append(f"    First released:   {r['first_release_date']}{age_str}")
+            if r.get("first_version"):
+                lines.append(f"    First version:    {r['first_version']}")
 
         if source:
             lines.append(f"    Data sources:     {source}")

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -19,6 +19,7 @@ from manus_agent.tools.get_dependency_blast_radius import (
     _enrich_package,
     _enrich_pypi,
     _fetch_ghsa_affected,
+    _fetch_maven_first_release,
     _fetch_nvd_affected,
     _fetch_osv_affected,
     _parse_input,
@@ -634,6 +635,157 @@ class TestEnrichMaven:
         with patch("requests.get", return_value=mock_resp):
             result = _enrich_maven("nonexistent-lib")
         assert result["total_artifacts_found"] == 0
+
+    def test_enrich_maven_includes_first_release_date_when_ids_found(self):
+        """_enrich_maven should call _fetch_maven_first_release when group+artifact resolved."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_maven_response("org.apache.logging.log4j", "log4j-core", "2.20.0")
+        first_release_data = {
+            "first_version": "2.0-alpha1",
+            "first_release_date": "2012-07-29",
+            "age_years": 12.0,
+        }
+        with patch("requests.get", return_value=search_resp):
+            with patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_maven_first_release",
+                return_value=first_release_data,
+            ) as mock_first:
+                result = _enrich_maven("org.apache.logging.log4j:log4j-core")
+        mock_first.assert_called_once_with("org.apache.logging.log4j", "log4j-core")
+        assert result["first_release_date"] == "2012-07-29"
+        assert result["first_version"] == "2.0-alpha1"
+        assert result["age_years"] == 12.0
+
+    def test_enrich_maven_no_first_release_when_no_group(self):
+        """_enrich_maven should NOT call _fetch_maven_first_release when search returns no docs."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"response": {"numFound": 0, "docs": []}}
+        with patch("requests.get", return_value=mock_resp):
+            with patch("manus_agent.tools.get_dependency_blast_radius._fetch_maven_first_release") as mock_first:
+                result = _enrich_maven("no-such-artifact")
+        mock_first.assert_not_called()
+        assert "first_release_date" not in result
+
+    def test_enrich_maven_first_release_failure_is_silent(self):
+        """If _fetch_maven_first_release fails, result still has core metadata."""
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_maven_response("com.example", "mylib", "3.0.0")
+        with patch("requests.get", return_value=search_resp):
+            with patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_maven_first_release",
+                return_value={},
+            ):
+                result = _enrich_maven("com.example:mylib")
+        assert result["latest_version"] == "3.0.0"
+        assert "first_release_date" not in result
+
+
+# ===========================================================================
+# _fetch_maven_first_release
+# ===========================================================================
+
+
+class TestFetchMavenFirstRelease:
+    """Tests for _fetch_maven_first_release — all HTTP calls mocked."""
+
+    def _make_gav_response(self, docs: list[dict]) -> dict:
+        return {"response": {"numFound": len(docs), "docs": docs}}
+
+    def test_returns_oldest_version_by_timestamp(self):
+        # Three versions with different timestamps; 2012 entry is oldest
+        docs = [
+            {"v": "2.20.0", "g": "org.apache.logging.log4j", "a": "log4j-core", "timestamp": 1700000000000},
+            {"v": "2.0-alpha1", "g": "org.apache.logging.log4j", "a": "log4j-core", "timestamp": 1343589186000},
+            {"v": "2.14.1", "g": "org.apache.logging.log4j", "a": "log4j-core", "timestamp": 1630000000000},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response(docs)
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("org.apache.logging.log4j", "log4j-core")
+        assert result["first_version"] == "2.0-alpha1"
+        # 2012-07-29 in UTC
+        assert result["first_release_date"] == "2012-07-29"
+        assert isinstance(result["age_years"], float)
+        assert result["age_years"] > 10  # log4j has been around > 10 years
+
+    def test_single_version_is_also_first(self):
+        docs = [
+            {"v": "1.0.0", "g": "com.example", "a": "mylib", "timestamp": 1500000000000},
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response(docs)
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("com.example", "mylib")
+        assert result["first_version"] == "1.0.0"
+        # 2017-07-14 in UTC
+        assert result["first_release_date"] == "2017-07-14"
+        assert result["age_years"] > 0
+
+    def test_empty_docs_returns_empty_dict(self):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response([])
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("com.example", "nonexistent")
+        assert result == {}
+
+    def test_doc_missing_timestamp_returns_empty_dict(self):
+        """Docs without a timestamp field should degrade gracefully."""
+        docs = [{"v": "1.0.0", "g": "com.example", "a": "mylib"}]  # no timestamp
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response(docs)
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("com.example", "mylib")
+        assert result == {}
+
+    def test_http_error_returns_empty_dict(self):
+        with patch("requests.get", side_effect=Exception("503 Service Unavailable")):
+            result = _fetch_maven_first_release("com.example", "mylib")
+        assert result == {}
+
+    def test_age_years_is_positive_float(self):
+        """age_years should be a positive float for any past timestamp."""
+        # Use a timestamp from year 2000
+        docs = [
+            {"v": "0.1", "g": "legacy", "a": "old-lib", "timestamp": 946684800000},  # 2000-01-01
+        ]
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response(docs)
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("legacy", "old-lib")
+        assert result["age_years"] > 20
+        assert isinstance(result["age_years"], float)
+
+    def test_correct_query_is_sent_to_maven_api(self):
+        """Verify the correct query parameters are sent to Maven Central."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response([])
+        with patch("requests.get", return_value=mock_resp) as mock_get:
+            _fetch_maven_first_release("org.springframework", "spring-core")
+        call_kwargs = mock_get.call_args
+        params = call_kwargs[1].get("params", {}) if call_kwargs[1] else call_kwargs[0][1]
+        assert params["core"] == "gav"
+        assert params["rows"] == 200
+        assert "org.springframework" in params["q"]
+        assert "spring-core" in params["q"]
+
+    def test_multiple_docs_selects_minimum_timestamp(self):
+        """Even with many docs, the oldest timestamp wins."""
+        import random
+
+        rng = random.Random(42)
+        base_ts = 1343589186000  # 2012-07-29 — the expected minimum
+        docs = [
+            {"v": f"2.{i}.0", "g": "com.test", "a": "lib", "timestamp": base_ts + rng.randint(1, 10**12)}
+            for i in range(1, 50)
+        ]
+        docs.append({"v": "1.0.0", "g": "com.test", "a": "lib", "timestamp": base_ts})
+        rng.shuffle(docs)
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = self._make_gav_response(docs)
+        with patch("requests.get", return_value=mock_resp):
+            result = _fetch_maven_first_release("com.test", "lib")
+        assert result["first_version"] == "1.0.0"
+        assert result["first_release_date"] == "2012-07-29"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds a `first_release_date` field to `_enrich_maven` in `get_dependency_blast_radius.py` — providing an **age-of-library** signal that is useful when assessing blast radius.  A newly-published library with 0 history is a very different risk profile from one that has been in production for 12 years.

## What changed

### `src/manus_agent/tools/get_dependency_blast_radius.py`

- Added `import datetime` (stdlib only — no new dependencies).
- Added `_MAVEN_GAV_URL` constant (points to the same Maven Central search endpoint, GAV core).
- Added `_fetch_maven_first_release(group_id, artifact_id) -> dict`:
  - Queries the Maven Central **GAV (group-artifact-version) core** for all known versions of an artifact (up to 200).
  - Each doc in the GAV response carries a `timestamp` (ms since epoch) representing when that version was first published.
  - Selects the **minimum timestamp** across all returned docs.
  - Returns `{ first_version, first_release_date (YYYY-MM-DD), age_years }`.
  - Fully graceful: empty response → `{}`, missing `timestamp` → `{}`, HTTP error → `{}`.
- Updated `_enrich_maven` to:
  - Preserve resolved `group_id` / `artifact_id` from the search response.
  - Call `_fetch_maven_first_release` when both IDs are available.
  - Merge the result into the returned dict (missing → silent no-op, no extra keys added).
- Updated the output rendering in `get_dependency_blast_radius` to display:
  - `First released: YYYY-MM-DD  (N.N yrs old)`
  - `First version:  x.y.z`
- Updated docstring to mention the GAV index as a data source.

### `tests/test_dependency_blast_radius.py`

Added **11 new tests** (all 100% mocked — no real HTTP):

| Class | Tests |
|---|---|
| `TestFetchMavenFirstRelease` (8 new) | oldest-by-timestamp, single-version, empty docs, missing timestamp, HTTP error, age > 0, correct query params, shuffle-stable min selection |
| `TestEnrichMaven` (3 new) | first-release date propagated, no-doc → no GAV call, GAV failure → silent |

All existing tests continue to pass (the double `requests.get` call is transparent because existing tests return the same mock for all calls, and the GAV response has no `timestamp` fields → graceful `{}` return).

## Before / After example

```
# Before
    Maven artifact:   org.apache.logging.log4j:log4j-core
    Latest version:   2.20.0
    Version count:    76

# After
    Maven artifact:   org.apache.logging.log4j:log4j-core
    Latest version:   2.20.0
    Version count:    76
    First released:   2012-07-29  (13.9 yrs old)
    First version:    2.0-alpha1
```

## Test results

```
996 passed, 3 deselected in 25s   (+11 new tests vs upstream/main)
```

## Open PRs checked — no overlap

Verified against all open PRs before building:
#51 (silent-patches), #53 (cve-timeline), #54 (version-range), #58 (vendor-response),
#60 (poc-freshness), #64 (sbom-scan), #65 (temporal-priority), #67 (variant-cluster),
#74 (epss-decay), #75 (exploit-maturity), #76 (vulnerability-triage-card),
#77 (cve-report-generator), #78 (diff-report), #79 (reachability-scorer),
#80 (epss-watchlist), #82 (attack-surface-scorer), #83 (watch-alert),
#85 (cli-integration-tests), #86 (patch-lag-rating), #87 (kev-context-dimension),
#88 (readme-scoring-workflow), #89 (core-tools-test-suite), #90 (exploit-search-tools-tests),
#91 (nvd-retry — already merged), #92 (github-tools-test-suite), #93 (submit-cves-test-suite)

None of these touch `_enrich_maven` or the Maven Central GAV index.
