### PR TITLE
feat(tools): OSV.dev affected-package resolver — get_osv_data tool + manus-agent osv CLI

### DIFF
--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -120,6 +120,13 @@ Your process is optimized to build a comprehensive picture from authoritative, f
   Use this to answer: *"how many downstream projects are exposed to this vulnerability?"*
   A CRITICAL blast radius (>5M weekly downloads or >50K npm dependents) should be flagged prominently.
 
+**Step 6d: OSV.dev Affected-Package Resolution**
+- Call `get_osv_data` with the CVE ID. OSV.dev normalises ecosystem advisories (GHSA, PyPA, npm, Go, RustSec, Maven) into concrete package + version-range tuples. Include in the report:
+  - The affected ecosystems and packages OSV lists for this CVE.
+  - Per package, the vulnerable version ranges and the first fixed version (from OSV range `introduced`/`fixed` events) -- this is the exact upgrade target for remediation.
+  - All aliases (GHSA/CVE) that refer to the same flaw.
+  Prefer OSV's per-package fixed versions when writing the Recommendations upgrade targets; they are more precise than NVD CPE ranges. If OSV has no package-level ranges, note this and rely on NVD/version-range data.
+
 **Step 7: Analyze Weakness**
 - From the NVD data, find the CWE ID and use the `get_cwe_details` tool to understand the software weakness.
 
@@ -213,6 +220,7 @@ class VulnerabilityIntelligenceAgent:
             from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
             from manus_agent.tools.get_epss_trend import get_epss_trend
             from manus_agent.tools.get_github_advisory import get_github_advisory
+            from manus_agent.tools.get_osv_data import get_osv_data
             from manus_agent.tools.get_patch_diff import get_patch_diff
             from manus_agent.tools.get_poc_week import get_poc_week
             from manus_agent.tools.get_trickest_pocs import get_trickest_pocs
@@ -269,6 +277,7 @@ class VulnerabilityIntelligenceAgent:
             get_github_advisory,
             "manus_agent.tools.verify_exploit",
             get_epss_trend,
