### PR TITLE
feat(tools): add first_release_date to _enrich_npm via npm registry timestamps

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -10,7 +10,7 @@ Data sources (all free, no API key required):
   2. OSV.dev API       — cross-ecosystem vulnerability data (PyPI, npm, Maven,
                          Go, RubyGems, crates.io, …)
   3. GitHub Advisory DB — GHSA packages + ecosystems
-  4. npm registry API  — dependents count + weekly download stats (npm only)
+  4. npm registry API  — dependents count + weekly download stats + first release date (npm only)
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
   6. Maven Central     — artifact metadata + version count (Maven only)
@@ -24,6 +24,7 @@ CLI: ``manus-agent blast-radius requests@2.28.0``
 
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 from typing import Any
@@ -48,6 +49,7 @@ _OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{}"
 _GHSA_URL = "https://api.github.com/advisories"
 _NPM_SEARCH_URL = "https://registry.npmjs.org/-/v1/search"
 _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
+_NPM_REGISTRY_URL = "https://registry.npmjs.org/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
@@ -301,8 +303,57 @@ def _fetch_ghsa_affected(cve_id: str) -> list[dict[str, str]]:
 # ---------------------------------------------------------------------------
 
 
+def _extract_npm_first_release(time_dict: dict[str, str]) -> dict[str, Any]:
+    """Return first_version/first_release_date/age_years from the npm registry ``time`` dict.
+
+    The ``time`` dict maps version strings to ISO-8601 timestamps.  Two special
+    keys (``created`` and ``modified``) are not version identifiers and must be
+    skipped.  We find the version with the oldest timestamp and return:
+
+    .. code-block:: python
+
+        {
+            "first_version":      "0.1.0",
+            "first_release_date": "2012-06-03",
+            "age_years":          12.1,
+        }
+
+    Returns an empty dict on any error (missing keys, malformed timestamps, …).
+    """
+    _skip = {"created", "modified"}
+    earliest_ts: datetime.datetime | None = None
+    earliest_ver: str = ""
+
+    for ver, ts_str in time_dict.items():
+        if ver in _skip:
+            continue
+        try:
+            # npm timestamps are like "2012-06-03T15:33:30.215Z"
+            ts_clean = ts_str.rstrip("Z").split("+")[0]
+            # Handle optional microseconds
+            fmt = "%Y-%m-%dT%H:%M:%S.%f" if "." in ts_clean else "%Y-%m-%dT%H:%M:%S"
+            naive = datetime.datetime.strptime(ts_clean, fmt)
+            ts = naive.replace(tzinfo=datetime.timezone.utc)
+        except (ValueError, AttributeError):
+            continue
+        if earliest_ts is None or ts < earliest_ts:
+            earliest_ts = ts
+            earliest_ver = ver
+
+    if earliest_ts is None:
+        return {}
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    age_years = round((now - earliest_ts).days / 365.25, 1)
+    return {
+        "first_version": earliest_ver,
+        "first_release_date": earliest_ts.strftime("%Y-%m-%d"),
+        "age_years": age_years,
+    }
+
+
 def _enrich_npm(name: str) -> dict[str, Any]:
-    """Fetch npm dependent count + weekly downloads."""
+    """Fetch npm dependent count, weekly downloads, and first release date."""
     result: dict[str, Any] = {"ecosystem": "npm", "package_name": name}
     try:
         # Search returns dependents count
@@ -320,6 +371,16 @@ def _enrich_npm(name: str) -> dict[str, Any]:
             result["weekly_downloads"] = dl_data.get("downloads", 0)
     except Exception as exc:
         logger.debug("npm enrich failed for %s: %s", name, exc)
+
+    # Second call: npm registry for version timestamps → first release date
+    try:
+        reg_data = _get(_NPM_REGISTRY_URL.format(name))
+        time_dict = reg_data.get("time", {})
+        first_info = _extract_npm_first_release(time_dict)
+        result.update(first_info)
+    except Exception as exc:
+        logger.debug("npm registry call failed for %s: %s", name, exc)
+
     return result
 
 
