### PR TITLE
feat(tools): add first_release_date + age_years to _enrich_pypi via PyPI upload timestamps

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -24,6 +24,7 @@ CLI: ``manus-agent blast-radius requests@2.28.0``
 
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 from typing import Any
@@ -323,8 +324,55 @@ def _enrich_npm(name: str) -> dict[str, Any]:
     return result
 
 
+def _extract_pypi_first_release(releases: dict[str, list[dict]]) -> dict[str, Any]:
+    """
+    Find the oldest release in a PyPI ``releases`` dict.
+
+    Each key is a version string; each value is a list of upload-file dicts,
+    each containing an ``upload_time_iso_8601`` field (e.g.
+    ``"2012-06-03T15:33:30.215975Z"``).  We scan every file across every
+    version and return the entry with the earliest timestamp.
+
+    Returns a dict with ``first_version``, ``first_release_date`` (YYYY-MM-DD),
+    and ``age_years`` (float, rounded to 1 decimal).  Returns ``{}`` when no
+    timestamp data is available.
+    """
+    earliest_ts: datetime.datetime | None = None
+    earliest_version: str | None = None
+
+    for version, files in releases.items():
+        if not files:
+            continue
+        for upload_info in files:
+            ts_str = upload_info.get("upload_time_iso_8601", "")
+            if not ts_str:
+                continue
+            try:
+                # Strip trailing 'Z' and parse as UTC
+                ts_str_clean = ts_str.rstrip("Z")
+                ts = datetime.datetime.fromisoformat(ts_str_clean).replace(tzinfo=datetime.timezone.utc)
+            except (ValueError, AttributeError):
+                continue
+            if earliest_ts is None or ts < earliest_ts:
+                earliest_ts = ts
+                earliest_version = version
+
+    if earliest_ts is None:
+        return {}
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    age_days = (now - earliest_ts).days
+    age_years = round(age_days / 365.25, 1)
+
+    return {
+        "first_version": earliest_version,
+        "first_release_date": earliest_ts.strftime("%Y-%m-%d"),
+        "age_years": age_years,
+    }
+
+
 def _enrich_pypi(name: str) -> dict[str, Any]:
-    """Fetch PyPI package metadata."""
+    """Fetch PyPI package metadata including first-release date."""
     result: dict[str, Any] = {"ecosystem": "PyPI", "package_name": name}
     try:
         pypi_data = _get(_PYPI_JSON_URL.format(name))
@@ -332,8 +380,12 @@ def _enrich_pypi(name: str) -> dict[str, Any]:
         result["description"] = info.get("summary", "")[:120]
         result["latest_version"] = info.get("version", "")
         result["home_page"] = info.get("project_url", info.get("home_page", ""))
+        releases = pypi_data.get("releases", {})
         # Total release count as a proxy for maturity
-        result["release_count"] = len(pypi_data.get("releases", {}))
+        result["release_count"] = len(releases)
+        # First release date from upload timestamps — pure stdlib, no extra HTTP call
+        first_release = _extract_pypi_first_release(releases)
+        result.update(first_release)
         # Try pypistats for download counts (rate-limited; degrade gracefully)
         try:
             stats = _get(_PYPISTATS_URL.format(name))
@@ -547,6 +599,12 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("release_count"):
                 lines.append(f"    Total releases:   {r['release_count']}")
