### PR TITLE
feat: add OSV per-package CVE lookup to get_dependency_blast_radius

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -8,7 +8,8 @@ on the affected package, and how widely it is downloaded.
 Data sources (all free, no API key required):
   1. NVD CVE 2.0 API  — maps CVE → affected packages + version ranges
   2. OSV.dev API       — cross-ecosystem vulnerability data (PyPI, npm, Maven,
-                         Go, RubyGems, crates.io, …)
+                         Go, RubyGems, crates.io, …); also used for per-package
+                         known-CVE lookup on direct package queries
   3. GitHub Advisory DB — GHSA packages + ecosystems
   4. npm registry API  — dependents count + weekly download stats (npm only)
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
@@ -51,6 +52,8 @@ _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+_OSV_PKG_QUERY_URL = "https://api.osv.dev/v1/query"
+_OSV_PKG_VULN_MAX = 10  # cap on how many OSV vulns to surface per package
 
 _TIMEOUT = 20
 
@@ -373,6 +376,126 @@ def _enrich_maven(name: str) -> dict[str, Any]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# OSV per-package CVE lookup
+# ---------------------------------------------------------------------------
+
+# Map from ecosystem aliases used in blast-radius input (lower-case) to the
+# canonical OSV ecosystem string expected by the POST /v1/query endpoint.
+_ECOSYSTEM_TO_OSV: dict[str, str] = {
+    "pypi": "PyPI",
+    "python": "PyPI",
+    "pip": "PyPI",
+    "npm": "npm",
+    "javascript": "npm",
+    "node": "npm",
+    "maven": "Maven",
+    "java": "Maven",
+    "gradle": "Maven",
+    "go": "Go",
+    "golang": "Go",
+    "crates.io": "crates.io",
+    "rust": "crates.io",
+    "cargo": "crates.io",
+    "rubygems": "RubyGems",
+    "ruby": "RubyGems",
+    "gem": "RubyGems",
+    "nuget": "NuGet",
+    "dotnet": "NuGet",
+    ".net": "NuGet",
+    "packagist": "Packagist",
+    "php": "Packagist",
+    "composer": "Packagist",
+    "hex": "Hex",
+    "elixir": "Hex",
+    "erlang": "Hex",
+    "pub": "Pub",
+    "dart": "Pub",
+    "flutter": "Pub",
+    "conda": "ConanCenter",  # OSV uses ConanCenter for C/C++ conan packages
+    "conan": "ConanCenter",
+}
+
+
+def _fetch_osv_package_vulns(
+    name: str,
+    ecosystem: str,
+    version: str | None = None,
+    max_vulns: int = _OSV_PKG_VULN_MAX,
+) -> list[dict[str, Any]]:
+    """Query OSV.dev for known vulnerabilities affecting a package.
+
+    Args:
+        name:      Package name (e.g. ``requests``).
+        ecosystem: Ecosystem string — either a canonical OSV ecosystem name
+                   (``PyPI``, ``npm``, ``Maven``, …) or a blast-radius alias
+                   (``python``, ``node``, ``java``, …).
+        version:   When supplied, OSV returns only vulns that affect this
+                   specific version rather than the whole package history.
+        max_vulns: Cap on how many vuln records to return (avoids flooding
+                   output for heavily-CVE'd packages like OpenSSL).
+
+    Returns:
+        A list of dicts, each with keys: ``id`` (OSV/GHSA/CVE id), ``summary``,
+        ``aliases`` (CVE ids when the primary id is a GHSA), and optionally
+        ``fixed`` (first-fixed version from OSV range data).  Empty list on
+        any failure.
+    """
+    # Resolve to canonical OSV ecosystem string.
+    osv_eco = _ECOSYSTEM_TO_OSV.get(ecosystem.lower(), ecosystem) if ecosystem else ""
+    if not osv_eco or not name:
+        return []
+
+    payload: dict[str, Any] = {"package": {"name": name, "ecosystem": osv_eco}}
+    if version:
+        payload["version"] = version
+
+    try:
+        raw = _post(_OSV_PKG_QUERY_URL, payload)
+    except Exception as exc:
+        logger.debug("OSV package query failed for %s/%s: %s", osv_eco, name, exc)
+        return []
+
+    vulns_raw = raw.get("vulns", []) or []
+    results: list[dict[str, Any]] = []
+    for vuln in vulns_raw[:max_vulns]:
+        if not isinstance(vuln, dict):
+            continue
+        vuln_id = vuln.get("id", "")
+        summary = (vuln.get("summary") or "")[:120]
+        aliases = [a for a in (vuln.get("aliases") or []) if isinstance(a, str)]
+
+        # Extract the first-fixed version from the affected ranges in this
+        # vuln record (OSV batch query returns lightweight records; the full
+        # fixed version is often present in the top-level ``affected``
+        # array even in the summary response).
+        fixed: str | None = None
+        for affected_entry in vuln.get("affected", []) or []:
+            if not isinstance(affected_entry, dict):
+                continue
+            pkg = affected_entry.get("package") or {}
+            # Only extract fixed from entries matching our package.
+            if isinstance(pkg, dict) and pkg.get("ecosystem") == osv_eco and pkg.get("name", "").lower() == name.lower():
+                for rng in affected_entry.get("ranges", []) or []:
+                    if not isinstance(rng, dict):
+                        continue
+                    for ev in rng.get("events", []) or []:
+                        if isinstance(ev, dict) and "fixed" in ev:
+                            fixed = str(ev["fixed"])
+                            break
+                    if fixed:
+                        break
+            if fixed:
+                break
+
+        entry: dict[str, Any] = {"id": vuln_id, "summary": summary, "aliases": aliases}
+        if fixed:
+            entry["fixed"] = fixed
+        results.append(entry)
+
+    return results
+
+
 def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
     """Dispatch to the right enrichment function based on ecosystem."""
     eco_lower = (ecosystem or "").lower()
