### PR TITLE
test(submit-cves): fix main CI — align missing-URL tests with error-status contract

### DIFF
--- a/tests/test_submit_cves_and_logger.py
+++ b/tests/test_submit_cves_and_logger.py
@@ -8,8 +8,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -207,8 +205,9 @@ class TestSubmitCvesInputValidation:
 
 
 class TestSubmitCvesMissingUrl:
-    def test_no_url_raises_value_error(self, monkeypatch):
-        """When neither config nor env has a webhook URL, submit_cves raises ValueError."""
+    def test_no_url_returns_error_status(self, monkeypatch):
+        """When neither config nor env has a webhook URL, submit_cves returns an
+        error-status dict instead of raising ValueError to the caller."""
         monkeypatch.delenv("CVE_SUBMIT_URL", raising=False)
         with patch("manus_agent.tools.submit_cves.Config") as mock_config:
             cfg = MagicMock()
@@ -217,11 +216,11 @@ class TestSubmitCvesMissingUrl:
 
             from manus_agent.tools.submit_cves import submit_cves
 
-            with pytest.raises(ValueError, match="webhook URL"):
-                submit_cves(_make_tool_use())
+            result = submit_cves(_make_tool_use())
+            assert result["status"] == "error"
 
     def test_no_url_error_message_mentions_config_toml(self, monkeypatch):
-        """ValueError message should guide users to config.toml."""
+        """Error message should guide users to config.toml."""
         monkeypatch.delenv("CVE_SUBMIT_URL", raising=False)
         with patch("manus_agent.tools.submit_cves.Config") as mock_config:
             cfg = MagicMock()
@@ -230,8 +229,9 @@ class TestSubmitCvesMissingUrl:
 
             from manus_agent.tools.submit_cves import submit_cves
 
-            with pytest.raises(ValueError, match="config.toml"):
-                submit_cves(_make_tool_use())
+            result = submit_cves(_make_tool_use())
+            assert result["status"] == "error"
+            assert "config.toml" in result["content"][0]["text"]
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

`main` CI is **red** (`Tests (Python 3.11)` and `Tests (Python 3.12)`) after PR #92 and #93 merged. Two tests fail with `DID NOT RAISE ValueError`:

- `tests/test_submit_cves_and_logger.py::TestSubmitCvesMissingUrl::test_no_url_raises_value_error`
- `tests/test_submit_cves_and_logger.py::TestSubmitCvesMissingUrl::test_no_url_error_message_mentions_config_toml`

## Root cause — a merge collision between two competing PRs

- **PR #93** deliberately moved the webhook-URL validation *inside* the `try` block in `submit_cves()` so a missing URL **returns `{"status": "error"}` instead of raising `ValueError`** to the caller. There's an explicit source comment documenting this, and its tests in `test_bug_fixes.py::TestSubmitCvesMissingUrl` assert the error-status contract (they pass).
- **PR #92** added a *second* `TestSubmitCvesMissingUrl` class in `test_submit_cves_and_logger.py` that still expects the **old** behavior (`pytest.raises(ValueError)`).

Both merged independently, so the source now follows #93's design while #92's stale tests still assert the removed raise → CI breaks.

## Fix

Update the two stale tests to assert the current, intended contract (error-status dict + `config.toml` hint in the message), matching the source and the passing sibling tests in `test_bug_fixes.py`. Also drops the now-unused `pytest` import (ruff F401).

This is the correct direction: reverting the source would break #93's deliberate design and its passing test suite.

## Verification

- Full suite: **1152 passed + 2 failed → 1154 passed**, 3 deselected, 0 failures (Python 3.11 & 3.12)
- `ruff check` + `ruff format --check` clean
- No source/behavior change — test-only