+            if r.get("first_release_date"):
+                first_v = r.get("first_version", "")
+                age = r.get("age_years", "")
+                age_str = f" ({age} yrs old)" if age != "" else ""
+                first_v_str = f"  first version: {first_v}" if first_v else ""
+                lines.append(f"    First released:   {r['first_release_date']}{age_str}{first_v_str}")
             if r.get("description"):
                 lines.append(f"    Description:      {r['description'][:80]}")
 

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -18,6 +18,7 @@ from manus_agent.tools.get_dependency_blast_radius import (
     _enrich_npm,
     _enrich_package,
     _enrich_pypi,
+    _extract_pypi_first_release,
     _fetch_ghsa_affected,
     _fetch_nvd_affected,
     _fetch_osv_affected,
@@ -582,6 +583,137 @@ class TestEnrichPypi:
         assert result["ecosystem"] == "PyPI"
         assert result["package_name"] == "requests"
 
+    def test_returns_first_release_date_when_timestamps_present(self):
+        """_enrich_pypi should populate first_release_date when upload_time_iso_8601 present."""
+        releases = {
+            "2.28.0": [{"upload_time_iso_8601": "2022-10-03T00:00:00Z"}],
+            "0.1.0": [{"upload_time_iso_8601": "2011-02-14T12:00:00Z"}],
+            "1.0.0": [{"upload_time_iso_8601": "2012-06-03T15:33:30.215975Z"}],
+        }
+        pypi_data = {
+            "info": {
+                "name": "requests",
+                "version": "2.28.0",
+                "summary": "HTTP for Humans",
+                "project_url": "https://pypi.org/project/requests/",
+            },
+            "releases": releases,
+        }
+        pypi_resp = MagicMock()
+        pypi_resp.json.return_value = pypi_data
+        pypi_resp.raise_for_status.return_value = None
+        stats_resp = MagicMock()
+        stats_resp.raise_for_status.side_effect = Exception("429")
+        with patch("requests.get", side_effect=[pypi_resp, stats_resp]):
+            result = _enrich_pypi("requests")
+        assert result["first_release_date"] == "2011-02-14"
+        assert result["first_version"] == "0.1.0"
+        assert isinstance(result["age_years"], float)
+        assert result["age_years"] > 10
+
+    def test_no_first_release_when_no_timestamps(self):
+        """When release files have no upload_time_iso_8601, keys should be absent."""
+        releases = {"1.0.0": [], "2.0.0": []}
+        pypi_data = {
+            "info": {
+                "name": "mylib",
+                "version": "2.0.0",
+                "summary": "A library",
+                "project_url": "",
+            },
+            "releases": releases,
+        }
+        pypi_resp = MagicMock()
+        pypi_resp.json.return_value = pypi_data
+        pypi_resp.raise_for_status.return_value = None
+        stats_resp = MagicMock()
+        stats_resp.raise_for_status.side_effect = Exception("429")
+        with patch("requests.get", side_effect=[pypi_resp, stats_resp]):
+            result = _enrich_pypi("mylib")
+        assert "first_release_date" not in result
+        assert "first_version" not in result
+        assert "age_years" not in result
+
+
+# ===========================================================================
+# _extract_pypi_first_release
+# ===========================================================================
+
+
+class TestExtractPypiFirstRelease:
+    def test_picks_oldest_version(self):
+        releases = {
+            "1.0.0": [{"upload_time_iso_8601": "2015-01-10T00:00:00Z"}],
+            "0.1.0": [{"upload_time_iso_8601": "2013-06-20T08:30:00Z"}],
+            "2.0.0": [{"upload_time_iso_8601": "2018-03-05T12:00:00Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert result["first_version"] == "0.1.0"
+        assert result["first_release_date"] == "2013-06-20"
+        assert result["age_years"] >= 7  # 2013 → at least 7 years ago
+
+    def test_picks_oldest_file_within_version(self):
+        """Multiple upload files for the same version — pick the earliest."""
+        releases = {
+            "1.0.0": [
+                {"upload_time_iso_8601": "2014-05-01T10:00:00Z"},
+                {"upload_time_iso_8601": "2014-04-30T08:00:00Z"},  # ← earliest
+            ],
+            "2.0.0": [{"upload_time_iso_8601": "2016-11-15T00:00:00Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert result["first_version"] == "1.0.0"
+        assert result["first_release_date"] == "2014-04-30"
+
+    def test_empty_releases_returns_empty_dict(self):
+        assert _extract_pypi_first_release({}) == {}
+
+    def test_all_empty_file_lists_returns_empty_dict(self):
+        releases = {"1.0.0": [], "2.0.0": []}
+        assert _extract_pypi_first_release(releases) == {}
+
+    def test_missing_upload_time_field_skipped(self):
+        releases = {
+            "1.0.0": [{"filename": "lib-1.0.0.tar.gz"}],  # no upload_time_iso_8601
+            "2.0.0": [{"upload_time_iso_8601": "2020-07-01T00:00:00Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert result["first_version"] == "2.0.0"
+        assert result["first_release_date"] == "2020-07-01"
+
+    def test_malformed_timestamp_skipped(self):
+        releases = {
+            "1.0.0": [{"upload_time_iso_8601": "not-a-date"}],
+            "2.0.0": [{"upload_time_iso_8601": "2019-12-01T00:00:00Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert result["first_version"] == "2.0.0"
+        assert result["first_release_date"] == "2019-12-01"
+
+    def test_all_malformed_timestamps_returns_empty_dict(self):
+        releases = {
+            "1.0.0": [{"upload_time_iso_8601": "bad"}],
+            "2.0.0": [{"upload_time_iso_8601": "also-bad"}],
+        }
+        assert _extract_pypi_first_release(releases) == {}
+
+    def test_age_years_is_float_and_positive(self):
+        releases = {
+            "1.0.0": [{"upload_time_iso_8601": "2010-01-01T00:00:00Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert isinstance(result["age_years"], float)
+        assert result["age_years"] > 10
+
+    def test_microseconds_in_timestamp_handled(self):
+        """PyPI often includes microseconds: 2012-06-03T15:33:30.215975Z"""
+        releases = {
+            "1.0.0": [{"upload_time_iso_8601": "2012-06-03T15:33:30.215975Z"}],
+        }
+        result = _extract_pypi_first_release(releases)
+        assert result["first_release_date"] == "2012-06-03"
+        assert result["first_version"] == "1.0.0"
+
 
 # ===========================================================================
 # _enrich_maven
@@ -886,6 +1018,34 @@ class TestGetDependencyBlastRadius:
         ):
             result = get_dependency_blast_radius("CVE-2023-32681")
         assert "Python" in result or "PyPI" in result
+
+    def test_first_release_date_shown_in_output(self):
+        """When _enrich_package returns first_release_date, output should show 'First released:' line."""
+        pkgs = [{"name": "requests", "ecosystem": "PyPI", "version_range": "<2.29.0", "source": "osv"}]
+        pypi_stats = {
+            "ecosystem": "PyPI",
+            "package_name": "requests",
+            "weekly_downloads": 60000000,
+            "latest_version": "2.34.0",
+            "release_count": 163,
+            "first_release_date": "2011-02-14",
+            "first_version": "0.2.0",
+            "age_years": 14.4,
+        }
+        with (
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=pkgs),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2023-32681")
+        assert "First released:" in result
+        assert "2011-02-14" in result
+        assert "14.4 yrs old" in result
+        assert "0.2.0" in result
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds `first_release_date`, `first_version`, and `age_years` fields to `_enrich_pypi` in `get_dependency_blast_radius.py`.

A 14-year-old library with 163 releases is a very different blast-radius risk profile from a brand-new one.
Library age is a meaningful signal: old packages tend to have wider transitive footprints and slower
upgrade cycles in consuming projects.

## How it works

The PyPI JSON API (`/pypi/{name}/json`) already returns a `releases` dict as part of the standard
metadata response — no additional HTTP call is required.  Each entry maps a version string to a list
of upload-file objects, each containing an `upload_time_iso_8601` field
(e.g. `"2012-06-03T15:33:30.215975Z"`).

The new `_extract_pypi_first_release(releases)` helper:

1. Iterates every version and every upload file in the `releases` dict
2. Parses `upload_time_iso_8601` timestamps (handles trailing `Z`, microseconds, malformed values)
3. Returns the **earliest** timestamp across all versions/files as `{first_version, first_release_date (YYYY-MM-DD), age_years}`
4. Returns `{}` on any failure (empty releases, missing fields, parse errors) — fully graceful degradation

`_enrich_pypi` calls `_extract_pypi_first_release` on the already-fetched `releases` dict and merges
the result into the return value.

The output renderer for PyPI packages now includes:

```
First released:   2011-02-14 (14.4 yrs old)  first version: 0.2.0
```

## Changes

- `src/manus_agent/tools/get_dependency_blast_radius.py`
  - Added `import datetime` (stdlib, no new dependency)
  - New `_extract_pypi_first_release(releases)` function
  - `_enrich_pypi`: passes `releases` dict to `_extract_pypi_first_release` and merges result
  - Output rendering: shows `First released: YYYY-MM-DD (N.N yrs old)  first version: x.y.z` for PyPI packages

- `tests/test_dependency_blast_radius.py`
  - Added `_extract_pypi_first_release` to import block
  - `TestEnrichPypi`: 2 new tests (`test_returns_first_release_date_when_timestamps_present`, `test_no_first_release_when_no_timestamps`)
  - New `TestExtractPypiFirstRelease` class: 9 tests covering oldest-version selection, multi-file versions, empty/missing/malformed timestamps, microsecond precision, age calculation
  - `TestGetDependencyBlastRadius`: 1 new test (`test_first_release_date_shown_in_output`) verifying the output rendering

## Test results

```
985 → 997 passing (+12), 0 failures, ruff clean
```

## Symmetry with PR #96

This PR is the PyPI equivalent of PR #96 (`feat/maven-first-release-date`), which added `first_release_date` via the Maven Central GAV index. Both follow the same pattern: extract library age from the ecosystem's existing metadata endpoint, add `first_version` + `first_release_date (YYYY-MM-DD)` + `age_years` to the enrichment result, and show them in the CLI output.

The PyPI implementation is simpler because the data lives in the same JSON response already being fetched, requiring no second HTTP call.

## Open PRs checked for overlap (no duplicates)

#51, #53, #54, #58, #60, #64, #65, #67, #74, #75, #76, #77, #78, #79, #80, #82, #83, #85, #86, #87, #88, #89, #90, #92, #93, #96, #97