+            get_osv_data,
             get_patch_diff,
             score_exploit_complexity,
             get_vulncheck_data,

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1051,6 +1051,7 @@ _SUBCOMMANDS = {
     "variants",
     "epss-trend",
     "patch-diff",
+    "osv",
     "compare",
     "exploit-complexity",
     "poc-search",
@@ -1219,6 +1220,81 @@ def _run_patch_diff(argv: list[str]) -> int:
             print("  Reproduction hints:")
             for hint in s["reproduction_condition_hints"]:
                 print(f"    • {hint}")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# osv subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_osv_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent osv",
+        description=(
+            "Resolve a CVE to its OSV.dev affected packages and version ranges.\n"
+            "OSV normalises ecosystem advisories (GHSA, PyPA, npm, Go, RustSec,\n"
+            "Maven) into concrete package + version-range tuples, giving exact\n"
+            "vulnerable ranges and first-fixed versions per package."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_osv(argv: list[str]) -> int:
+    parser = _build_osv_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.get_osv_data import fetch_osv_data
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    payload = fetch_osv_data(cve_id)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    # --- text output ---
+    print(payload["message"])
+    if not payload.get("found"):
+        return 0
+
+    if payload.get("aliases"):
+        print(f"Aliases: {', '.join(payload['aliases'])}")
+
+    for rec in payload.get("records", []):
+        pkgs = rec.get("affected_packages", [])
+        if not pkgs:
+            continue
+        print(f"\nOSV record: {rec['osv_id']}")
+        for sev in rec.get("severity", []):
+            if sev.get("score"):
+                print(f"  Severity ({sev['type']}): {sev['score']}")
+        for p in pkgs:
+            loc = f"{p['ecosystem']}:{p['package']}"
+            fixed = ", ".join(p["fixed"]) if p["fixed"] else "(no fixed version listed)"
+            introduced = ", ".join(p["introduced"]) if p["introduced"] else "0"
+            print(f"  {loc}")
+            print(f"    Vulnerable from : {introduced}")
+            print(f"    First fixed     : {fixed}")
+            if p.get("last_affected"):
+                print(f"    Last affected   : {', '.join(p['last_affected'])}")
     return 0
 
 
@@ -2168,6 +2244,10 @@ def main() -> None:
     if first_positional == "patch-diff":
         idx = argv.index("patch-diff")
         sys.exit(_run_patch_diff(argv[idx + 1 :]))
+
+    if first_positional == "osv":
+        idx = argv.index("osv")
+        sys.exit(_run_osv(argv[idx + 1 :]))
 
     if first_positional == "compare":
         idx = argv.index("compare")

--- a/src/manus_agent/tools/get_osv_data.py
+++ b/src/manus_agent/tools/get_osv_data.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+"""
+Tool for fetching OSV.dev (Open Source Vulnerabilities) data for a CVE.
+
+OSV.dev aggregates vulnerability records from many ecosystem databases
+(GHSA, PyPA/PyPI, npm, Go, RustSec, Maven, etc.) into a single normalised
+schema. Unlike NVD's CPE-centric model, OSV expresses affected software as
+concrete *package + version-range* tuples keyed by ecosystem, which makes it
+far more actionable for dependency-level triage.
+
+This tool answers three questions NVD alone cannot:
+
+1. Which ecosystems and packages does this CVE actually affect?
+2. What are the exact vulnerable version ranges and first-fixed versions,
+   per package (from OSV ``affected[].ranges`` events)?
+3. What are all the aliases (GHSA/CVE/other) that refer to the same flaw?
+
+Strategy: fetch the CVE's own OSV record from ``/v1/vulns/{cve}``; the CVE
+record frequently lacks package-level ``affected`` data (which lives in the
+GHSA advisory instead). When that happens we follow each ``GHSA-`` alias and
+merge its per-package version ranges, deduplicating merged records by OSV id.
+
+Public API, no key required:
+- GET https://api.osv.dev/v1/vulns/{osv_id}
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Retry / back-off configuration (mirrors get_vulncheck_data conventions)
+# ---------------------------------------------------------------------------
+# Maximum number of HTTP attempts per request (1 = no retry).
+# Override with OSV_MAX_RETRIES env var (useful in tests: set to "1").
+_OSV_MAX_RETRIES: int = int(os.environ.get("OSV_MAX_RETRIES", "3"))
+
+# Base delay between retries in seconds (doubles each attempt: 1s, 2s…).
+# Override with OSV_RETRY_BASE_DELAY env var (set to "0" in tests).
+_OSV_RETRY_BASE_DELAY: float = float(os.environ.get("OSV_RETRY_BASE_DELAY", "1.0"))
+
+# HTTP status codes that are retryable (rate-limit or transient server error).
+_OSV_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+_OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{osv_id}"
+_OSV_TIMEOUT = 15
+
+# Cap on how many GHSA alias records we will follow for one CVE, to bound
+# fan-out and output size for pathological cases.
+_OSV_MAX_ALIAS_FOLLOWS = 8
+
+TOOL_SPEC = {
+    "name": "get_osv_data",
+    "description": (
+        "Fetches OSV.dev (Open Source Vulnerabilities) records for a given CVE ID. "
+        "OSV normalises advisories from GHSA, PyPA/PyPI, npm, Go, RustSec, Maven and other "
+        "ecosystem databases into concrete package + version-range tuples, which is far more "
+        "actionable for dependency triage than NVD's CPE model. Returns, per affected package: "
+        "the ecosystem, package name, vulnerable version ranges, and first-fixed versions "
+        "(derived from OSV range events); plus all aliases (GHSA/CVE), severity (CVSS vectors), "
+        "and references. Use this to answer 'which packages and versions does this CVE affect, "
+        "and what version fixes it?'. Public API, no key required."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2024-3094').",
+                }
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper with retry/back-off
+# ---------------------------------------------------------------------------
+def _osv_get_with_retry(osv_id: str) -> requests.Response:
+    """GET a single OSV record with exponential back-off on transient errors.
+
+    Retries on 429/5xx and on connection/timeout errors. Non-retryable 4xx
+    (e.g. 404 for an unknown id) are returned to the caller as-is so they can
+    be handled without raising.
+    """
+    url = _OSV_VULN_URL.format(osv_id=osv_id)
+    last_exc: Exception | None = None
+    for attempt in range(_OSV_MAX_RETRIES):
+        try:
+            resp = requests.get(url, timeout=_OSV_TIMEOUT, headers={"Accept": "application/json"})
+            if resp.status_code in _OSV_RETRYABLE_STATUSES and attempt < _OSV_MAX_RETRIES - 1:
+                time.sleep(_OSV_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            return resp
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+            last_exc = exc
+            if attempt < _OSV_MAX_RETRIES - 1:
+                time.sleep(_OSV_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("OSV request failed without a specific exception")
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+def _parse_affected(affected: list[Any]) -> list[dict[str, Any]]:
+    """Flatten OSV ``affected[]`` entries into package + version-range summaries."""
+    packages: list[dict[str, Any]] = []
+    for entry in affected or []:
+        if not isinstance(entry, dict):
+            continue
+        pkg = entry.get("package") or {}
+        ecosystem = pkg.get("ecosystem") if isinstance(pkg, dict) else None
+        name = pkg.get("name") if isinstance(pkg, dict) else None
+        # Skip fully package-less entries (nothing actionable to report).
+        if ecosystem is None and name is None:
+            continue
+
+        introduced: list[str] = []
+        fixed: list[str] = []
+        last_affected: list[str] = []
+        for rng in entry.get("ranges", []) or []:
+            if not isinstance(rng, dict):
+                continue
+            for ev in rng.get("events", []) or []:
+                if not isinstance(ev, dict):
+                    continue
+                if "introduced" in ev:
+                    introduced.append(str(ev["introduced"]))
+                if "fixed" in ev:
+                    fixed.append(str(ev["fixed"]))
+                if "last_affected" in ev:
+                    last_affected.append(str(ev["last_affected"]))
+
+        versions = [str(v) for v in (entry.get("versions", []) or []) if v is not None]
+
+        packages.append(
+            {
+                "ecosystem": ecosystem,
+                "package": name,
+                "introduced": introduced,
+                "fixed": fixed,
+                "last_affected": last_affected,
+                "affected_version_count": len(versions),
+                "affected_versions_sample": versions[:10],
+            }
+        )
+    return packages
+
+
+def _parse_severity(record: dict[str, Any]) -> list[dict[str, str]]:
+    """Extract CVSS severity entries from an OSV record."""
+    out: list[dict[str, str]] = []
+    for sev in record.get("severity", []) or []:
+        if isinstance(sev, dict):
+            out.append({"type": str(sev.get("type", "")), "score": str(sev.get("score", ""))})
+    return out
+
+
+def _summarise_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Build a compact, structured summary from a single OSV vuln record."""
+    packages = _parse_affected(record.get("affected", []))
+    ecosystems = sorted({p["ecosystem"] for p in packages if p.get("ecosystem")})
+    references = [r.get("url") for r in (record.get("references", []) or []) if isinstance(r, dict) and r.get("url")]
+    return {
+        "osv_id": record.get("id"),
+        "summary": record.get("summary") or record.get("details"),
+        "aliases": record.get("aliases", []) or [],
+        "modified": record.get("modified"),
+        "published": record.get("published"),
+        "withdrawn": record.get("withdrawn"),
+        "severity": _parse_severity(record),
+        "affected_ecosystems": ecosystems,
+        "affected_packages": packages,
+        "references": references[:20],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public fetch entry point (used by both the tool and the CLI)
+# ---------------------------------------------------------------------------
+def fetch_osv_data(cve_id: str) -> dict[str, Any]:
+    """Query OSV.dev for a CVE and return a structured, normalised summary.
+
+    Fetches the CVE's own OSV record and, when that record carries no
+    package-level ``affected`` data, follows its ``GHSA-`` aliases to recover
+    per-package version ranges. Merged records are deduplicated by OSV id.
+
+    Returns a dict with keys: ``found`` (bool), ``cve_id``, ``records`` (list
+    of per-record summaries), aggregated ``aliases`` and
+    ``affected_ecosystems``, and a human-readable ``message``. Network/API
+    errors are captured in ``error`` with ``found=False``.
+    """
+    cve_id = (cve_id or "").strip()
+    if not cve_id:
+        return {
+            "found": False,
+            "cve_id": cve_id,
+            "records": [],
+            "aliases": [],
+            "affected_ecosystems": [],
+            "error": "Invalid CVE ID. Must be a non-empty string.",
+            "message": "Invalid CVE ID. Must be a non-empty string.",
+        }
+
+    records: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+
+    def _add_record(rec: dict[str, Any]) -> dict[str, Any]:
+        summary = _summarise_record(rec)
+        rid = summary.get("osv_id")
+        if rid and rid not in seen_ids:
+            seen_ids.add(rid)
+            records.append(summary)
+        return summary
+
+    try:
+        resp = _osv_get_with_retry(cve_id)
+    except Exception as exc:  # noqa: BLE001 - report any transport failure
+        return {
+            "found": False,
+            "cve_id": cve_id,
+            "records": [],
+            "aliases": [],
+            "affected_ecosystems": [],
+            "error": f"OSV request failed: {exc}",
+            "message": f"OSV.dev lookup failed for {cve_id}: {exc}",
+        }
+
+    if resp.status_code == 404:
+        return {
+            "found": False,
+            "cve_id": cve_id,
+            "records": [],
+            "aliases": [],
+            "affected_ecosystems": [],
+            "message": f"No OSV.dev record found for {cve_id}.",
+        }
+
+    try:
+        resp.raise_for_status()
+        primary = resp.json()
+    except (requests.exceptions.HTTPError, ValueError) as exc:
+        return {
+            "found": False,
+            "cve_id": cve_id,
+            "records": [],
+            "aliases": [],
+            "affected_ecosystems": [],
+            "error": f"OSV response error: {exc}",
+            "message": f"OSV.dev returned an unusable response for {cve_id}: {exc}",
+        }
+
+    primary_summary = _add_record(primary)
+
+    # If the CVE record has no package-level data, follow GHSA aliases to
+    # recover per-package version ranges (they live in the GHSA advisory).
+    if not primary_summary["affected_packages"]:
+        ghsa_aliases = [a for a in primary_summary["aliases"] if isinstance(a, str) and a.startswith("GHSA-")]
+        for alias in ghsa_aliases[:_OSV_MAX_ALIAS_FOLLOWS]:
+            try:
+                a_resp = _osv_get_with_retry(alias)
+                if a_resp.status_code == 200:
+                    _add_record(a_resp.json())
+            except Exception:  # noqa: BLE001 - alias enrichment is best-effort
+                continue
+
+    # Aggregate across all merged records.
+    all_aliases = sorted(
+        {a for rec in records for a in rec["aliases"] if isinstance(a, str)}
+        | ({cve_id} if any(cve_id in rec["aliases"] or rec["osv_id"] == cve_id for rec in records) else set())
+    )
+    all_ecosystems = sorted({e for rec in records for e in rec["affected_ecosystems"]})
+    total_packages = sum(len(rec["affected_packages"]) for rec in records)
+
+    if all_ecosystems:
+        eco = ", ".join(all_ecosystems)
+        message = (
+            f"OSV.dev: {cve_id} affects {total_packages} package(s) across {len(all_ecosystems)} ecosystem(s): {eco}."
+        )
+    else:
+        message = (
+            f"OSV.dev has a record for {cve_id} but no package-level version ranges (no ecosystem-specific advisory)."
+        )
+
+    return {
+        "found": True,
+        "cve_id": cve_id,
+        "records": records,
+        "aliases": all_aliases,
+        "affected_ecosystems": all_ecosystems,
+        "affected_package_count": total_packages,
+        "message": message,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+def get_osv_data(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool.get("input", {}) or {}
+    cve_id = tool_input.get("cve_id")
+
+    if not isinstance(cve_id, str) or not cve_id.strip():
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID. Must be a non-empty string."}],
+        }
+        log_tool_output_size("get_osv_data", result)
+        return result
+
+    payload = fetch_osv_data(cve_id)
+    status = "success" if payload.get("found") else "error"
+    if "error" in payload and not payload.get("found"):
+        status = "error"
+
+    import json
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": status,
+        "content": [{"text": json.dumps(payload, indent=2)}],
+    }
+    log_tool_output_size("get_osv_data", result)
+    return result

--- a/tests/test_osv_data.py
+++ b/tests/test_osv_data.py
@@ -1,0 +1,406 @@
+"""Tests for get_osv_data — OSV.dev CVE enrichment tool.
+
+All HTTP calls are fully mocked; no real network requests are made. The
+OSV_RETRY_BASE_DELAY env var is forced to "0" so retry loops complete
+instantly without real sleeping.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from manus_agent.tools import get_osv_data as mod
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _make_tool_use(cve_id="CVE-2021-44228", tool_use_id="osv-test-001"):
+    return {"toolUseId": tool_use_id, "input": {"cve_id": cve_id}}
+
+
+def _make_response(status_code=200, payload=None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload if payload is not None else {}
+    if status_code < 400:
+        resp.raise_for_status.return_value = None
+    else:
+        resp.raise_for_status.side_effect = requests.exceptions.HTTPError(f"HTTP {status_code}", response=resp)
+    return resp
+
+
+def _cve_record_with_packages(cve_id="CVE-2021-44228"):
+    """A CVE record that directly carries Maven package ranges."""
+    return {
+        "id": cve_id,
+        "summary": "Log4Shell RCE",
+        "aliases": ["GHSA-jfh8-c2jp-5v3q"],
+        "modified": "2024-01-01T00:00:00Z",
+        "published": "2021-12-10T00:00:00Z",
+        "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"}],
+        "affected": [
+            {
+                "package": {"ecosystem": "Maven", "name": "org.apache.logging.log4j:log4j-core"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "2.0-beta9"}, {"fixed": "2.15.0"}],
+                    }
+                ],
+                "versions": ["2.0-beta9", "2.14.1"],
+            }
+        ],
+        "references": [{"type": "WEB", "url": "https://logging.apache.org/log4j/"}],
+    }
+
+
+def _cve_record_no_packages(cve_id="CVE-2024-3094"):
+    """A CVE record with a GHSA alias but no package-level affected data."""
+    return {
+        "id": cve_id,
+        "details": "xz backdoor",
+        "aliases": ["GHSA-rxwq-x6h5-x525"],
+        "modified": "2024-04-01T00:00:00Z",
+        "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"}],
+        "affected": [],
+        "references": [{"type": "ADVISORY", "url": "https://www.openwall.com/lists/oss-security"}],
+    }
+
+
+def _ghsa_record_with_packages(ghsa_id="GHSA-rxwq-x6h5-x525"):
+    return {
+        "id": ghsa_id,
+        "summary": "Malicious code in xz",
+        "aliases": ["CVE-2024-3094"],
+        "affected": [
+            {
+                "package": {"ecosystem": "Alpine:v3.20", "name": "xz"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "5.6.0"}, {"fixed": "5.6.1-r2"}]}],
+            }
+        ],
+        "references": [{"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"}],
+    }
+
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC contract
+# ---------------------------------------------------------------------------
+class TestToolSpec:
+    def test_name(self):
+        assert mod.TOOL_SPEC["name"] == "get_osv_data"
+
+    def test_required_input(self):
+        schema = mod.TOOL_SPEC["inputSchema"]["json"]
+        assert schema["required"] == ["cve_id"]
+        assert "cve_id" in schema["properties"]
+
+    def test_description_mentions_osv(self):
+        assert "OSV" in mod.TOOL_SPEC["description"]
+
+    def test_retryable_statuses(self):
+        assert mod._OSV_RETRYABLE_STATUSES == frozenset({429, 500, 502, 503, 504})
+
+    def test_config_env_defaults(self):
+        assert mod._OSV_MAX_RETRIES >= 1
+        assert mod._OSV_RETRY_BASE_DELAY >= 0
+
+
+# ---------------------------------------------------------------------------
+# Parsing helpers
+# ---------------------------------------------------------------------------
+class TestParseAffected:
+    def test_extracts_ranges(self):
+        pkgs = mod._parse_affected(_cve_record_with_packages()["affected"])
+        assert len(pkgs) == 1
+        p = pkgs[0]
+        assert p["ecosystem"] == "Maven"
+        assert p["package"] == "org.apache.logging.log4j:log4j-core"
+        assert p["introduced"] == ["2.0-beta9"]
+        assert p["fixed"] == ["2.15.0"]
+        assert p["affected_version_count"] == 2
+
+    def test_skips_packageless_entry(self):
+        pkgs = mod._parse_affected([{"ranges": [{"events": [{"introduced": "0"}]}]}])
+        assert pkgs == []
+
+    def test_handles_empty(self):
+        assert mod._parse_affected([]) == []
+        assert mod._parse_affected(None) == []
+
+    def test_ignores_non_dict_entries(self):
+        assert mod._parse_affected(["nope", 42, None]) == []
+
+    def test_last_affected_captured(self):
+        affected = [
+            {
+                "package": {"ecosystem": "npm", "name": "foo"},
+                "ranges": [{"events": [{"introduced": "0"}, {"last_affected": "1.2.3"}]}],
+            }
+        ]
+        pkgs = mod._parse_affected(affected)
+        assert pkgs[0]["last_affected"] == ["1.2.3"]
+        assert pkgs[0]["fixed"] == []
+
+    def test_versions_sample_capped(self):
+        affected = [
+            {
+                "package": {"ecosystem": "PyPI", "name": "bar"},
+                "versions": [str(i) for i in range(50)],
+            }
+        ]
+        pkgs = mod._parse_affected(affected)
+        assert pkgs[0]["affected_version_count"] == 50
+        assert len(pkgs[0]["affected_versions_sample"]) == 10
+
+
+class TestParseSeverity:
+    def test_extracts_cvss(self):
+        sev = mod._parse_severity(_cve_record_with_packages())
+        assert sev == [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"}]
+
+    def test_empty_when_missing(self):
+        assert mod._parse_severity({}) == []
+
+    def test_ignores_non_dict(self):
+        assert mod._parse_severity({"severity": ["x", 1]}) == []
+
+
+class TestSummariseRecord:
+    def test_full_summary(self):
+        s = mod._summarise_record(_cve_record_with_packages())
+        assert s["osv_id"] == "CVE-2021-44228"
+        assert s["affected_ecosystems"] == ["Maven"]
+        assert s["aliases"] == ["GHSA-jfh8-c2jp-5v3q"]
+        assert len(s["references"]) == 1
+
+    def test_details_fallback_for_summary(self):
+        s = mod._summarise_record(_cve_record_no_packages())
+        assert s["summary"] == "xz backdoor"
+
+    def test_references_capped_at_20(self):
+        rec = {"id": "X", "references": [{"url": f"https://e/{i}"} for i in range(30)]}
+        s = mod._summarise_record(rec)
+        assert len(s["references"]) == 20
+
+
+# ---------------------------------------------------------------------------
+# _osv_get_with_retry — retry/back-off
+# ---------------------------------------------------------------------------
+class TestRetry:
+    def test_success_first_try(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod.requests, "get", return_value=_make_response(200, {"id": "X"})) as g:
+            resp = mod._osv_get_with_retry("CVE-2021-44228")
+        assert resp.status_code == 200
+        assert g.call_count == 1
+
+    def test_retries_on_429_then_succeeds(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        monkeypatch.setattr(mod, "_OSV_MAX_RETRIES", 3)
+        responses = [_make_response(429), _make_response(200, {"id": "X"})]
+        with patch.object(mod.requests, "get", side_effect=responses) as g:
+            with patch.object(mod.time, "sleep") as slp:
+                resp = mod._osv_get_with_retry("CVE-1")
+        assert resp.status_code == 200
+        assert g.call_count == 2
+        assert slp.call_count == 1
+
+    def test_retries_on_503(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        monkeypatch.setattr(mod, "_OSV_MAX_RETRIES", 3)
+        responses = [_make_response(503), _make_response(502), _make_response(200, {"id": "X"})]
+        with patch.object(mod.requests, "get", side_effect=responses):
+            with patch.object(mod.time, "sleep"):
+                resp = mod._osv_get_with_retry("CVE-1")
+        assert resp.status_code == 200
+
+    def test_returns_last_retryable_after_exhaustion(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        monkeypatch.setattr(mod, "_OSV_MAX_RETRIES", 2)
+        with patch.object(mod.requests, "get", return_value=_make_response(500)):
+            with patch.object(mod.time, "sleep"):
+                resp = mod._osv_get_with_retry("CVE-1")
+        # After exhausting retries the final (still-500) response is returned.
+        assert resp.status_code == 500
+
+    def test_404_not_retried(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod.requests, "get", return_value=_make_response(404)) as g:
+            resp = mod._osv_get_with_retry("CVE-NOPE")
+        assert resp.status_code == 404
+        assert g.call_count == 1
+
+    def test_connection_error_retried(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        monkeypatch.setattr(mod, "_OSV_MAX_RETRIES", 3)
+        side = [requests.exceptions.ConnectionError("boom"), _make_response(200, {"id": "X"})]
+        with patch.object(mod.requests, "get", side_effect=side):
+            with patch.object(mod.time, "sleep"):
+                resp = mod._osv_get_with_retry("CVE-1")
+        assert resp.status_code == 200
+
+    def test_timeout_raised_after_exhaustion(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        monkeypatch.setattr(mod, "_OSV_MAX_RETRIES", 2)
+        with patch.object(mod.requests, "get", side_effect=requests.exceptions.Timeout("t")):
+            with patch.object(mod.time, "sleep"):
+                with pytest.raises(requests.exceptions.Timeout):
+                    mod._osv_get_with_retry("CVE-1")
+
+
+# ---------------------------------------------------------------------------
+# fetch_osv_data — end-to-end (mocked HTTP)
+# ---------------------------------------------------------------------------
+class TestFetchOsvData:
+    def test_empty_cve_id(self):
+        r = mod.fetch_osv_data("   ")
+        assert r["found"] is False
+        assert "Invalid CVE ID" in r["error"]
+
+    def test_cve_with_direct_packages(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(
+            mod, "_osv_get_with_retry", return_value=_make_response(200, _cve_record_with_packages())
+        ) as g:
+            r = mod.fetch_osv_data("CVE-2021-44228")
+        # Only one call — no alias follow needed since packages present.
+        assert g.call_count == 1
+        assert r["found"] is True
+        assert r["affected_ecosystems"] == ["Maven"]
+        assert r["affected_package_count"] == 1
+        assert "Maven" in r["message"]
+
+    def test_follows_ghsa_alias_when_no_packages(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+
+        def fake_get(osv_id):
+            if osv_id == "CVE-2024-3094":
+                return _make_response(200, _cve_record_no_packages())
+            if osv_id == "GHSA-rxwq-x6h5-x525":
+                return _make_response(200, _ghsa_record_with_packages())
+            return _make_response(404)
+
+        with patch.object(mod, "_osv_get_with_retry", side_effect=fake_get) as g:
+            r = mod.fetch_osv_data("CVE-2024-3094")
+        assert g.call_count == 2  # CVE record + GHSA alias
+        assert r["found"] is True
+        assert "Alpine:v3.20" in r["affected_ecosystems"]
+        assert r["affected_package_count"] == 1
+        # Both records merged, deduped.
+        assert len(r["records"]) == 2
+
+    def test_dedup_when_alias_returns_same_id(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        rec = _cve_record_no_packages()
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(200, rec)):
+            r = mod.fetch_osv_data("CVE-2024-3094")
+        # primary added; alias GHSA fetch returns same id => deduped
+        ids = [rec["osv_id"] for rec in r["records"]]
+        assert len(ids) == len(set(ids))
+
+    def test_404_returns_not_found(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(404)):
+            r = mod.fetch_osv_data("CVE-0000-0000")
+        assert r["found"] is False
+        assert "No OSV.dev record" in r["message"]
+
+    def test_transport_failure_captured(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod, "_osv_get_with_retry", side_effect=requests.exceptions.Timeout("t")):
+            r = mod.fetch_osv_data("CVE-1")
+        assert r["found"] is False
+        assert "failed" in r["message"].lower()
+
+    def test_bad_json_captured(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        resp = _make_response(200)
+        resp.json.side_effect = ValueError("bad json")
+        with patch.object(mod, "_osv_get_with_retry", return_value=resp):
+            r = mod.fetch_osv_data("CVE-1")
+        assert r["found"] is False
+        assert "unusable" in r["message"].lower()
+
+    def test_alias_follow_best_effort_on_error(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+
+        def fake_get(osv_id):
+            if osv_id == "CVE-2024-3094":
+                return _make_response(200, _cve_record_no_packages())
+            raise requests.exceptions.ConnectionError("alias down")
+
+        with patch.object(mod, "_osv_get_with_retry", side_effect=fake_get):
+            r = mod.fetch_osv_data("CVE-2024-3094")
+        # Primary still returned; alias failure swallowed.
+        assert r["found"] is True
+        assert r["affected_package_count"] == 0
+        assert "no package-level" in r["message"]
+
+    def test_record_no_packages_no_ghsa_alias(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        rec = {"id": "CVE-9", "aliases": ["CVE-other"], "affected": []}
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(200, rec)) as g:
+            r = mod.fetch_osv_data("CVE-9")
+        assert g.call_count == 1  # no GHSA alias to follow
+        assert r["found"] is True
+        assert r["affected_ecosystems"] == []
+
+
+# ---------------------------------------------------------------------------
+# get_osv_data — Strands tool entry point
+# ---------------------------------------------------------------------------
+class TestToolEntryPoint:
+    def test_invalid_cve_id_error(self):
+        res = mod.get_osv_data({"toolUseId": "t1", "input": {"cve_id": "  "}})
+        assert res["status"] == "error"
+        assert res["toolUseId"] == "t1"
+
+    def test_missing_input_key(self):
+        res = mod.get_osv_data({"toolUseId": "t2", "input": {}})
+        assert res["status"] == "error"
+
+    def test_success_status_and_json_content(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(200, _cve_record_with_packages())):
+            res = mod.get_osv_data(_make_tool_use())
+        assert res["status"] == "success"
+        payload = json.loads(res["content"][0]["text"])
+        assert payload["found"] is True
+        assert payload["affected_ecosystems"] == ["Maven"]
+
+    def test_not_found_is_error_status(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(404)):
+            res = mod.get_osv_data(_make_tool_use("CVE-0000-0000"))
+        assert res["status"] == "error"
+
+    def test_content_is_valid_json(self, monkeypatch):
+        monkeypatch.setattr(mod, "_OSV_RETRY_BASE_DELAY", 0)
+        with patch.object(mod, "_osv_get_with_retry", return_value=_make_response(200, _cve_record_with_packages())):
+            res = mod.get_osv_data(_make_tool_use())
+        # Must round-trip through json.loads without error.
+        json.loads(res["content"][0]["text"])
+
+
+# ---------------------------------------------------------------------------
+# VI agent wiring
+# ---------------------------------------------------------------------------
+class TestViAgentWiring:
+    def test_tool_importable_from_vi_agent_path(self):
+        from manus_agent.tools.get_osv_data import get_osv_data
+
+        assert callable(get_osv_data)
+
+    def test_vi_agent_source_registers_tool(self):
+        import inspect
+
+        from manus_agent.agents import vi_agent
+
+        src = inspect.getsource(vi_agent)
+        assert "get_osv_data" in src
+        assert "OSV.dev" in src  # system-prompt step present


### PR DESCRIPTION
## Summary

Adds **OSV.dev** (Open Source Vulnerabilities) as a first-class CVE intel source — the highest-value remaining gap in the analysis pipeline. OSV normalises ecosystem advisories (GHSA, PyPA/PyPI, npm, Go, RustSec, Maven) into concrete **package + version-range tuples**, which is far more actionable for dependency-level triage than NVD's CPE model.

It answers three questions NVD alone can't:\n1. Which ecosystems and packages does this CVE actually affect?
2. What are the exact vulnerable version ranges and **first-fixed versions** per package?
3. What are all the aliases (GHSA/CVE) referring to the same flaw?

## New Strands tool: `get_osv_data`
- Fetches the CVE's own OSV record from `/v1/vulns/{cve}`.
- When the CVE record has no package-level `affected` data (common — that data usually lives in the GHSA advisory), **follows each `GHSA-` alias** and merges its per-package version ranges. Merged records are **deduplicated by OSV id**.
- Emits, per affected package: ecosystem, package name, vulnerable version ranges, and **first-fixed version** (from OSV range `introduced`/`fixed` events) — the exact upgrade target for remediation — plus all aliases, CVSS severity, and references.
- Exponential back-off retry (429/5xx + connection/timeout) mirroring the `get_vulncheck_data` convention; env-overridable via `OSV_MAX_RETRIES` / `OSV_RETRY_BASE_DELAY`.
- Graceful degradation: transport/JSON/404 errors return `found=False` with a message instead of raising.

## CLI: `manus-agent osv CVE-XXXX-YYYY`
`--output {text,json}`. Example (text):

```
OSV.dev: CVE-2021-44228 affects 10 package(s) across 1 ecosystem(s): Maven.
Aliases: CVE-2021-44228, GHSA-jfh8-c2jp-5v3q

OSV record: GHSA-jfh8-c2jp-5v3q
  Severity (CVSS_V3): CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H/E:H
  Maven:org.apache.logging.log4j:log4j-core
    Vulnerable from : 2.0-beta9
    First fixed     : 2.15.0
  ...
```

`--output json` emits the full structured payload for piping (e.g. `jq '.records[].affected_packages[].fixed'`).

## Wiring
- Registered in `VulnerabilityIntelligenceAgent`'s tool list.
- Added system-prompt **Step 6d: OSV.dev Affected-Package Resolution**, instructing the agent to prefer OSV's per-package fixed versions as Recommendations upgrade targets over NVD CPE ranges.

## Tests
`tests/test_osv_data.py` — **40 fully-mocked unit tests**, no real network calls:
- TOOL_SPEC contract, config constants
- `_parse_affected` / `_parse_severity` / `_summarise_record` parsing (ranges, package-less skip, non-dict guards, version-sample cap, references cap, details fallback)
- retry/back-off: 429/503 retry, connection-error retry, exhaustion returns last retryable, 404 not retried, timeout raised after exhaustion
- `fetch_osv_data` end-to-end: direct packages, GHSA alias follow, dedup, 404, transport/JSON errors, best-effort alias-failure swallow, no-GHSA-alias path
- Strands tool entry point (error/success status, JSON round-trip)
- VI agent wiring (importable + registered in source + prompt step present)

**Suite: 985 → 1025 passing (+40), 0 failures.** `ruff check` + `ruff format` clean.

No new dependencies (public API, no key). No overlap with any open PR.
