### PR TITLE
fix(vi-agent): drop no-op timeout kwarg; guard optional browser_use imports

### DIFF
--- a/src/manus_agent/agents/browser.py
+++ b/src/manus_agent/agents/browser.py
@@ -1,11 +1,16 @@
 import asyncio
 
-from browser_use.agent.service import Agent
+try:
+    from browser_use.agent.service import Agent
 
-# from browser_use import Agent, ActionResult
-from browser_use.browser.browser import BrowserProfile, BrowserSession
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatAnthropicBedrock
+    # from browser_use import Agent, ActionResult
+    from browser_use.browser.browser import BrowserProfile, BrowserSession
+    from browser_use.controller.service import Controller
+    from browser_use.llm import ChatAnthropicBedrock
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "This module requires the optional 'browser' extra. Install it with: pip install 'manus-agent[browser]'"
+    ) from exc
 from pydantic import BaseModel, Field
 
 

--- a/src/manus_agent/agents/vi_agent.py
+++ b/src/manus_agent/agents/vi_agent.py
@@ -290,7 +290,12 @@ class VulnerabilityIntelligenceAgent:
         cleaned up afterwards.
         """
         try:
-            return self.agent(request, timeout=600)
+            # NOTE: Strands ``Agent.__call__`` has no ``timeout`` parameter; any
+            # extra kwargs are folded into the (deprecated) event-loop
+            # ``invocation_state`` and silently ignored, so passing
+            # ``timeout=600`` here enforced nothing. The real wall-clock cap is
+            # applied by ``GoalLoop(timeout=900.0)`` in ``_build_agent``.
+            return self.agent(request)
         finally:
             cleanup = getattr(self._local_chromium_browser, "_cleanup", None)
             if callable(cleanup):

--- a/src/manus_agent/mcp/browser.py
+++ b/src/manus_agent/mcp/browser.py
@@ -5,12 +5,18 @@ import logging
 import sys
 
 import requests
-from browser_use.agent.service import Agent
 
-# from browser_use import Agent, ActionResult
-from browser_use.browser.browser import BrowserProfile, BrowserSession
-from browser_use.controller.service import Controller
-from browser_use.llm import ChatAnthropicBedrock
+try:
+    from browser_use.agent.service import Agent
+
+    # from browser_use import Agent, ActionResult
+    from browser_use.browser.browser import BrowserProfile, BrowserSession
+    from browser_use.controller.service import Controller
+    from browser_use.llm import ChatAnthropicBedrock
+except ImportError as exc:  # pragma: no cover - optional dependency
+    raise ImportError(
+        "This module requires the optional 'browser' extra. Install it with: pip install 'manus-agent[browser]'"
+    ) from exc
 from mcp.server.fastmcp import FastMCP
 from pydantic import BaseModel, Field
 

--- a/tests/test_vi_agent.py
+++ b/tests/test_vi_agent.py
@@ -111,6 +111,28 @@ def test_run_analyze_calls_handle_request_with_cve():
     assert "CVE-2025-6554" in sent
 
 
+def test_handle_request_does_not_pass_timeout_kwarg_to_agent():
+    """``Agent.__call__`` has no ``timeout`` param; ensure we don't pass one.
+
+    Strands folds unknown kwargs into the deprecated event-loop
+    ``invocation_state`` and ignores them, so a ``timeout=`` kwarg here would
+    be a silent no-op. The real cap lives in ``GoalLoop(timeout=...)``.
+    """
+    from manus_agent.agents.vi_agent import VulnerabilityIntelligenceAgent
+
+    with mock.patch.object(VulnerabilityIntelligenceAgent, "__init__", return_value=None):
+        agent = VulnerabilityIntelligenceAgent()
+        agent.agent = mock.MagicMock(return_value="REPORT")
+        agent._local_chromium_browser = None
+
+        result = agent.handle_request("analyze CVE-2025-6554")
+
+    assert result == "REPORT"
+    agent.agent.assert_called_once()
+    assert "timeout" not in agent.agent.call_args.kwargs
+    assert agent.agent.call_args.args == ("analyze CVE-2025-6554",)
+
+
 # ---------------------------------------------------------------------------
 # Prompt <-> validator alignment (drift guard)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

Two small, evidence-driven fixes verified against the installed Strands source.

### 1. Drop the no-op `timeout=600` kwarg in `handle_request` (the real fix)
`vi_agent.handle_request` called `self.agent(request, timeout=600)`. Inspecting the installed Strands `Agent.__call__`:

```
def __call__(self, prompt=None, *, invocation_state=None, structured_output_model=None,
             structured_output_prompt=None, idempotency_token=None, limits=None, **kwargs): ...
```

There is **no `timeout` parameter**. Unknown kwargs are folded into the **deprecated** event-loop `invocation_state` (docstring: *"Additional parameters to pass through the event loop [Deprecating]"*) and ignored — so `timeout=600` **enforced nothing** and rode a deprecation path. It was also inconsistent with the sibling agents (`remediation`, `variant`, `vd`), which all call `self.agent(request)` with no timeout.

The real wall-clock cap already lives in `GoalLoop(timeout=900.0)` in `_build_agent`, which *is* an honored parameter (`GoalLoop.__init__(..., timeout: float = inf, ...)`).

- Removed the bogus kwarg (with an explanatory comment).
- Added `test_handle_request_does_not_pass_timeout_kwarg_to_agent` to lock the behavior in.

> This resolves the `handle_request(timeout=600)` vs `GoalLoop(timeout=900)` mismatch flagged during the #101 review — the answer is that `timeout=600` was never doing anything.

### 2. Guard optional `browser_use` imports in the two standalone modules
`agents/browser.py` and `mcp/browser.py` imported `browser_use` at module top level. `browser_use` is an **optional** extra (`[project.optional-dependencies].browser`), and `browser_use_agent.py` already guards it — but these two standalone modules didn't, so a direct importer without the extra got a raw `ModuleNotFoundError`.

Wrapped their `browser_use` imports in `try/except ImportError` that re-raises with an actionable message:

```
This module requires the optional 'browser' extra.
Install it with: pip install 'manus-agent[browser]'
```

The package already imports cleanly without the extra (verified by simulating a missing `browser_use`); this just makes the two direct-import entry points fail gracefully and consistently with the rest of the codebase.

## Verification
- **Full suite: 1158 passed**, 3 deselected, 0 failures (was 1157; +1 new regression test).
- `ruff check` clean, `ruff format --check` clean on all touched files.
- Simulated a missing `browser_use`: `import manus_agent.agents` still succeeds (9 exports); both standalone modules raise the friendly `[browser]`-extra ImportError.

## Not included
No behavioral timeout is added in place of the removed one — `GoalLoop(timeout=900.0)` already provides the wall-clock cap. If a *tighter* per-request cap is desired later, that's a deliberate design choice for a separate change.
