### PR TITLE
feat: add crates.io enrichment to get_dependency_blast_radius

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -14,6 +14,8 @@ Data sources (all free, no API key required):
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
   6. Maven Central     — artifact metadata + version count (Maven only)
+  7. crates.io API     — Rust crate metadata: all-time + recent downloads,
+                         reverse-dependency count, first release date (crates.io only)
 
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
@@ -24,6 +26,7 @@ CLI: ``manus-agent blast-radius requests@2.28.0``
 
 from __future__ import annotations
 
+import datetime
 import logging
 import re
 from typing import Any
@@ -51,6 +54,9 @@ _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+_CRATES_IO_CRATE_URL = "https://crates.io/api/v1/crates/{}"
+_CRATES_IO_RDEPS_URL = "https://crates.io/api/v1/crates/{}/reverse_dependencies"
+_CRATES_IO_USER_AGENT = "manus-agent/1.0 (https://github.com/manus-use/manus-agent)"
 
 _TIMEOUT = 20
 
@@ -373,6 +379,48 @@ def _enrich_maven(name: str) -> dict[str, Any]:
     return result
 
 
+def _enrich_crates(name: str) -> dict[str, Any]:
+    """Fetch crates.io crate metadata: downloads, reverse-dep count, first release date."""
+    result: dict[str, Any] = {"ecosystem": "crates.io", "package_name": name}
+    headers = {"User-Agent": _CRATES_IO_USER_AGENT}
+    try:
+        crate_data = _get(_CRATES_IO_CRATE_URL.format(name), headers=headers)
+        crate = crate_data.get("crate", {})
+        if crate:
+            result["description"] = (crate.get("description") or "")[:120]
+            result["newest_version"] = crate.get("newest_version") or crate.get("max_version", "")
+            result["total_downloads"] = crate.get("downloads", 0)
+            result["recent_downloads"] = crate.get("recent_downloads", 0)
+            result["homepage"] = crate.get("homepage") or crate.get("repository") or ""
+            # created_at is the first-publish timestamp — same signal as first_release_date
+            created_at = crate.get("created_at", "")
+            if created_at:
+                try:
+                    # Strip trailing Z and parse ISO-8601
+                    ts_str = created_at.rstrip("Z").split("+")[0]
+                    if "." in ts_str:
+                        ts_str = ts_str[: ts_str.index(".") + 7]  # keep up to 6 decimal places
+                    dt = datetime.datetime.fromisoformat(ts_str).replace(tzinfo=datetime.timezone.utc)
+                    result["first_release_date"] = dt.strftime("%Y-%m-%d")
+                    now_utc = datetime.datetime.now(datetime.timezone.utc)
+                    result["age_years"] = round((now_utc - dt).days / 365.25, 1)
+                except (ValueError, OverflowError):
+                    pass
+        # Reverse-dependency count (second call — graceful on failure)
+        try:
+            rdeps_data = _get(
+                _CRATES_IO_RDEPS_URL.format(name),
+                params={"per_page": 1},
+                headers=headers,
+            )
+            result["dependent_packages_count"] = rdeps_data.get("meta", {}).get("total", 0)
+        except Exception as exc:
+            logger.debug("crates.io reverse_dependencies failed for %s: %s", name, exc)
+    except Exception as exc:
+        logger.debug("crates.io enrich failed for %s: %s", name, exc)
+    return result
+
+
 def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
     """Dispatch to the right enrichment function based on ecosystem."""
     eco_lower = (ecosystem or "").lower()
@@ -382,6 +430,8 @@ def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
         return _enrich_pypi(name)
     elif eco_lower in ("maven", "java", "gradle"):
         return _enrich_maven(name)
+    elif eco_lower in ("crates.io", "rust", "cargo"):
+        return _enrich_crates(name)
     # Unknown ecosystem — return minimal record
     return {"ecosystem": ecosystem, "package_name": name}
 
@@ -395,9 +445,13 @@ def _blast_score(stats: dict[str, Any]) -> str:
     """
     Produce a qualitative blast-radius label based on download/dependent counts.
 
+    Uses ``weekly_downloads`` when available (npm, PyPI); falls back to
+    ``recent_downloads`` for ecosystems like crates.io that report
+    a recent-period total instead of a weekly figure.
+
     Returns one of: critical / high / medium / low / unknown
     """
-    weekly = stats.get("weekly_downloads") or 0
+    weekly = stats.get("weekly_downloads") or stats.get("recent_downloads") or 0
     dependents = stats.get("dependent_packages_count") or 0
 
     if weekly >= 5_000_000 or dependents >= 50_000:
@@ -433,6 +487,7 @@ def get_dependency_blast_radius(  # noqa: C901
        - **npm**: dependent package count + weekly/monthly download stats
        - **PyPI**: package metadata + download stats (when pypistats is available)
        - **Maven**: artifact metadata from Maven Central
+       - **crates.io**: all-time + recent downloads, reverse-dep count, first release date
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
 
     Use after ``get_nvd_data`` to understand *how many projects are exposed*
@@ -534,12 +589,13 @@ def get_dependency_blast_radius(  # noqa: C901
             lines.append(f"    Vulnerable range: {ver_range}")
 
         # npm-specific stats
-        if "dependent_packages_count" in r:
-            lines.append(f"    npm dependents:   {r['dependent_packages_count']:,}")
-        if r.get("weekly_downloads") is not None:
-            lines.append(f"    Weekly downloads: {r['weekly_downloads']:,}")
-        if r.get("monthly_downloads") is not None:
-            lines.append(f"    Monthly downloads:{r['monthly_downloads']:,}")
+        if eco.lower() in ("npm", "javascript", "node"):
+            if "dependent_packages_count" in r:
+                lines.append(f"    npm dependents:   {r['dependent_packages_count']:,}")
+            if r.get("weekly_downloads") is not None:
+                lines.append(f"    Weekly downloads: {r['weekly_downloads']:,}")
+            if r.get("monthly_downloads") is not None:
+                lines.append(f"    Monthly downloads:{r['monthly_downloads']:,}")
 
         # PyPI-specific stats
         if eco.lower() in ("pypi", "python"):
@@ -558,6 +614,22 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("version_count"):
                 lines.append(f"    Version count:    {r['version_count']}")
+
+        # crates.io-specific stats
+        if eco.lower() in ("crates.io", "rust", "cargo"):
+            if r.get("newest_version"):
+                lines.append(f"    Latest version:   {r['newest_version']}")
+            if "dependent_packages_count" in r:
+                lines.append(f"    Reverse deps:     {r['dependent_packages_count']:,}")
+            if r.get("total_downloads") is not None:
+                lines.append(f"    All-time DLs:     {r['total_downloads']:,}")
+            if r.get("recent_downloads") is not None:
+                lines.append(f"    Recent DLs:       {r['recent_downloads']:,}")
+            if r.get("first_release_date"):
+                age = f"  ({r['age_years']} yrs old)" if r.get("age_years") is not None else ""
+                lines.append(f"    First released:   {r['first_release_date']}{age}")
+            if r.get("description"):
+                lines.append(f"    Description:      {r['description'][:80]}")
 
         if source:
             lines.append(f"    Data sources:     {source}")

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -2,7 +2,7 @@
 Tests for src/manus_agent/tools/get_dependency_blast_radius.py
 
 All external HTTP calls are mocked — no real network I/O.
-100% mocked: NVD, OSV, GHSA, npm, PyPI, pypistats, Maven Central.
+100% mocked: NVD, OSV, GHSA, npm, PyPI, pypistats, Maven Central, crates.io.
 """
 
 from __future__ import annotations
@@ -933,3 +933,342 @@ class TestCliParser:
         from manus_agent.cli import _SUBCOMMANDS
 
         assert "blast-radius" in _SUBCOMMANDS
+
+
+# ===========================================================================
+# _enrich_crates
+# ===========================================================================
+
+
+def _make_crates_response(
+    name: str = "serde",
+    description: str = "A generic serialization/deserialization framework",
+    newest_version: str = "1.0.228",
+    downloads: int = 1_137_080_403,
+    recent_downloads: int = 226_277_234,
+    created_at: str = "2014-12-05T20:20:39.487502Z",
+    homepage: str = "https://serde.rs",
+) -> dict:
+    return {
+        "crate": {
+            "id": name,
+            "name": name,
+            "description": description,
+            "newest_version": newest_version,
+            "max_version": newest_version,
+            "downloads": downloads,
+            "recent_downloads": recent_downloads,
+            "created_at": created_at,
+            "homepage": homepage,
+            "repository": f"https://github.com/serde-rs/{name}",
+        }
+    }
+
+
+def _make_rdeps_response(total: int = 104_836) -> dict:
+    return {"versions": [], "meta": {"total": total}}
+
+
+class TestEnrichCrates:
+    def test_returns_full_metadata(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response()
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.status_code = 200
+        rdeps_resp.json.return_value = _make_rdeps_response(total=104_836)
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        assert result["ecosystem"] == "crates.io"
+        assert result["package_name"] == "serde"
+        assert result["newest_version"] == "1.0.228"
+        assert result["total_downloads"] == 1_137_080_403
+        assert result["recent_downloads"] == 226_277_234
+        assert result["dependent_packages_count"] == 104_836
+        assert result["description"] == "A generic serialization/deserialization framework"
+
+    def test_first_release_date_parsed(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response(created_at="2014-12-05T20:20:39.487502Z")
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.status_code = 200
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        assert result["first_release_date"] == "2014-12-05"
+        assert result["age_years"] >= 11.0  # serde is at least 11 years old
+
+    def test_first_release_date_no_microseconds(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response(created_at="2015-06-01T12:00:00Z")
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.status_code = 200
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("tokio")
+
+        assert result["first_release_date"] == "2015-06-01"
+
+    def test_graceful_degradation_on_main_call_error(self):
+        with patch("requests.get", side_effect=Exception("connection refused")):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        assert result["ecosystem"] == "crates.io"
+        assert result["package_name"] == "serde"
+        assert "total_downloads" not in result
+        assert "newest_version" not in result
+
+    def test_graceful_degradation_on_rdeps_error(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response()
+        crates_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, Exception("timeout")]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        # Main data should still be present
+        assert result["newest_version"] == "1.0.228"
+        assert result["total_downloads"] == 1_137_080_403
+        # But dependent_packages_count should be absent (graceful degradation)
+        assert "dependent_packages_count" not in result
+
+    def test_empty_crate_key_returns_minimal(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = {"crate": {}}
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.json.return_value = _make_rdeps_response(0)
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("unknown-crate")
+
+        assert result["ecosystem"] == "crates.io"
+
+    def test_malformed_created_at_skipped(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response(created_at="not-a-date")
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        # Bad date → no first_release_date key added
+        assert "first_release_date" not in result
+        assert "age_years" not in result
+
+    def test_empty_created_at_skipped(self):
+        crates_resp = MagicMock()
+        crates_resp.status_code = 200
+        crates_resp.json.return_value = _make_crates_response(created_at="")
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        assert "first_release_date" not in result
+
+    def test_homepage_falls_back_to_repository(self):
+        crate = _make_crates_response()
+        crate["crate"]["homepage"] = None
+        crate["crate"]["repository"] = "https://github.com/serde-rs/serde"
+
+        crates_resp = MagicMock()
+        crates_resp.json.return_value = crate
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("serde")
+
+        assert "github.com" in result.get("homepage", "")
+
+    def test_description_truncated_at_120(self):
+        long_desc = "A" * 200
+        crates_resp = MagicMock()
+        crates_resp.json.return_value = _make_crates_response(description=long_desc)
+        crates_resp.raise_for_status.return_value = None
+
+        rdeps_resp = MagicMock()
+        rdeps_resp.json.return_value = _make_rdeps_response()
+        rdeps_resp.raise_for_status.return_value = None
+
+        with patch("requests.get", side_effect=[crates_resp, rdeps_resp]):
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_crates
+
+            result = _enrich_crates("big-desc")
+
+        assert len(result["description"]) == 120
+
+
+# ===========================================================================
+# _enrich_package dispatch — crates.io
+# ===========================================================================
+
+
+class TestEnrichPackageDispatchCrates:
+    def test_crates_io_ecosystem(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_crates") as mock_crates:
+            mock_crates.return_value = {"ecosystem": "crates.io", "package_name": "serde"}
+            _enrich_package("serde", "crates.io")
+        mock_crates.assert_called_once_with("serde")
+
+    def test_rust_ecosystem_routes_to_crates(self):
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_crates") as mock_crates:
+            mock_crates.return_value = {"ecosystem": "crates.io", "package_name": "tokio"}
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+            _enrich_package("tokio", "rust")
+        mock_crates.assert_called_once_with("tokio")
+
+    def test_cargo_ecosystem_routes_to_crates(self):
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_crates") as mock_crates:
+            mock_crates.return_value = {"ecosystem": "crates.io", "package_name": "anyhow"}
+            from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+            _enrich_package("anyhow", "cargo")
+        mock_crates.assert_called_once_with("anyhow")
+
+
+# ===========================================================================
+# _blast_score — crates.io recent_downloads fallback
+# ===========================================================================
+
+
+class TestBlastScoreCratesIo:
+    def test_critical_via_recent_downloads(self):
+        assert _blast_score({"recent_downloads": 10_000_000}) == "CRITICAL"
+
+    def test_high_via_recent_downloads(self):
+        assert _blast_score({"recent_downloads": 1_000_000}) == "HIGH"
+
+    def test_medium_via_recent_downloads(self):
+        assert _blast_score({"recent_downloads": 100_000}) == "MEDIUM"
+
+    def test_low_via_recent_downloads(self):
+        assert _blast_score({"recent_downloads": 5_000}) == "LOW"
+
+    def test_weekly_takes_precedence_over_recent(self):
+        # weekly_downloads wins when both present
+        result = _blast_score({"weekly_downloads": 10_000_000, "recent_downloads": 1_000})
+        assert result == "CRITICAL"
+
+    def test_unknown_without_either(self):
+        assert _blast_score({"total_downloads": 5_000_000}) == "UNKNOWN"
+
+
+# ===========================================================================
+# Integration: crates.io package in full blast-radius output
+# ===========================================================================
+
+
+class TestGetBlastRadiusCratesIo:
+    def test_crates_package_spec_renders_output(self):
+        crates_stats = {
+            "ecosystem": "crates.io",
+            "package_name": "serde",
+            "newest_version": "1.0.228",
+            "total_downloads": 1_137_080_403,
+            "recent_downloads": 226_277_234,
+            "dependent_packages_count": 104_836,
+            "first_release_date": "2014-12-05",
+            "age_years": 11.6,
+            "description": "A generic serialization/deserialization framework",
+        }
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=crates_stats,
+        ):
+            result = get_dependency_blast_radius("crates.io:serde")
+
+        assert "serde" in result
+        assert "CRITICAL" in result
+        assert "1.0.228" in result
+        assert "2014-12-05" in result
+        assert "11.6" in result
+        assert "104,836" in result
+
+    def test_crates_cve_shows_crates_ecosystem(self):
+        pkgs = [
+            {
+                "name": "openssl",
+                "ecosystem": "crates.io",
+                "version_range": ">=0.10.0, <0.10.66",
+                "source": "osv",
+            }
+        ]
+        crates_stats = {
+            "ecosystem": "crates.io",
+            "package_name": "openssl",
+            "newest_version": "0.10.68",
+            "total_downloads": 250_000_000,
+            "recent_downloads": 35_000_000,
+            "dependent_packages_count": 12_500,
+            "first_release_date": "2015-01-15",
+            "age_years": 11.5,
+        }
+        with (
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=pkgs),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=crates_stats,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2023-0286")
+
+        assert "openssl" in result
+        assert "crates.io" in result.lower() or "Rust" in result
+        assert "HIGH" in result or "CRITICAL" in result


### PR DESCRIPTION
## Summary

Adds `_enrich_crates()` to `get_dependency_blast_radius`, completing ecosystem coverage for the blast-radius tool after Maven (#96), PyPI (#98), and npm (#100).

When a vulnerability affects a **crates.io** (Rust / Cargo) package, the tool now fetches and renders:

| Field | Source |
|---|---|
| Latest version | `crate.newest_version` |
| Reverse deps | `meta.total` from `/reverse_dependencies` |
| All-time downloads | `crate.downloads` |
| Recent downloads | `crate.recent_downloads` |
| First released | `crate.created_at` parsed to `YYYY-MM-DD` + age in years |
| Description | `crate.description` (truncated at 80 chars in output) |

## Changes

### `src/manus_agent/tools/get_dependency_blast_radius.py`

- **Constants**: `_CRATES_IO_CRATE_URL` and `_CRATES_IO_RDEPS_URL`
- **`_enrich_crates(name)`**: two-call enrichment with graceful degradation (rdeps failure does not prevent main metadata from being returned)
- **`_enrich_package` dispatch**: routes `crates.io` / `rust` / `cargo` ecosystems
- **Rendering block**: crates.io section after Maven block, consistent style
- **`_blast_score` update**: falls back to `recent_downloads` when `weekly_downloads` is absent (crates.io reports a rolling recent total rather than a weekly figure)
- **npm output gate**: now ecosystem-gated like PyPI and Maven (avoids showing "npm dependents" for crates packages that happen to have `dependent_packages_count`)
- **Module-level `import datetime`**: moved from inside the function

### `tests/test_dependency_blast_radius.py`

19 new test cases across four test classes:

- **`TestEnrichCrates`** (10): full metadata, ISO date parsing with/without microseconds, graceful degradation on main-call and rdeps errors, empty crate response, malformed/empty `created_at`, homepage→repository fallback, description truncation at 120 chars
- **`TestEnrichPackageDispatchCrates`** (3): `crates.io` / `rust` / `cargo` routing
- **`TestBlastScoreCratesIo`** (6): scoring via `recent_downloads`, `weekly_downloads` precedence, `UNKNOWN` without either field
- **`TestGetBlastRadiusCratesIo`** (2): end-to-end output rendering for package spec and CVE path

All 1179 tests pass. No real HTTP calls — 100% mocked.

## Testing

```
pytest tests/test_dependency_blast_radius.py -v  # 95 passed
pytest tests/ -q                                  # 1179 passed
```

## crates.io API

- `GET https://crates.io/api/v1/crates/{name}` — crate metadata
- `GET https://crates.io/api/v1/crates/{name}/reverse_dependencies?per_page=1` — reverse dep count
- Both requests include a `User-Agent` header per crates.io API policy
