### PR TITLE
feat(tools): conda/conda-forge enrichment in get_dependency_blast_radius

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -14,18 +14,22 @@ Data sources (all free, no API key required):
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
   6. Maven Central     — artifact metadata + version count (Maven only)
+  7. Anaconda API      — conda-forge / defaults channel metadata + total
+                         download counts (conda only; no auth required)
 
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
 
 CLI: ``manus-agent blast-radius requests@2.28.0``
      ``manus-agent blast-radius CVE-2021-44228``
+     ``manus-agent blast-radius conda:numpy@1.26.0``
 """
 
 from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime, timezone
 from typing import Any
 
 import requests
@@ -51,6 +55,8 @@ _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+_ANACONDA_PKG_URL = "https://api.anaconda.org/package/{channel}/{name}"
+_ANACONDA_CHANNELS = ("conda-forge", "anaconda")
 
 _TIMEOUT = 20
 
@@ -66,6 +72,7 @@ _ECOSYSTEM_LABEL: dict[str, str] = {
     "Packagist": "Packagist (PHP)",
     "Hex": "Hex (Elixir/Erlang)",
     "Pub": "Pub (Dart/Flutter)",
+    "conda": "conda (Anaconda/conda-forge)",
 }
 
 
@@ -373,6 +380,94 @@ def _enrich_maven(name: str) -> dict[str, Any]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# Conda enrichment helper
+# ---------------------------------------------------------------------------
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _parse_anaconda_timestamp(ts: str) -> datetime | None:
+    """Parse an Anaconda API timestamp string into a UTC-aware datetime.
+
+    Handles the format returned by ``api.anaconda.org``:
+    ``"2016-04-20 07:41:54.299000+00:00"``
+    """
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace(" ", "T")).astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _enrich_conda(name: str) -> dict[str, Any]:
+    """Fetch conda-forge (or Anaconda defaults) metadata for *name*.
+
+    Makes a single ``GET https://api.anaconda.org/package/{channel}/{name}``
+    request, trying ``conda-forge`` first then falling back to the ``anaconda``
+    defaults channel.  Extracts:
+
+    * ``total_downloads``   — cumulative all-time download counter (``ndownloads``)
+    * ``weekly_downloads``  — rolling weekly average (``total_downloads // 52``;
+                               Anaconda exposes no per-week endpoint)
+    * ``latest_version``    — current stable release
+    * ``total_versions``    — number of distinct versions published
+    * ``first_release_date`` / ``age_years`` — derived from the oldest
+                               ``upload_time`` across all published files
+    * ``description``       — package summary (truncated to 120 chars)
+    * ``license``           — SPDX license expression
+    * ``home_page``         — upstream project URL
+    * ``conda_page``        — Anaconda.org HTML page URL
+    """
+    result: dict[str, Any] = {"ecosystem": "conda", "package_name": name}
+    for channel in _ANACONDA_CHANNELS:
+        url = _ANACONDA_PKG_URL.format(channel=channel, name=name)
+        try:
+            data = _get(url)
+        except Exception as exc:
+            logger.debug("Anaconda enrich failed for %s/%s: %s", channel, name, exc)
+            continue  # try next channel
+
+        # --- download counts ------------------------------------------------
+        total_dl = data.get("ndownloads") or 0
+        result["total_downloads"] = total_dl
+        # weekly_downloads proxy: all-time / 52 weeks per year rolling average
+        result["weekly_downloads"] = int(total_dl // 52) if total_dl else None
+
+        # --- version metadata -----------------------------------------------
+        result["latest_version"] = data.get("latest_version") or ""
+        versions = data.get("versions") or []
+        result["total_versions"] = len(versions)
+
+        # --- first release date from file upload timestamps -----------------
+        files = data.get("files") or []
+        file_times = [_parse_anaconda_timestamp(f["upload_time"]) for f in files if f.get("upload_time")]
+        valid_times = [t for t in file_times if t is not None]
+        if valid_times:
+            first_dt = min(valid_times)
+            result["first_release_date"] = first_dt.strftime("%Y-%m-%d")
+            age_years = (datetime.now(timezone.utc) - first_dt).days / 365.25
+            result["age_years"] = round(age_years, 1)
+
+        # --- package metadata -----------------------------------------------
+        summary = (data.get("summary") or "").replace("\n", " ").strip()
+        if summary:
+            result["description"] = summary[:120]
+        if data.get("license"):
+            result["license"] = data["license"]
+        if data.get("home"):
+            result["home_page"] = data["home"]
+        if data.get("html_url"):
+            result["conda_page"] = data["html_url"]
+
+        result["channel"] = channel
+        return result  # success — no need to try fallback channel
+
+    # All channels failed — return minimal stub
+    return result
+
+
 def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
     """Dispatch to the right enrichment function based on ecosystem."""
     eco_lower = (ecosystem or "").lower()
@@ -382,6 +477,8 @@ def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
         return _enrich_pypi(name)
     elif eco_lower in ("maven", "java", "gradle"):
         return _enrich_maven(name)
+    elif eco_lower in ("conda", "conda-forge", "anaconda"):
+        return _enrich_conda(name)
     # Unknown ecosystem — return minimal record
     return {"ecosystem": ecosystem, "package_name": name}
 
@@ -433,6 +530,8 @@ def get_dependency_blast_radius(  # noqa: C901
        - **npm**: dependent package count + weekly/monthly download stats
        - **PyPI**: package metadata + download stats (when pypistats is available)
        - **Maven**: artifact metadata from Maven Central
+       - **conda**: total + estimated weekly downloads from Anaconda API
+         (conda-forge channel first, then Anaconda defaults)
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
 
     Use after ``get_nvd_data`` to understand *how many projects are exposed*
@@ -440,9 +539,12 @@ def get_dependency_blast_radius(  # noqa: C901
     the single vulnerable package.
 
     Args:
-        package_or_cve: Package spec (``name@version``, ``ecosystem:name@version``)
-                        or CVE ID (``CVE-YYYY-NNNN``).
-        max_packages:   Maximum number of packages to enrich with stats (default 10).
+        package_or_cve: Package spec (``name@version``,
+                        ``ecosystem:name@version``, e.g.
+                        ``conda:numpy@1.26.0``) or CVE ID
+                        (``CVE-YYYY-NNNN``).
+        max_packages:   Maximum number of packages to enrich with stats
+                        (default 10).
 
     Returns:
         A structured text report with per-package exposure stats and a
@@ -558,6 +660,28 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("version_count"):
                 lines.append(f"    Version count:    {r['version_count']}")
+
+        # conda-specific stats
+        if eco.lower() in ("conda", "conda-forge", "anaconda"):
+            if r.get("latest_version"):
+                lines.append(f"    Latest version:   {r['latest_version']}")
+            if r.get("total_versions"):
+                lines.append(f"    Total versions:   {r['total_versions']}")
+            if r.get("total_downloads") is not None:
+                lines.append(f"    Total downloads:  {r['total_downloads']:,}")
+            if r.get("weekly_downloads") is not None:
+                lines.append(f"    Weekly avg (est): {r['weekly_downloads']:,}")
+            if r.get("first_release_date"):
+                age = f" ({r['age_years']}y ago)" if r.get("age_years") else ""
+                lines.append(f"    First released:   {r['first_release_date']}{age}")
+            if r.get("description"):
+                lines.append(f"    Description:      {r['description'][:80]}")
+            if r.get("license"):
+                lines.append(f"    License:          {r['license']}")
+            if r.get("home_page"):
+                lines.append(f"    Home page:        {r['home_page']}")
+            if r.get("conda_page"):
+                lines.append(f"    Conda page:       {r['conda_page']}")
 
         if source:
             lines.append(f"    Data sources:     {source}")

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -933,3 +933,464 @@ class TestCliParser:
         from manus_agent.cli import _SUBCOMMANDS
 
         assert "blast-radius" in _SUBCOMMANDS
+
+
+# ===========================================================================
+# _parse_anaconda_timestamp
+# ===========================================================================
+
+
+class TestParseAnacondaTimestamp:
+    """Unit tests for the Anaconda timestamp parser."""
+
+    def test_standard_format_with_offset(self):
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        dt = _parse_anaconda_timestamp("2016-04-20 07:41:54.299000+00:00")
+        assert dt is not None
+        assert dt.year == 2016
+        assert dt.month == 4
+        assert dt.day == 20
+
+    def test_standard_format_no_microseconds(self):
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        dt = _parse_anaconda_timestamp("2020-06-06 23:22:39+00:00")
+        assert dt is not None
+        assert dt.year == 2020
+        assert dt.month == 6
+        assert dt.day == 6
+
+    def test_empty_string_returns_none(self):
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        assert _parse_anaconda_timestamp("") is None
+
+    def test_none_returns_none(self):
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        assert _parse_anaconda_timestamp(None) is None  # type: ignore[arg-type]
+
+    def test_invalid_string_returns_none(self):
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        assert _parse_anaconda_timestamp("not-a-date") is None
+
+    def test_result_is_utc_aware(self):
+
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        dt = _parse_anaconda_timestamp("2018-03-15 12:00:00.000000+00:00")
+        assert dt is not None
+        assert dt.tzinfo is not None
+        assert dt.utcoffset().total_seconds() == 0  # UTC
+
+    def test_t_separator_also_works(self):
+        """ISO 8601 T-separator variant should also parse."""
+        from manus_agent.tools.get_dependency_blast_radius import _parse_anaconda_timestamp
+
+        dt = _parse_anaconda_timestamp("2021-01-01T00:00:00+00:00")
+        assert dt is not None
+        assert dt.year == 2021
+
+
+# ===========================================================================
+# _enrich_conda
+# ===========================================================================
+
+
+def _make_anaconda_response(
+    name: str = "numpy",
+    ndownloads: int = 141_000_000,
+    latest_version: str = "2.5.1",
+    versions: list | None = None,
+    summary: str = "The fundamental package for scientific computing.",
+    license_str: str = "BSD-3-Clause",
+    home: str = "https://numpy.org",
+    html_url: str = "http://anaconda.org/conda-forge/numpy",
+    files: list | None = None,
+) -> dict:
+    """Build a minimal Anaconda API package response dict."""
+    if versions is None:
+        versions = ["1.11.0", "1.20.0", "1.25.0", "2.0.0", "2.5.1"]
+    if files is None:
+        files = [
+            {"upload_time": "2016-05-20 11:59:19.246000+00:00", "version": "1.11.0"},
+            {"upload_time": "2021-06-15 08:30:00.000000+00:00", "version": "1.21.0"},
+            {"upload_time": "2025-01-01 00:00:00.000000+00:00", "version": "2.5.0"},
+        ]
+    return {
+        "name": name,
+        "ndownloads": ndownloads,
+        "latest_version": latest_version,
+        "versions": versions,
+        "summary": summary,
+        "license": license_str,
+        "home": home,
+        "html_url": html_url,
+        "files": files,
+    }
+
+
+class TestEnrichConda:
+    """Tests for _enrich_conda — all HTTP calls mocked."""
+
+    def _mock_get(self, response_data: dict) -> MagicMock:
+        mock = MagicMock(return_value=response_data)
+        return mock
+
+    def test_basic_fields_populated(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response()
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("numpy")
+
+        assert result["ecosystem"] == "conda"
+        assert result["package_name"] == "numpy"
+        assert result["latest_version"] == "2.5.1"
+        assert result["total_versions"] == 5
+        assert result["total_downloads"] == 141_000_000
+
+    def test_weekly_downloads_is_total_divided_by_52(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(ndownloads=52_000)
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("somelib")
+
+        assert result["weekly_downloads"] == 1_000  # 52_000 // 52
+
+    def test_first_release_date_from_files(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(
+            files=[
+                {"upload_time": "2020-06-01 00:00:00.000000+00:00", "version": "1.0.0"},
+                {"upload_time": "2016-04-20 07:41:54.299000+00:00", "version": "0.9.0"},
+                {"upload_time": "2022-01-15 12:00:00.000000+00:00", "version": "2.0.0"},
+            ]
+        )
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("numpy")
+
+        # Oldest file is 2016-04-20
+        assert result.get("first_release_date") == "2016-04-20"
+        assert result.get("age_years") is not None
+        assert result["age_years"] > 5  # 2016 → ~9 years
+
+    def test_description_truncated_to_120_chars(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        long_desc = "x" * 200
+        data = _make_anaconda_response(summary=long_desc)
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert len(result["description"]) == 120
+
+    def test_description_newlines_stripped(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(summary="line one\nline two\nline three")
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert "\n" not in result["description"]
+
+    def test_license_and_home_page_present(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(license_str="MIT", home="https://example.com")
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert result["license"] == "MIT"
+        assert result["home_page"] == "https://example.com"
+
+    def test_conda_page_html_url(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(html_url="http://anaconda.org/conda-forge/numpy")
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("numpy")
+
+        assert result["conda_page"] == "http://anaconda.org/conda-forge/numpy"
+
+    def test_channel_recorded(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response()
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("numpy")
+
+        assert result["channel"] == "conda-forge"
+
+    def test_fallback_to_anaconda_channel_on_404(self):
+        """When conda-forge raises an HTTP error, fall back to 'anaconda' channel."""
+        import requests as req
+
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        anaconda_data = _make_anaconda_response(ndownloads=5_000_000, latest_version="1.24.0")
+
+        call_count = {"n": 0}
+
+        def side_effect(url, **kwargs):
+            call_count["n"] += 1
+            if "conda-forge" in url:
+                raise req.HTTPError("404 Not Found")
+            return anaconda_data
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", side_effect=side_effect):
+            result = _enrich_conda("numpy")
+
+        assert result["channel"] == "anaconda"
+        assert result["total_downloads"] == 5_000_000
+        assert call_count["n"] == 2  # tried conda-forge, then anaconda
+
+    def test_all_channels_fail_returns_stub(self):
+        """When all channels raise, return a minimal stub dict."""
+        import requests as req
+
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=req.HTTPError("404"),
+        ):
+            result = _enrich_conda("nonexistent-pkg")
+
+        assert result["ecosystem"] == "conda"
+        assert result["package_name"] == "nonexistent-pkg"
+        assert "total_downloads" not in result
+
+    def test_files_without_upload_time_skipped(self):
+        """Files lacking upload_time should not cause a crash."""
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(
+            files=[
+                {"version": "1.0.0"},  # no upload_time
+                {"upload_time": None, "version": "1.1.0"},  # None upload_time
+                {"upload_time": "2021-01-01 00:00:00.000000+00:00", "version": "1.2.0"},
+            ]
+        )
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert result.get("first_release_date") == "2021-01-01"
+
+    def test_no_files_no_first_release_date(self):
+        """Package with empty files list: first_release_date should be absent."""
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(files=[])
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert "first_release_date" not in result
+
+    def test_zero_ndownloads_weekly_is_none(self):
+        """If total downloads is 0 (or missing), weekly_downloads should be None."""
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        data = _make_anaconda_response(ndownloads=0)
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("pkg")
+
+        assert result.get("weekly_downloads") is None
+
+    def test_blast_score_for_high_download_package(self):
+        """141M total → ~2.7M weekly → HIGH blast radius."""
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score, _enrich_conda
+
+        data = _make_anaconda_response(ndownloads=141_000_000)
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("numpy")
+
+        score = _blast_score(result)
+        assert score in ("CRITICAL", "HIGH")
+
+    def test_blast_score_for_low_download_package(self):
+        """500 total → 9 weekly → LOW blast radius."""
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score, _enrich_conda
+
+        data = _make_anaconda_response(ndownloads=500)
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=data):
+            result = _enrich_conda("niche-pkg")
+
+        score = _blast_score(result)
+        assert score == "LOW"
+
+    def test_missing_optional_fields_no_error(self):
+        """A minimal API response (only name + ndownloads) should not crash."""
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_conda
+
+        minimal = {"name": "mypkg", "ndownloads": 1000}
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", return_value=minimal):
+            result = _enrich_conda("mypkg")
+
+        assert result["ecosystem"] == "conda"
+        assert result["total_downloads"] == 1000
+
+
+# ===========================================================================
+# _enrich_package dispatch for conda ecosystem strings
+# ===========================================================================
+
+
+class TestEnrichPackageCondaDispatch:
+    """_enrich_package should route conda/conda-forge/anaconda to _enrich_conda."""
+
+    def test_dispatch_conda(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_conda") as mock:
+            mock.return_value = {"ecosystem": "conda", "package_name": "numpy"}
+            result = _enrich_package("numpy", "conda")
+
+        mock.assert_called_once_with("numpy")
+        assert result["ecosystem"] == "conda"
+
+    def test_dispatch_conda_forge(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_conda") as mock:
+            mock.return_value = {"ecosystem": "conda", "package_name": "pandas"}
+            _enrich_package("pandas", "conda-forge")
+
+        mock.assert_called_once_with("pandas")
+
+    def test_dispatch_anaconda(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_conda") as mock:
+            mock.return_value = {"ecosystem": "conda", "package_name": "scipy"}
+            _enrich_package("scipy", "anaconda")
+
+        mock.assert_called_once_with("scipy")
+
+    def test_conda_not_confused_with_other_ecosystems(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_npm") as npm_mock:
+            npm_mock.return_value = {"ecosystem": "npm", "package_name": "lodash"}
+            result = _enrich_package("lodash", "npm")
+
+        npm_mock.assert_called_once()
+        assert result["ecosystem"] == "npm"
+
+
+# ===========================================================================
+# Integration: conda package spec in get_dependency_blast_radius
+# ===========================================================================
+
+
+class TestGetDependencyBlastRadiusConda:
+    """End-to-end integration tests for conda package spec handling."""
+
+    def _conda_stats(self) -> dict:
+        return {
+            "ecosystem": "conda",
+            "package_name": "numpy",
+            "latest_version": "2.5.1",
+            "total_versions": 115,
+            "total_downloads": 141_000_000,
+            "weekly_downloads": 2_711_538,
+            "first_release_date": "2016-05-20",
+            "age_years": 10.1,
+            "description": "The fundamental package for scientific computing with Python.",
+            "license": "BSD-3-Clause",
+            "home_page": "https://numpy.org",
+            "conda_page": "http://anaconda.org/conda-forge/numpy",
+            "channel": "conda-forge",
+        }
+
+    def test_conda_spec_produces_output(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy@1.26.0")
+
+        assert "numpy" in result
+        assert isinstance(result, str)
+
+    def test_conda_blast_label_in_output(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy@1.26.0")
+
+        assert "HIGH" in result or "CRITICAL" in result
+
+    def test_conda_metadata_in_output(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy@1.26.0")
+
+        # Specific conda output fields
+        assert "2.5.1" in result  # latest version
+        assert "BSD-3-Clause" in result  # license
+        assert "141,000,000" in result  # total downloads
+        assert "2016-05-20" in result  # first release date
+
+    def test_conda_weekly_downloads_label(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy@1.26.0")
+
+        assert "Weekly avg" in result or "weekly" in result.lower()
+
+    def test_ecosystem_label_conda_in_output(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy@1.26.0")
+
+        assert "conda" in result.lower() or "Anaconda" in result
+
+    def test_conda_without_version_parses_correctly(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._conda_stats(),
+        ):
+            result = get_dependency_blast_radius("conda:numpy")
+
+        assert "numpy" in result
+
+
+# ===========================================================================
+# _ECOSYSTEM_LABEL includes conda
+# ===========================================================================
+
+
+class TestEcosystemLabelConda:
+    def test_conda_label_present(self):
+        from manus_agent.tools.get_dependency_blast_radius import _ECOSYSTEM_LABEL
+
+        assert "conda" in _ECOSYSTEM_LABEL
+
+    def test_conda_label_mentions_anaconda(self):
+        from manus_agent.tools.get_dependency_blast_radius import _ECOSYSTEM_LABEL
+
+        assert "Anaconda" in _ECOSYSTEM_LABEL["conda"] or "conda" in _ECOSYSTEM_LABEL["conda"].lower()


### PR DESCRIPTION
## Summary

Adds **conda/conda-forge enrichment** to `get_dependency_blast_radius` — enabling blast-radius analysis for the data science and scientific computing ecosystem (numpy, scipy, pandas, cryptography, Pillow, …) using the free [Anaconda public API](https://api.anaconda.org).

## What Changed

### `src/manus_agent/tools/get_dependency_blast_radius.py`

- **New constant** `_ANACONDA_PKG_URL` — template for `https://api.anaconda.org/package/{channel}/{name}`
- **New constant** `_ANACONDA_CHANNELS` — `("conda-forge", "anaconda")` fallback order
- **`_ECOSYSTEM_LABEL`** — added `"conda"` → `"conda (Anaconda/conda-forge)"`
- **`_parse_anaconda_timestamp(ts)`** — parses Anaconda API timestamp strings (`"2016-04-20 07:41:54.299000+00:00"`) to UTC-aware `datetime`; returns `None` on any error
- **`_enrich_conda(name)`** — single-call enricher:
  - Tries `conda-forge` channel first; falls back to `anaconda` defaults on any error
  - Extracts: `total_downloads` (all-time `ndownloads`), `weekly_downloads` (`total_downloads // 52` rolling average — Anaconda exposes no per-week endpoint), `latest_version`, `total_versions`, `first_release_date` + `age_years` (min `upload_time` across all published files), `description` (120-char truncated, newlines stripped), `license`, `home_page`, `conda_page`, `channel`
  - All channels failing returns a minimal stub — never raises
- **`_enrich_package` dispatch** — routes `"conda"`, `"conda-forge"`, `"anaconda"` ecosystem strings to `_enrich_conda`
- **Output block** — new `# conda-specific stats` section renders: Latest version · Total versions · Total downloads · Weekly avg (est.) · First released + age · Description · License · Home page · Conda page
- **`datetime` import** added; module docstring + tool docstring updated to document conda support and the `conda:name@version` spec format

### `tests/test_dependency_blast_radius.py`

**+43 new tests** across 5 new test classes (1158 → 1193 suite-wide):

| Class | Tests |
|---|---|
| `TestParseAnacondaTimestamp` | 7 — space/T separator, empty, None, invalid, UTC-aware, offset |
| `TestEnrichConda` | 17 — basic fields, weekly proxy math, first-release date (min across files), description truncation/newlines, license/home/conda_page, channel recorded, conda-forge→anaconda fallback, all-channels-fail stub, files-without-upload-time, no-files, zero-downloads, blast-score HIGH/LOW, missing-optional-fields |
| `TestEnrichPackageCondaDispatch` | 4 — `conda` / `conda-forge` / `anaconda` dispatch + no cross-contamination with npm |
| `TestGetDependencyBlastRadiusConda` | 6 — end-to-end: produces output, blast label, metadata fields, weekly-avg label, ecosystem label, version-less spec |
| `TestEcosystemLabelConda` | 2 — label present and mentions Anaconda/conda |

## Why conda?

The conda ecosystem is a massive CVE surface that existing enrichers all miss:

| Package | Total downloads | Weekly avg proxy |
|---|---|---|
| `numpy` (conda-forge) | ~141 M | ~2.7 M → **HIGH** |
| `requests` | ~87 M | ~1.7 M → **HIGH** |
| `cryptography` | ~79 M | ~1.5 M → **HIGH** |
| `pandas` | ~87 M | ~1.7 M → **HIGH** |

Vulnerabilities in scientific Python packages routinely appear in both PyPI and conda-forge simultaneously. Knowing the conda blast radius helps triage severity for ML/data-science stacks that pin conda-only (Anaconda Distribution, conda-forge).

## Design Decisions

- **Single API call**: `api.anaconda.org/package/{channel}/{name}` returns downloads + versions + files + metadata in one response — no second call needed
- **Weekly downloads proxy**: `total_downloads // 52` — no per-week endpoint exists; dividing all-time by 52 gives a conservative rolling annual average rather than inflating it
- **Channel fallback**: conda-forge first (community standard, broader coverage); Anaconda defaults second — `channel` key in result records which channel answered
- **`first_release_date`** from files: `min(upload_time)` across all files in the response — more accurate than the package-level `created_at` (which is when conda-forge indexed it, not when the first build was uploaded)
- **Graceful degradation**: each channel attempt wrapped in its own `try/except`; all-fail returns a minimal `{"ecosystem": "conda", "package_name": name}` stub consistent with other enrichers
- **No auth required**: Anaconda public API works without an API key

## Existing PRs Checked — No Overlap

Confirmed no open or merged PR covers conda/Anaconda enrichment:

Open PRs checked: #51, #53, #54, #58, #60, #64, #65, #67, #74, #75, #76, #77, #78, #79, #80, #82, #83, #85, #86, #87, #88, #89, #90, #96, #98, #100, #103 (crates.io), #104 (RubyGems), #105 (NuGet), #106 (Go), #107 (Packagist), #108 (Hex), #109 (Pub)

None cover conda or the Anaconda ecosystem.