@@ -430,7 +491,7 @@ def get_dependency_blast_radius(  # noqa: C901
     1. Identifies the affected package(s) and version range(s) from NVD,
        OSV.dev, and the GitHub Advisory Database.
     2. For each affected package, fetches downstream exposure metrics:
-       - **npm**: dependent package count + weekly/monthly download stats
+       - **npm**: dependent package count + weekly/monthly download stats + first release date / age
        - **PyPI**: package metadata + download stats (when pypistats is available)
        - **Maven**: artifact metadata from Maven Central
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
@@ -540,6 +601,12 @@ def get_dependency_blast_radius(  # noqa: C901
             lines.append(f"    Weekly downloads: {r['weekly_downloads']:,}")
         if r.get("monthly_downloads") is not None:
             lines.append(f"    Monthly downloads:{r['monthly_downloads']:,}")
+        if eco.lower() in ("npm", "javascript", "node"):
+            if r.get("first_release_date"):
+                lines.append(
+                    f"    First released:   {r['first_release_date']}"
+                    f" ({r['age_years']} yrs old)  first version: {r.get('first_version', '')}"
+                )
 
         # PyPI-specific stats
         if eco.lower() in ("pypi", "python"):

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -18,6 +18,7 @@ from manus_agent.tools.get_dependency_blast_radius import (
     _enrich_npm,
     _enrich_package,
     _enrich_pypi,
+    _extract_npm_first_release,
     _fetch_ghsa_affected,
     _fetch_nvd_affected,
     _fetch_osv_affected,
@@ -533,6 +534,201 @@ class TestEnrichNpm:
         with patch("requests.get", return_value=mock_resp):
             result = _enrich_npm("lodash")
         assert result.get("dependent_packages_count") == 100
+
+
+# ===========================================================================
+# _extract_npm_first_release
+# ===========================================================================
+
+
+class TestExtractNpmFirstRelease:
+    """Tests for the _extract_npm_first_release helper."""
+
+    def _time_dict(self, versions: dict[str, str]) -> dict[str, str]:
+        """Build a minimal npm time dict including created/modified noise."""
+        d = {
+            "created": "2010-01-01T00:00:00.000Z",
+            "modified": "2024-01-01T00:00:00.000Z",
+        }
+        d.update(versions)
+        return d
+
+    def test_returns_oldest_version(self):
+        time_dict = self._time_dict(
+            {
+                "0.1.0": "2012-06-03T10:00:00.000Z",
+                "1.0.0": "2015-03-15T10:00:00.000Z",
+                "4.17.21": "2021-02-02T10:00:00.000Z",
+            }
+        )
+        result = _extract_npm_first_release(time_dict)
+        assert result["first_version"] == "0.1.0"
+        assert result["first_release_date"] == "2012-06-03"
+        assert isinstance(result["age_years"], float)
+        assert result["age_years"] > 10
+
+    def test_skips_created_and_modified_keys(self):
+        # created/modified are very early; they must not be treated as versions
+        time_dict = {
+            "created": "2000-01-01T00:00:00.000Z",
+            "modified": "2001-01-01T00:00:00.000Z",
+            "1.0.0": "2018-05-20T12:00:00.000Z",
+        }
+        result = _extract_npm_first_release(time_dict)
+        assert result["first_version"] == "1.0.0"
+        assert result["first_release_date"] == "2018-05-20"
+
+    def test_returns_empty_dict_for_empty_input(self):
+        assert _extract_npm_first_release({}) == {}
+
+    def test_returns_empty_dict_when_only_special_keys(self):
+        time_dict = {"created": "2020-01-01T00:00:00.000Z", "modified": "2021-01-01T00:00:00.000Z"}
+        assert _extract_npm_first_release(time_dict) == {}
+
+    def test_handles_malformed_timestamp_gracefully(self):
+        time_dict = self._time_dict(
+            {
+                "1.0.0": "NOT-A-DATE",
+                "2.0.0": "2020-01-15T08:00:00.000Z",
+            }
+        )
+        result = _extract_npm_first_release(time_dict)
+        # Malformed entry skipped; valid one returned
+        assert result["first_version"] == "2.0.0"
+        assert result["first_release_date"] == "2020-01-15"
+
+    def test_handles_timestamp_without_microseconds(self):
+        time_dict = self._time_dict(
+            {
+                "0.5.0": "2013-07-04T14:30:00Z",
+            }
+        )
+        result = _extract_npm_first_release(time_dict)
+        assert result["first_release_date"] == "2013-07-04"
+
+    def test_handles_all_malformed_returns_empty(self):
+        time_dict = self._time_dict(
+            {
+                "1.0.0": "bad",
+                "2.0.0": "also-bad",
+            }
+        )
+        assert _extract_npm_first_release(time_dict) == {}
+
+    def test_age_years_is_reasonable(self):
+        time_dict = self._time_dict({"1.0.0": "2010-01-01T00:00:00.000Z"})
+        result = _extract_npm_first_release(time_dict)
+        # As of 2026, this package would be ~16 years old
+        assert result["age_years"] >= 14
+
+    def test_single_version_entry(self):
+        time_dict = {"1.0.0": "2019-11-11T11:11:11.111Z"}
+        result = _extract_npm_first_release(time_dict)
+        assert result["first_version"] == "1.0.0"
+        assert result["first_release_date"] == "2019-11-11"
+
+
+# ===========================================================================
+# _enrich_npm — registry call tests (first_release_date)
+# ===========================================================================
+
+
+class TestEnrichNpmFirstRelease:
+    """Tests for the registry HTTP call added to _enrich_npm."""
+
+    def _make_search_response(self, name: str, dependents: int = 1000, weekly: int = 5000000) -> dict:
+        return {
+            "objects": [
+                {
+                    "package": {"name": name},
+                    "dependents": str(dependents),
+                    "downloads": {"weekly": weekly, "monthly": weekly * 4},
+                }
+            ]
+        }
+
+    def _make_registry_response(self, name: str) -> dict:
+        return {
+            "name": name,
+            "time": {
+                "created": "2014-01-01T00:00:00.000Z",
+                "modified": "2024-06-01T00:00:00.000Z",
+                "0.1.0": "2014-01-15T10:00:00.000Z",
+                "1.0.0": "2015-06-01T10:00:00.000Z",
+                "4.17.21": "2021-02-02T10:00:00.000Z",
+            },
+        }
+
+    def test_first_release_date_included_in_result(self):
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response("lodash")
+        reg_resp = MagicMock()
+        reg_resp.json.return_value = self._make_registry_response("lodash")
+        with patch("requests.get", side_effect=[search_resp, reg_resp]):
+            result = _enrich_npm("lodash")
+        assert result["first_version"] == "0.1.0"
+        assert result["first_release_date"] == "2014-01-15"
+        assert isinstance(result["age_years"], float)
+
+    def test_graceful_degradation_when_registry_fails(self):
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response("axios")
+        with patch("requests.get", side_effect=[search_resp, Exception("503 Service Unavailable")]):
+            result = _enrich_npm("axios")
+        # Counts still returned; first_release_date absent but no crash
+        assert result["ecosystem"] == "npm"
+        assert "first_release_date" not in result
+        assert result["weekly_downloads"] == 5000000
+
+    def test_graceful_degradation_when_registry_returns_no_time_dict(self):
+        search_resp = MagicMock()
+        search_resp.json.return_value = self._make_search_response("express")
+        reg_resp = MagicMock()
+        reg_resp.json.return_value = {"name": "express"}  # no 'time' key
+        with patch("requests.get", side_effect=[search_resp, reg_resp]):
+            result = _enrich_npm("express")
+        assert "first_release_date" not in result
+
+    def test_first_release_date_shown_in_output(self):
+        """Integration: first release date appears in the rendered text output."""
+        from unittest.mock import patch
+
+        # Build a minimal enriched result with first_release_date populated
+        npm_result = {
+            "ecosystem": "npm",
+            "package_name": "lodash",
+            "blast_radius": "HIGH",
+            "version_range": "<4.17.21",
+            "dependent_packages_count": 200000,
+            "weekly_downloads": 50000000,
+            "monthly_downloads": 200000000,
+            "first_version": "0.1.0",
+            "first_release_date": "2014-01-15",
+            "age_years": 12.5,
+            "source": "NVD",
+        }
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_npm",
+            return_value=npm_result,
+        ):
+            with patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_nvd_affected",
+                return_value=[{"name": "lodash", "ecosystem": "npm", "version_range": "<4.17.21"}],
+            ):
+                with patch(
+                    "manus_agent.tools.get_dependency_blast_radius._fetch_osv_affected",
+                    return_value=[],
+                ):
+                    with patch(
+                        "manus_agent.tools.get_dependency_blast_radius._fetch_ghsa_affected",
+                        return_value=[],
+                    ):
+                        output = get_dependency_blast_radius("CVE-2021-23337")
+
+        assert "First released:" in output
+        assert "2014-01-15" in output
+        assert "0.1.0" in output
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Adds **first release date** and **library age** signals to `_enrich_npm` in
`get_dependency_blast_radius.py` — completing the trilogy started by
PR #96 (Maven) and PR #98 (PyPI).

**New keys added to `_enrich_npm` result:**

| Key | Example |
|-----|---------|
| `first_version` | `"0.1.0"` |
| `first_release_date` | `"2014-01-15"` |
| `age_years` | `12.5` |

**Output rendering** shows the new data:
```
First released:   2014-01-15 (12.5 yrs old)  first version: 0.1.0
```

## Design

### Data source

The npm registry package endpoint (`https://registry.npmjs.org/{name}`) returns
a `time` dict mapping every published version to its ISO-8601 publish timestamp
(plus two special keys `created` and `modified` which are skipped).
`min(timestamp)` across version entries gives the first release date.

This is a **second HTTP call** added to `_enrich_npm` (after the existing
search + downloads calls). The call is isolated in its own `try/except` block:
if the registry is unreachable, the result degrades gracefully — only
`first_release_date`, `first_version`, and `age_years` keys are absent; all
download/dependent counts are unaffected.

### Helper function

`_extract_npm_first_release(time_dict: dict[str, str]) -> dict[str, Any]`

- Skips `created` / `modified` special keys
- Handles both microsecond (`2019-11-11T11:11:11.111Z`) and non-microsecond
  (`2013-07-04T14:30:00Z`) ISO timestamps
- Uses timezone-aware `datetime.timezone.utc` (avoids Python 3.12 deprecation)
- Returns `{}` on any error (empty input, all-malformed timestamps, etc.)

### Symmetric design

The same `first_version` / `first_release_date` / `age_years` keys are used by
PR #96 (Maven) and PR #98 (PyPI), making it easy to handle all three ecosystems
uniformly in downstream consumers.

## Tests

13 new fully-mocked tests, 0 real HTTP calls:

**`TestExtractNpmFirstRelease`** (9 tests):
- Returns oldest version (not `created`/`modified`)
- Skips `created` and `modified` special keys
- Empty dict on empty input
- Empty dict when only special keys present
- Graceful handling of malformed timestamps
- Handles timestamps without microseconds
- All-malformed → empty dict
- `age_years` sanity check
- Single-version entry

**`TestEnrichNpmFirstRelease`** (4 tests):
- `first_release_date` included in result when registry responds
- Graceful degradation when registry HTTP call fails (download counts still returned)
- Graceful degradation when registry response has no `time` key
- Integration: `first_release_date` appears in rendered text output

Previous `TestEnrichNpm` (4 tests) all continue to pass — the registry call is
independent from the search/downloads logic.

**Suite delta:** 74 → 87 passing, 0 failures, 0 ruff issues.

## Checked open PRs (no overlap)

This PR does not duplicate any open or merged PR. Checked against:
#51, #53, #54, #58, #60, #64, #65, #67, #74, #75, #76, #77, #78, #79, #80,
#82, #83, #85, #86, #87, #88, #89, #90, #92, #93, #94, #95, #96, #97, #98

The closest PRs are #96 (Maven `first_release_date`) and #98 (PyPI
`first_release_date`) — this PR extends the same pattern to npm, completing
the trilogy for all three major ecosystems supported by the blast-radius tool.