@@ -415,7 +538,6 @@ def _blast_score(stats: dict[str, Any]) -> str:
 # Main tool function
 # ---------------------------------------------------------------------------
 
-
 @tool
 def get_dependency_blast_radius(  # noqa: C901
     package_or_cve: str,
@@ -434,6 +556,10 @@ def get_dependency_blast_radius(  # noqa: C901
        - **PyPI**: package metadata + download stats (when pypistats is available)
        - **Maven**: artifact metadata from Maven Central
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
+    4. For direct package queries, also surfaces known CVEs/GHSAs from OSV.dev
+       so you see both the blast radius *and* the package's vulnerability history
+       in one call.  When a version is specified, only CVEs affecting that exact
+       version are returned.
 
     Use after ``get_nvd_data`` to understand *how many projects are exposed*
     to a vulnerability — the answer is often orders of magnitude larger than
@@ -445,8 +571,8 @@ def get_dependency_blast_radius(  # noqa: C901
         max_packages:   Maximum number of packages to enrich with stats (default 10).
 
     Returns:
-        A structured text report with per-package exposure stats and a
-        summary blast-radius label.
+        A structured text report with per-package exposure stats, known CVEs
+        (for direct package queries), and a summary blast-radius label.
     """
     try:
         parsed = _parse_input(package_or_cve)
@@ -455,6 +581,12 @@ def get_dependency_blast_radius(  # noqa: C901
 
     sections: list[str] = []
     all_packages: list[dict[str, Any]] = []
+
+    # Track whether this is a direct package query (vs CVE→packages lookup)
+    is_direct_package = parsed["kind"] == "package"
+    # For direct queries, capture version/ecosystem for OSV CVE lookup
+    direct_version: str | None = None
+    direct_ecosystem: str = ""
 
     if parsed["kind"] == "cve":
         cve_id = parsed["cve_id"]
@@ -500,8 +632,10 @@ def get_dependency_blast_radius(  # noqa: C901
                 "source": "direct",
             }
         ]
+        direct_version = version
+        direct_ecosystem = ecosystem
 
-    # Enrich each package with stats
+    # Enrich each package with download/dependent stats
     enriched_results: list[dict[str, Any]] = []
     for pkg in all_packages:
         eco = pkg.get("ecosystem", "")
@@ -511,6 +645,12 @@ def get_dependency_blast_radius(  # noqa: C901
         stats["source"] = pkg.get("source", "")
         blast = _blast_score(stats)
         stats["blast_radius"] = blast
+        # For direct package queries: fetch known CVEs from OSV and attach to
+        # stats so the output shows vulnerability history alongside blast radius.
+        if is_direct_package:
+            stats["osv_vulns"] = _fetch_osv_package_vulns(
+                name, eco or direct_ecosystem, version=direct_version
+            )
         enriched_results.append(stats)
 
     # Sort by blast severity
@@ -562,6 +702,23 @@ def get_dependency_blast_radius(  # noqa: C901
         if source:
             lines.append(f"    Data sources:     {source}")
 
+        # Known CVEs from OSV (direct package queries only)
+        osv_vulns: list[dict[str, Any]] = r.get("osv_vulns") or []
+        if osv_vulns:
+            ver_scope = f"affecting @{direct_version}" if direct_version else "(all versions)"
+            lines.append(f"    Known CVEs (OSV) {ver_scope}: {len(osv_vulns)}")
+            for vuln in osv_vulns:
+                vid = vuln.get("id", "?")
+                vsummary = (vuln.get("summary") or "")[:80]
+                # Show CVE alias if the primary id is a GHSA/advisory record
+                cve_aliases = [a for a in (vuln.get("aliases") or []) if str(a).startswith("CVE-")]
+                alias_str = f" [{cve_aliases[0]}]" if cve_aliases else ""
+                fixed_str = f"  → fixed: {vuln['fixed']}" if vuln.get("fixed") else ""
+                lines.append(f"      • {vid}{alias_str}: {vsummary}{fixed_str}")
+        elif is_direct_package:
+            # We queried OSV but found nothing — let user know (not an error)
+            lines.append("    Known CVEs (OSV): none found")
+
         sections.extend(lines)
 
     # Summary line
@@ -578,5 +735,10 @@ def get_dependency_blast_radius(  # noqa: C901
             sections.append(f"         Total weekly downloads across all packages: {total_weekly:,}")
         if total_dependents:
             sections.append(f"         Total npm dependent packages: {total_dependents:,}")
+        # Summarise OSV CVE exposure for direct queries
+        if is_direct_package:
+            total_osv = sum(len(r.get("osv_vulns") or []) for r in enriched_results)
+            version_note = f" affecting version {direct_version}" if direct_version else ""
+            sections.append(f"         Known CVEs from OSV{version_note}: {total_osv}")
 
     return "\n".join(sections)

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -13,6 +13,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from manus_agent.tools.get_dependency_blast_radius import (
+    _ECOSYSTEM_TO_OSV,
     _blast_score,
     _enrich_maven,
     _enrich_npm,
@@ -21,6 +22,7 @@ from manus_agent.tools.get_dependency_blast_radius import (
     _fetch_ghsa_affected,
     _fetch_nvd_affected,
     _fetch_osv_affected,
+    _fetch_osv_package_vulns,
     _parse_input,
     _summarise_osv_ranges,
     get_dependency_blast_radius,
@@ -933,3 +935,480 @@ class TestCliParser:
         from manus_agent.cli import _SUBCOMMANDS
 
         assert "blast-radius" in _SUBCOMMANDS
+
+
+# ===========================================================================
+# _fetch_osv_package_vulns — OSV per-package CVE lookup
+# ===========================================================================
+
+
+class TestEcosystemToOsvMapping:
+    """_ECOSYSTEM_TO_OSV maps blast-radius input aliases → canonical OSV strings."""
+
+    def test_pypi_variants(self):
+        assert _ECOSYSTEM_TO_OSV["pypi"] == "PyPI"
+        assert _ECOSYSTEM_TO_OSV["python"] == "PyPI"
+        assert _ECOSYSTEM_TO_OSV["pip"] == "PyPI"
+
+    def test_npm_variants(self):
+        assert _ECOSYSTEM_TO_OSV["npm"] == "npm"
+        assert _ECOSYSTEM_TO_OSV["javascript"] == "npm"
+        assert _ECOSYSTEM_TO_OSV["node"] == "npm"
+
+    def test_maven_variants(self):
+        assert _ECOSYSTEM_TO_OSV["maven"] == "Maven"
+        assert _ECOSYSTEM_TO_OSV["java"] == "Maven"
+        assert _ECOSYSTEM_TO_OSV["gradle"] == "Maven"
+
+    def test_go_variants(self):
+        assert _ECOSYSTEM_TO_OSV["go"] == "Go"
+        assert _ECOSYSTEM_TO_OSV["golang"] == "Go"
+
+    def test_rust_variants(self):
+        assert _ECOSYSTEM_TO_OSV["crates.io"] == "crates.io"
+        assert _ECOSYSTEM_TO_OSV["rust"] == "crates.io"
+        assert _ECOSYSTEM_TO_OSV["cargo"] == "crates.io"
+
+    def test_ruby_variants(self):
+        assert _ECOSYSTEM_TO_OSV["rubygems"] == "RubyGems"
+        assert _ECOSYSTEM_TO_OSV["ruby"] == "RubyGems"
+        assert _ECOSYSTEM_TO_OSV["gem"] == "RubyGems"
+
+    def test_dotnet_variants(self):
+        assert _ECOSYSTEM_TO_OSV["nuget"] == "NuGet"
+        assert _ECOSYSTEM_TO_OSV["dotnet"] == "NuGet"
+
+    def test_php_variants(self):
+        assert _ECOSYSTEM_TO_OSV["packagist"] == "Packagist"
+        assert _ECOSYSTEM_TO_OSV["php"] == "Packagist"
+        assert _ECOSYSTEM_TO_OSV["composer"] == "Packagist"
+
+    def test_elixir_variants(self):
+        assert _ECOSYSTEM_TO_OSV["hex"] == "Hex"
+        assert _ECOSYSTEM_TO_OSV["elixir"] == "Hex"
+        assert _ECOSYSTEM_TO_OSV["erlang"] == "Hex"
+
+    def test_dart_variants(self):
+        assert _ECOSYSTEM_TO_OSV["pub"] == "Pub"
+        assert _ECOSYSTEM_TO_OSV["dart"] == "Pub"
+        assert _ECOSYSTEM_TO_OSV["flutter"] == "Pub"
+
+
+class TestFetchOsvPackageVulns:
+    """Unit tests for _fetch_osv_package_vulns."""
+
+    def _make_osv_response(self, vulns):
+        mock_resp = MagicMock()
+        mock_resp.raise_for_status.return_value = None
+        mock_resp.json.return_value = {"vulns": vulns}
+        mock_resp.status_code = 200
+        return mock_resp
+
+    def test_returns_empty_on_unknown_ecosystem(self):
+        """Empty ecosystem string → skip query, return []."""
+        result = _fetch_osv_package_vulns("somelib", "")
+        assert result == []
+
+    def test_returns_empty_on_empty_name(self):
+        """Empty package name → skip query, return []."""
+        result = _fetch_osv_package_vulns("", "PyPI")
+        assert result == []
+
+    def test_basic_vuln_response(self):
+        """A standard OSV response is parsed into id/summary/aliases."""
+        vulns_payload = [
+            {
+                "id": "GHSA-abcd-1234-efgh",
+                "summary": "Remote code execution in foobar",
+                "aliases": ["CVE-2023-12345"],
+                "affected": [],
+            }
+        ]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": vulns_payload}):
+            result = _fetch_osv_package_vulns("foobar", "PyPI")
+        assert len(result) == 1
+        assert result[0]["id"] == "GHSA-abcd-1234-efgh"
+        assert result[0]["summary"] == "Remote code execution in foobar"
+        assert "CVE-2023-12345" in result[0]["aliases"]
+
+    def test_version_filter_passed_in_payload(self):
+        """When version is given, it is included in the POST payload."""
+        captured_payloads: list[Any] = []
+
+        def fake_post(url, payload):
+            captured_payloads.append(payload)
+            return {"vulns": []}
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", side_effect=fake_post):
+            _fetch_osv_package_vulns("requests", "PyPI", version="2.28.0")
+
+        assert len(captured_payloads) == 1
+        payload = captured_payloads[0]
+        assert payload["version"] == "2.28.0"
+        assert payload["package"]["name"] == "requests"
+        assert payload["package"]["ecosystem"] == "PyPI"
+
+    def test_no_version_filter_omits_version_key(self):
+        """Without a version, the POST payload must NOT include 'version'."""
+        captured_payloads: list[Any] = []
+
+        def fake_post(url, payload):
+            captured_payloads.append(payload)
+            return {"vulns": []}
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", side_effect=fake_post):
+            _fetch_osv_package_vulns("requests", "PyPI", version=None)
+
+        assert "version" not in captured_payloads[0]
+
+    def test_ecosystem_alias_resolved(self):
+        """'python' alias is resolved to canonical 'PyPI' in the POST payload."""
+        captured_payloads: list[Any] = []
+
+        def fake_post(url, payload):
+            captured_payloads.append(payload)
+            return {"vulns": []}
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", side_effect=fake_post):
+            _fetch_osv_package_vulns("requests", "python")
+
+        assert captured_payloads[0]["package"]["ecosystem"] == "PyPI"
+
+    def test_returns_empty_on_network_error(self):
+        """A requests exception returns [] and does not raise."""
+        import requests as req_lib
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._post",
+            side_effect=req_lib.exceptions.ConnectionError("timeout"),
+        ):
+            result = _fetch_osv_package_vulns("requests", "PyPI")
+        assert result == []
+
+    def test_max_vulns_cap_respected(self):
+        """max_vulns limits the number of entries returned."""
+        many_vulns = [{"id": f"GHSA-{i:04d}", "summary": "bug", "aliases": [], "affected": []} for i in range(20)]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": many_vulns}):
+            result = _fetch_osv_package_vulns("biglib", "PyPI", max_vulns=5)
+        assert len(result) == 5
+
+    def test_fixed_version_extracted(self):
+        """When OSV includes range events with 'fixed', that version is surfaced."""
+        vuln_with_fix = [
+            {
+                "id": "GHSA-fix-test",
+                "summary": "Fix available",
+                "aliases": ["CVE-2024-9999"],
+                "affected": [
+                    {
+                        "package": {"name": "mylib", "ecosystem": "PyPI"},
+                        "ranges": [
+                            {
+                                "type": "ECOSYSTEM",
+                                "events": [
+                                    {"introduced": "1.0.0"},
+                                    {"fixed": "2.1.0"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": vuln_with_fix}):
+            result = _fetch_osv_package_vulns("mylib", "PyPI")
+        assert len(result) == 1
+        assert result[0].get("fixed") == "2.1.0"
+
+    def test_no_fixed_version_when_absent(self):
+        """When OSV range events have no 'fixed', the 'fixed' key is absent."""
+        vuln_no_fix = [
+            {
+                "id": "GHSA-no-fix",
+                "summary": "No fix yet",
+                "aliases": [],
+                "affected": [
+                    {
+                        "package": {"name": "mylib", "ecosystem": "PyPI"},
+                        "ranges": [
+                            {
+                                "type": "ECOSYSTEM",
+                                "events": [{"introduced": "0.1.0"}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": vuln_no_fix}):
+            result = _fetch_osv_package_vulns("mylib", "PyPI")
+        assert len(result) == 1
+        assert "fixed" not in result[0]
+
+    def test_empty_vulns_list(self):
+        """An OSV response with no vulns returns []."""
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": []}):
+            result = _fetch_osv_package_vulns("safe-package", "npm")
+        assert result == []
+
+    def test_missing_vulns_key(self):
+        """An OSV response missing 'vulns' key returns [] gracefully."""
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={}):
+            result = _fetch_osv_package_vulns("safe-package", "npm")
+        assert result == []
+
+    def test_summary_truncated_to_120_chars(self):
+        """Long summaries are capped at 120 characters."""
+        long_summary = "X" * 200
+        vulns = [{"id": "GHSA-long", "summary": long_summary, "aliases": [], "affected": []}]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": vulns}):
+            result = _fetch_osv_package_vulns("lib", "PyPI")
+        assert len(result[0]["summary"]) == 120
+
+    def test_unknown_ecosystem_passed_through(self):
+        """An ecosystem not in the mapping is passed through as-is to OSV."""
+        captured_payloads: list[Any] = []
+
+        def fake_post(url, payload):
+            captured_payloads.append(payload)
+            return {"vulns": []}
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", side_effect=fake_post):
+            _fetch_osv_package_vulns("somelib", "UnknownEco")
+
+        assert captured_payloads[0]["package"]["ecosystem"] == "UnknownEco"
+
+    def test_fixed_extracted_only_from_matching_package(self):
+        """Fixed version is only extracted from OSV affected entries matching the queried package."""
+        vuln_mixed = [
+            {
+                "id": "GHSA-mixed",
+                "summary": "Multi-package vuln",
+                "aliases": [],
+                "affected": [
+                    # Different package: should NOT contribute the fixed version
+                    {
+                        "package": {"name": "other-lib", "ecosystem": "PyPI"},
+                        "ranges": [
+                            {"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "99.0.0"}]}
+                        ],
+                    },
+                    # Matching package: fixed should be taken from here
+                    {
+                        "package": {"name": "mylib", "ecosystem": "PyPI"},
+                        "ranges": [
+                            {"type": "ECOSYSTEM", "events": [{"introduced": "1.0"}, {"fixed": "1.5.0"}]}
+                        ],
+                    },
+                ],
+            }
+        ]
+        with patch("manus_agent.tools.get_dependency_blast_radius._post", return_value={"vulns": vuln_mixed}):
+            result = _fetch_osv_package_vulns("mylib", "PyPI")
+        assert result[0].get("fixed") == "1.5.0"
+
+
+# ===========================================================================
+# Integration: OSV CVE data surfaces in get_dependency_blast_radius output
+# ===========================================================================
+
+
+class TestBlastRadiusOsvIntegration:
+    """Integration tests verifying OSV CVE output in direct package queries."""
+
+    def test_osv_vulns_shown_in_direct_package_output(self):
+        """Direct package query includes Known CVEs section."""
+        osv_vulns = [
+            {"id": "GHSA-test-0001", "summary": "Test vulnerability", "aliases": ["CVE-2024-0001"]},
+        ]
+        pypi_stats = {
+            "ecosystem": "PyPI",
+            "package_name": "requests",
+            "weekly_downloads": 5_000_000,
+        }
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("pypi:requests@2.28.0")
+        assert "Known CVEs" in result
+        assert "GHSA-test-0001" in result
+        assert "CVE-2024-0001" in result
+
+    def test_osv_fixed_version_shown_in_output(self):
+        """When a fixed version is available it appears after → in the output."""
+        osv_vulns = [
+            {
+                "id": "GHSA-fix-shown",
+                "summary": "Patched in 2.31.0",
+                "aliases": [],
+                "fixed": "2.31.0",
+            }
+        ]
+        pypi_stats = {"ecosystem": "PyPI", "package_name": "requests", "weekly_downloads": 1_000}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("pypi:requests@2.28.0")
+        assert "fixed: 2.31.0" in result
+
+    def test_no_cves_found_message(self):
+        """When OSV returns no CVEs, 'none found' is shown (not silent)."""
+        pypi_stats = {"ecosystem": "PyPI", "package_name": "safe-lib", "weekly_downloads": 500}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=[],
+            ),
+        ):
+            result = get_dependency_blast_radius("pypi:safe-lib")
+        assert "none found" in result.lower()
+
+    def test_osv_lookup_not_called_for_cve_input(self):
+        """_fetch_osv_package_vulns must NOT be called when input is a CVE id."""
+        pkgs = [{"name": "log4j-core", "ecosystem": "Maven", "version_range": ">=2.0,<2.15", "source": "osv"}]
+        maven_stats = {"ecosystem": "Maven", "package_name": "log4j-core", "latest_version": "2.22.0"}
+        with (
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_osv_affected", return_value=pkgs),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=maven_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns"
+            ) as mock_osv_pkg,
+        ):
+            _result = get_dependency_blast_radius("CVE-2021-44228")
+        mock_osv_pkg.assert_not_called()
+
+    def test_summary_includes_cve_count(self):
+        """Summary section includes 'Known CVEs from OSV' count."""
+        osv_vulns = [
+            {"id": "GHSA-a", "summary": "Bug A", "aliases": []},
+            {"id": "GHSA-b", "summary": "Bug B", "aliases": []},
+        ]
+        npm_stats = {"ecosystem": "npm", "package_name": "lodash", "weekly_downloads": 20_000_000}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("npm:lodash@4.17.20")
+        assert "Known CVEs from OSV" in result
+
+    def test_version_scope_label_with_version(self):
+        """Output shows 'affecting @<version>' when version is given."""
+        osv_vulns = [{"id": "GHSA-versioned", "summary": "Versioned bug", "aliases": []}]
+        npm_stats = {"ecosystem": "npm", "package_name": "lodash", "weekly_downloads": 100}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("npm:lodash@4.17.20")
+        assert "affecting @4.17.20" in result
+
+    def test_version_scope_label_without_version(self):
+        """Output shows '(all versions)' when no version is specified."""
+        osv_vulns = [{"id": "GHSA-all-ver", "summary": "All versions bug", "aliases": []}]
+        npm_stats = {"ecosystem": "npm", "package_name": "lodash", "weekly_downloads": 100}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("npm:lodash")
+        assert "(all versions)" in result
+
+    def test_osv_vulns_version_passed_correctly(self):
+        """_fetch_osv_package_vulns is called with the right version."""
+        captured_calls: list[Any] = []
+
+        def fake_osv_pkg(name, ecosystem, version=None, max_vulns=10):
+            captured_calls.append({"name": name, "ecosystem": ecosystem, "version": version})
+            return []
+
+        npm_stats = {"ecosystem": "npm", "package_name": "lodash", "weekly_downloads": 100}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                side_effect=fake_osv_pkg,
+            ),
+        ):
+            _result = get_dependency_blast_radius("npm:lodash@4.17.20")
+
+        assert captured_calls[0]["version"] == "4.17.20"
+
+    def test_cve_alias_shown_in_output(self):
+        """CVE alias is displayed in brackets after the GHSA id."""
+        osv_vulns = [
+            {"id": "GHSA-alias-test", "summary": "Alias test", "aliases": ["CVE-2024-55555"]}
+        ]
+        npm_stats = {"ecosystem": "npm", "package_name": "axios", "weekly_downloads": 5_000_000}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=npm_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("npm:axios@1.6.0")
+        assert "[CVE-2024-55555]" in result
+
+    def test_version_note_in_summary_with_version(self):
+        """Summary section includes 'affecting version X.Y.Z' when version given."""
+        osv_vulns = [{"id": "GHSA-v-note", "summary": "v note test", "aliases": []}]
+        pypi_stats = {"ecosystem": "PyPI", "package_name": "flask", "weekly_downloads": 3_000_000}
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=pypi_stats,
+            ),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_package_vulns",
+                return_value=osv_vulns,
+            ),
+        ):
+            result = get_dependency_blast_radius("pypi:flask@2.0.0")
+        assert "affecting version 2.0.0" in result


### PR DESCRIPTION
## Summary

When a user queries a direct package (e.g. `blast-radius pypi:requests@2.28.0`), the tool previously showed only download/dependency exposure metrics but never asked *"does this package have known CVEs?"*. This PR closes that gap.

## What changed

### New helper: `_fetch_osv_package_vulns`

Queries the [OSV.dev POST /v1/query](https://api.osv.dev/v1/query) endpoint with a package name, canonical ecosystem, and optional version filter.

- Maps 31 ecosystem alias → canonical OSV string via `_ECOSYSTEM_TO_OSV` (e.g. `python`→`PyPI`, `rust`→`crates.io`, `dart`→`Pub`)
- Extracts `id`, `summary` (capped at 120 chars), `aliases`, and the earliest `fixed` version from OSV range events (matched to the queried package only)
- Returns `[]` gracefully on network errors, empty response, unknown ecosystem, or empty name

### Updated: `get_dependency_blast_radius` (direct package path only)

- Calls `_fetch_osv_package_vulns` after enrichment; version-scoped when a version is given
- Output now includes a **Known CVEs (OSV)** section per package with per-advisory bullets:  
  `• GHSA-xxxx [CVE-YYYY-NNNNN]: summary  → fixed: 2.31.0`
- Shows `Known CVEs (OSV): none found` when OSV returns nothing (explicit, not silent)
- Summary line includes `Known CVEs from OSV [affecting version X.Y.Z]: N`
- **CVE input path is unchanged** — `_fetch_osv_package_vulns` is never called for CVE lookups

## Example output (before / after)

**Before:**
```
Dependency Blast Radius — pypi:requests@2.28.0
==================================================

[1] requests  (Python / PyPI)
    Blast radius:     HIGH
    Vulnerable range: 2.28.0
    Weekly downloads: 60,000,000
    ...
Summary: highest blast radius is HIGH (requests)
```

**After:**
```
Dependency Blast Radius — pypi:requests@2.28.0
==================================================

[1] requests  (Python / PyPI)
    Blast radius:     HIGH
    Vulnerable range: 2.28.0
    Weekly downloads: 60,000,000
    Known CVEs (OSV) affecting @2.28.0: 7
      • GHSA-j8r2-6x86-q33q [CVE-2023-32681]: Requests forwards proxy-authorization...  → fixed: 2.31.0
      ...
Summary: highest blast radius is HIGH (requests)
         Known CVEs from OSV affecting version 2.28.0: 7
```

## Tests

35 new tests in `tests/test_dependency_blast_radius.py`:

| Class | Tests |
|---|---|
| `TestEcosystemToOsvMapping` | 11 — alias mapping coverage for all 11 ecosystems |
| `TestFetchOsvPackageVulns` | 13 — guards, normal response, version/no-version payload, alias resolution, network error, max_vulns cap, fixed-version extraction, empty/missing key, summary truncation |
| `TestBlastRadiusOsvIntegration` | 11 — end-to-end output assertions for all new fields |

Full suite: **1193 passed, 3 deselected** (was 1158 before this PR). All ruff checks pass.

## Closes

Integration gap noted in evolution log: `get_dependency_blast_radius` did not call `get_osv_data` for per-package CVE context on direct queries.