### PR TITLE
feat(tools): Swift package enrichment in get_dependency_blast_radius

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -8,12 +8,13 @@ on the affected package, and how widely it is downloaded.
 Data sources (all free, no API key required):
   1. NVD CVE 2.0 API  — maps CVE → affected packages + version ranges
   2. OSV.dev API       — cross-ecosystem vulnerability data (PyPI, npm, Maven,
-                         Go, RubyGems, crates.io, …)
+                         Go, RubyGems, crates.io, SwiftURL, …)
   3. GitHub Advisory DB — GHSA packages + ecosystems
   4. npm registry API  — dependents count + weekly download stats (npm only)
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
   6. Maven Central     — artifact metadata + version count (Maven only)
+  7. GitHub REST API   — repo metadata + release history (Swift packages only)
 
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
@@ -51,6 +52,9 @@ _NPM_DOWNLOADS_URL = "https://api.npmjs.org/downloads/point/last-week/{}"
 _PYPI_JSON_URL = "https://pypi.org/pypi/{}/json"
 _PYPISTATS_URL = "https://pypistats.org/api/packages/{}/recent"
 _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
+_GITHUB_REPO_URL = "https://api.github.com/repos/{}"
+_GITHUB_RELEASES_URL = "https://api.github.com/repos/{}/releases"
+_GITHUB_TAGS_URL = "https://api.github.com/repos/{}/tags"
 
 _TIMEOUT = 20
 
@@ -66,6 +70,7 @@ _ECOSYSTEM_LABEL: dict[str, str] = {
     "Packagist": "Packagist (PHP)",
     "Hex": "Hex (Elixir/Erlang)",
     "Pub": "Pub (Dart/Flutter)",
+    "SwiftURL": "Swift Package Index (Swift/Apple)",
 }
 
 
@@ -373,6 +378,115 @@ def _enrich_maven(name: str) -> dict[str, Any]:
     return result
 
 
+def _parse_swift_timestamp(ts: str) -> str:
+    """Normalise a GitHub ISO-8601 timestamp to ``YYYY-MM-DD``.
+
+    GitHub returns timestamps as ``2014-07-31T05:56:19Z``.
+    """
+    if not ts:
+        return ""
+    # Strip trailing Z or +HH:MM offset before slicing
+    ts = ts.rstrip("Z")
+    if "+" in ts:
+        ts = ts.split("+")[0]
+    return ts[:10]  # YYYY-MM-DD
+
+
+def _enrich_swift(name: str) -> dict[str, Any]:
+    """Fetch Swift package metadata from the GitHub API.
+
+    *name* must be an ``owner/repo`` slug (e.g. ``Alamofire/Alamofire``).
+    Swift packages are always hosted on GitHub (or another VCS), and their
+    identity in the OSV ``SwiftURL`` ecosystem is ``github.com/{owner}/{repo}``.
+
+    Metrics returned:
+      - ``github_stars``        — repository star count (main engagement proxy)
+      - ``forks``               — fork count
+      - ``latest_version``      — latest release tag (or latest tag if no releases)
+      - ``total_versions``      — total published release/tag count
+      - ``first_release_date``  — date of the oldest release/tag (ISO YYYY-MM-DD)
+      - ``age_years``           — approximate package age
+      - ``description``         — repo description (120-char truncated)
+      - ``language``            — primary language reported by GitHub
+      - ``github_page``         — HTML URL
+
+    ``weekly_downloads`` is set to ``github_stars * 100`` so that
+    :func:`_blast_score` produces meaningful CRITICAL/HIGH/MEDIUM/LOW labels
+    without requiring a download-stats API.  This proxy is conservative:
+    a package with 40 k stars is depended upon by vastly more than 4 M
+    weekly users, but the scaling keeps the label roughly calibrated with
+    the other ecosystems.
+    """
+    result: dict[str, Any] = {"ecosystem": "SwiftURL", "package_name": name}
+
+    # ---------- Step 1: repository metadata ----------
+    try:
+        repo_data = _get(_GITHUB_REPO_URL.format(name))
+        result["github_stars"] = repo_data.get("stargazers_count", 0)
+        result["forks"] = repo_data.get("forks_count", 0)
+        result["language"] = repo_data.get("language") or ""
+        raw_desc = repo_data.get("description") or ""
+        result["description"] = raw_desc.replace("\n", " ")[:120]
+        result["github_page"] = repo_data.get("html_url", "")
+        created_at = repo_data.get("created_at", "")
+        # Use repo creation as a conservative lower bound for age
+        result["_repo_created_at"] = _parse_swift_timestamp(created_at)
+    except Exception as exc:
+        logger.debug("Swift GitHub repo fetch failed for %s: %s", name, exc)
+        return result
+
+    # Blast-score proxy: stars × 100 → weekly_downloads equivalent
+    stars = result.get("github_stars", 0) or 0
+    result["weekly_downloads"] = stars * 100
+
+    # ---------- Step 2: release history ----------
+    try:
+        releases = _get(_GITHUB_RELEASES_URL.format(name), params={"per_page": 100})
+        if isinstance(releases, list) and releases:
+            result["total_versions"] = len(releases)
+            # GitHub returns newest-first
+            result["latest_version"] = releases[0].get("tag_name", "")
+            oldest_ts = ""
+            for rel in reversed(releases):
+                ts = rel.get("published_at", "")
+                if ts:
+                    oldest_ts = ts
+                    break
+            if oldest_ts:
+                result["first_release_date"] = _parse_swift_timestamp(oldest_ts)
+    except Exception as exc:
+        logger.debug("Swift releases fetch failed for %s: %s", name, exc)
+
+    # ---------- Step 3: tag fallback (no formal releases) ----------
+    if "total_versions" not in result:
+        try:
+            tags = _get(_GITHUB_TAGS_URL.format(name), params={"per_page": 100})
+            if isinstance(tags, list) and tags:
+                result["total_versions"] = len(tags)
+                result["latest_version"] = tags[0].get("name", "")
+        except Exception as exc:
+            logger.debug("Swift tags fetch failed for %s: %s", name, exc)
+
+    # ---------- Step 4: age_years from first_release_date or repo creation ----------
+    base_date = result.get("first_release_date") or result.get("_repo_created_at", "")
+    if base_date:
+        try:
+            import datetime  # noqa: PLC0415
+
+            year = int(base_date[:4])
+            month = int(base_date[5:7])
+            day = int(base_date[8:10])
+            origin = datetime.date(year, month, day)
+            today = datetime.date.today()
+            result["age_years"] = round((today - origin).days / 365.25, 1)
+        except Exception:
+            pass
+
+    # Remove internal key
+    result.pop("_repo_created_at", None)
+    return result
+
+
 def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
     """Dispatch to the right enrichment function based on ecosystem."""
     eco_lower = (ecosystem or "").lower()
@@ -382,6 +496,8 @@ def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
         return _enrich_pypi(name)
     elif eco_lower in ("maven", "java", "gradle"):
         return _enrich_maven(name)
+    elif eco_lower in ("swift", "swifturl", "swiftpackage", "ios", "macos", "spm"):
+        return _enrich_swift(name)
     # Unknown ecosystem — return minimal record
     return {"ecosystem": ecosystem, "package_name": name}
 
@@ -434,6 +550,12 @@ def get_dependency_blast_radius(  # noqa: C901
        - **PyPI**: package metadata + download stats (when pypistats is available)
        - **Maven**: artifact metadata from Maven Central
     3. Computes a qualitative blast-radius label: CRITICAL / HIGH / MEDIUM / LOW.
+
+    Supported ecosystems and their enrichment data sources:
+      - **npm**:      dependent package count + weekly/monthly download stats
+      - **PyPI**:     package metadata + download stats (when pypistats is available)
+      - **Maven**:    artifact metadata from Maven Central
+      - **Swift**:    GitHub repo stars, release history, age (via GitHub REST API)
 
     Use after ``get_nvd_data`` to understand *how many projects are exposed*
     to a vulnerability — the answer is often orders of magnitude larger than
@@ -558,6 +680,27 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("version_count"):
                 lines.append(f"    Version count:    {r['version_count']}")
+
+        # Swift-specific stats
+        if eco.lower() in ("swifturl", "swift", "swiftpackage", "ios", "macos", "spm"):
+            if r.get("github_stars") is not None:
+                lines.append(f"    GitHub stars:     {r['github_stars']:,}")
+            if r.get("forks") is not None:
+                lines.append(f"    Forks:            {r['forks']:,}")
+            if r.get("latest_version"):
+                lines.append(f"    Latest version:   {r['latest_version']}")
+            if r.get("total_versions"):
+                lines.append(f"    Total versions:   {r['total_versions']}")
+            if r.get("first_release_date"):
+                age = r.get("age_years", "")
+                age_str = f" ({age} yrs)" if age else ""
+                lines.append(f"    First released:   {r['first_release_date']}{age_str}")
+            if r.get("description"):
+                lines.append(f"    Description:      {r['description'][:80]}")
+            if r.get("language"):
+                lines.append(f"    Language:         {r['language']}")
+            if r.get("github_page"):
+                lines.append(f"    GitHub page:      {r['github_page']}")
 
         if source:
             lines.append(f"    Data sources:     {source}")

--- a/tests/test_dependency_blast_radius.py
+++ b/tests/test_dependency_blast_radius.py
@@ -18,10 +18,12 @@ from manus_agent.tools.get_dependency_blast_radius import (
     _enrich_npm,
     _enrich_package,
     _enrich_pypi,
+    _enrich_swift,
     _fetch_ghsa_affected,
     _fetch_nvd_affected,
     _fetch_osv_affected,
     _parse_input,
+    _parse_swift_timestamp,
     _summarise_osv_ranges,
     get_dependency_blast_radius,
 )
@@ -933,3 +935,478 @@ class TestCliParser:
         from manus_agent.cli import _SUBCOMMANDS
 
         assert "blast-radius" in _SUBCOMMANDS
+
+
+# ===========================================================================
+# _parse_swift_timestamp
+# ===========================================================================
+
+
+class TestParseSwiftTimestamp:
+    def test_standard_z_suffix(self):
+
+        assert _parse_swift_timestamp("2014-07-31T05:56:19Z") == "2014-07-31"
+
+    def test_no_time_component(self):
+
+        assert _parse_swift_timestamp("2021-01-15") == "2021-01-15"
+
+    def test_with_offset(self):
+
+        assert _parse_swift_timestamp("2023-06-01T12:00:00+05:30") == "2023-06-01"
+
+    def test_empty_string(self):
+
+        assert _parse_swift_timestamp("") == ""
+
+    def test_year_month_day_preserved(self):
+
+        assert _parse_swift_timestamp("2019-03-22T18:45:00Z") == "2019-03-22"
+
+
+# ===========================================================================
+# _enrich_swift — unit tests
+# ===========================================================================
+
+_ALAMOFIRE_REPO = {
+    "name": "Alamofire",
+    "description": "Elegant HTTP Networking in Swift",
+    "stargazers_count": 42404,
+    "forks_count": 7665,
+    "created_at": "2014-07-31T05:56:19Z",
+    "html_url": "https://github.com/Alamofire/Alamofire",
+    "language": "Swift",
+}
+
+_ALAMOFIRE_RELEASES = [
+    {"tag_name": "5.10.2", "published_at": "2026-05-05T10:00:00Z"},
+    {"tag_name": "5.10.1", "published_at": "2026-03-01T10:00:00Z"},
+    {"tag_name": "5.0.0", "published_at": "2020-01-01T10:00:00Z"},
+    {"tag_name": "1.0.0", "published_at": "2014-09-16T10:00:00Z"},
+]
+
+
+class TestEnrichSwift:
+    def _make_get(self, repo_data=None, releases_data=None, tags_data=None):
+        """Return a side_effect function that routes mock GET calls."""
+        repo = repo_data if repo_data is not None else _ALAMOFIRE_REPO
+        releases = releases_data if releases_data is not None else _ALAMOFIRE_RELEASES
+        tags = tags_data if tags_data is not None else []
+
+        def _side_effect(url, params=None, headers=None):
+            if "/releases" in url:
+                return releases
+            if "/tags" in url:
+                return tags
+            # Repo metadata call
+            return repo
+
+        return _side_effect
+
+    def test_returns_dict_with_ecosystem(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["ecosystem"] == "SwiftURL"
+        assert result["package_name"] == "Alamofire/Alamofire"
+
+    def test_github_stars_extracted(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["github_stars"] == 42404
+
+    def test_weekly_downloads_proxy_stars_times_100(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["weekly_downloads"] == 42404 * 100
+
+    def test_forks_extracted(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["forks"] == 7665
+
+    def test_description_extracted(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["description"] == "Elegant HTTP Networking in Swift"
+
+    def test_language_extracted(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["language"] == "Swift"
+
+    def test_github_page_extracted(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["github_page"] == "https://github.com/Alamofire/Alamofire"
+
+    def test_latest_version_from_releases(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["latest_version"] == "5.10.2"
+
+    def test_total_versions_from_releases(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["total_versions"] == 4
+
+    def test_first_release_date_oldest_release(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert result["first_release_date"] == "2014-09-16"
+
+    def test_age_years_positive(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        # Package was created in 2014 — should be 10+ years
+        assert result.get("age_years", 0) >= 10.0
+
+    def test_internal_repo_created_at_not_in_result(self):
+        """_repo_created_at should be popped before returning."""
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(),
+        ):
+            result = _enrich_swift("Alamofire/Alamofire")
+        assert "_repo_created_at" not in result
+
+    def test_fallback_to_tags_when_no_releases(self):
+
+        tags = [{"name": "2.0.0"}, {"name": "1.5.0"}, {"name": "1.0.0"}]
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(releases_data=[], tags_data=tags),
+        ):
+            result = _enrich_swift("owner/pkg")
+        assert result["total_versions"] == 3
+        assert result["latest_version"] == "2.0.0"
+
+    def test_graceful_degradation_on_repo_fetch_failure(self):
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=Exception("connection refused"),
+        ):
+            result = _enrich_swift("owner/pkg")
+        # Should return minimal dict without raising
+        assert result["ecosystem"] == "SwiftURL"
+        assert "github_stars" not in result
+
+    def test_graceful_degradation_on_releases_fetch_failure(self):
+
+        call_count = {"n": 0}
+
+        def _side_effect(url, params=None, headers=None):
+            call_count["n"] += 1
+            if "/releases" in url or "/tags" in url:
+                raise Exception("timeout")
+            return _ALAMOFIRE_REPO
+
+        with patch("manus_agent.tools.get_dependency_blast_radius._get", side_effect=_side_effect):
+            result = _enrich_swift("Alamofire/Alamofire")
+        # stars and description should still be populated
+        assert result["github_stars"] == 42404
+        # No crash; version fields missing is acceptable
+        assert result["ecosystem"] == "SwiftURL"
+
+    def test_zero_stars_gives_zero_weekly_downloads(self):
+
+        repo = {**_ALAMOFIRE_REPO, "stargazers_count": 0}
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(repo_data=repo),
+        ):
+            result = _enrich_swift("owner/new-pkg")
+        assert result["weekly_downloads"] == 0
+
+    def test_none_description_does_not_crash(self):
+
+        repo = {**_ALAMOFIRE_REPO, "description": None}
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(repo_data=repo),
+        ):
+            result = _enrich_swift("owner/pkg")
+        assert result["description"] == ""
+
+    def test_description_truncated_to_120_chars(self):
+
+        long_desc = "x" * 200
+        repo = {**_ALAMOFIRE_REPO, "description": long_desc}
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(repo_data=repo),
+        ):
+            result = _enrich_swift("owner/pkg")
+        assert len(result["description"]) <= 120
+
+    def test_multiline_description_newlines_stripped(self):
+
+        repo = {**_ALAMOFIRE_REPO, "description": "First line\nSecond line"}
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=self._make_get(repo_data=repo),
+        ):
+            result = _enrich_swift("owner/pkg")
+        assert "\n" not in result["description"]
+
+
+# ===========================================================================
+# _enrich_package — dispatch to _enrich_swift
+# ===========================================================================
+
+
+class TestEnrichPackageSwiftDispatch:
+    def _patched_enrich_swift(self):
+        """Return a mock _enrich_swift that records its call args."""
+        calls = []
+
+        def _mock(name):
+            calls.append(name)
+            return {"ecosystem": "SwiftURL", "package_name": name, "github_stars": 500, "weekly_downloads": 50000}
+
+        return _mock, calls
+
+    def test_swift_ecosystem_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            result = _enrich_package("Alamofire/Alamofire", "swift")
+        assert calls == ["Alamofire/Alamofire"]
+        assert result["ecosystem"] == "SwiftURL"
+
+    def test_swifturl_ecosystem_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("owner/repo", "SwiftURL")
+        assert calls == ["owner/repo"]
+
+    def test_ios_alias_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("owner/repo", "ios")
+        assert calls == ["owner/repo"]
+
+    def test_macos_alias_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("owner/repo", "macos")
+        assert calls == ["owner/repo"]
+
+    def test_spm_alias_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("owner/repo", "spm")
+        assert calls == ["owner/repo"]
+
+    def test_swiftpackage_alias_dispatches(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("owner/repo", "swiftpackage")
+        assert calls == ["owner/repo"]
+
+    def test_unknown_ecosystem_not_swift(self):
+        from manus_agent.tools.get_dependency_blast_radius import _enrich_package
+
+        mock_fn, calls = self._patched_enrich_swift()
+        with patch("manus_agent.tools.get_dependency_blast_radius._enrich_swift", mock_fn):
+            _enrich_package("requests", "PyPI")
+        assert calls == []
+
+
+# ===========================================================================
+# get_dependency_blast_radius — Swift integration (end-to-end with mocks)
+# ===========================================================================
+
+
+class TestGetDependencyBlastRadiusSwift:
+    _SWIFT_STATS = {
+        "ecosystem": "SwiftURL",
+        "package_name": "Alamofire/Alamofire",
+        "github_stars": 42404,
+        "forks": 7665,
+        "weekly_downloads": 42404 * 100,
+        "latest_version": "5.10.2",
+        "total_versions": 87,
+        "first_release_date": "2014-09-16",
+        "age_years": 11.8,
+        "description": "Elegant HTTP Networking in Swift",
+        "language": "Swift",
+        "github_page": "https://github.com/Alamofire/Alamofire",
+    }
+
+    def test_direct_swift_package_query(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with (
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=self._SWIFT_STATS,
+            ),
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "Alamofire" in result
+
+    def test_output_contains_github_stars(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "42,404" in result or "42404" in result
+
+    def test_output_contains_latest_version(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "5.10.2" in result
+
+    def test_output_contains_first_released(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "2014-09-16" in result
+
+    def test_output_contains_description(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "Elegant HTTP" in result
+
+    def test_output_contains_github_page(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "github.com/Alamofire" in result
+
+    def test_blast_radius_high_for_alamofire(self):
+        """42 k stars × 100 = 4.24M weekly_downloads → HIGH blast radius."""
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "HIGH" in result or "CRITICAL" in result
+
+    def test_cve_swift_package_in_osv_output(self):
+        """CVE query returning a SwiftURL package should enrich it properly."""
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        osv_pkgs = [
+            {
+                "name": "Alamofire/Alamofire",
+                "ecosystem": "SwiftURL",
+                "version_range": "<5.10.0",
+                "source": "osv",
+            }
+        ]
+        with (
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_nvd_affected", return_value=[]),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._fetch_osv_affected",
+                return_value=osv_pkgs,
+            ),
+            patch("manus_agent.tools.get_dependency_blast_radius._fetch_ghsa_affected", return_value=[]),
+            patch(
+                "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+                return_value=self._SWIFT_STATS,
+            ),
+        ):
+            result = get_dependency_blast_radius("CVE-2025-99999")
+        assert "Alamofire" in result
+
+    def test_ecosystem_label_swift_in_output(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=self._SWIFT_STATS,
+        ):
+            result = get_dependency_blast_radius("swift:Alamofire/Alamofire")
+        assert "Swift" in result
+
+    def test_low_stars_gives_low_blast_radius(self):
+        from manus_agent.tools.get_dependency_blast_radius import get_dependency_blast_radius
+
+        low_stats = {**self._SWIFT_STATS, "github_stars": 10, "weekly_downloads": 1000}
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_package",
+            return_value=low_stats,
+        ):
+            result = get_dependency_blast_radius("swift:owner/tiny-pkg")
+        assert "LOW" in result


### PR DESCRIPTION
## Summary

Adds `_enrich_swift` + `_parse_swift_timestamp` to `get_dependency_blast_radius`, giving the blast-radius tool first-class support for the Swift/Apple package ecosystem.

Swift packages (iOS/macOS/watchOS/tvOS) are a significant CVE surface: Alamofire (42 k stars), SDWebImage (25 k), Kingfisher (23 k), and similar packages are embedded in **millions of deployed apps**. When a vulnerability affects one of these packages the real blast radius is enormous, yet the tool previously had no way to surface that signal.

## What changed

### `src/manus_agent/tools/get_dependency_blast_radius.py`

| Addition | Detail |
|---|---|
| `_parse_swift_timestamp(ts)` | Normalises GitHub ISO-8601 timestamps (`2014-07-31T05:56:19Z`, `+HH:MM` offsets) → `YYYY-MM-DD`; same pattern as `_parse_go_timestamp` / `_parse_hex_timestamp` |
| `_enrich_swift(name)` | `owner/repo` → two unauthenticated GitHub REST API calls: (1) `GET /repos/{owner}/{repo}` for stars, forks, description, language, html_url; (2) `GET /repos/{owner}/{repo}/releases?per_page=100` for latest_version, total_versions, first_release_date — with tag fallback when no formal releases exist |
| Blast-score proxy | `weekly_downloads = github_stars × 100` — GitHub stars are the canonical engagement metric for Swift packages; this conservative scaling produces CRITICAL/HIGH/MEDIUM/LOW labels calibrated with the other ecosystems (Alamofire: 42 k × 100 = 4.24 M → **HIGH**) |
| Graceful degradation | Repo fetch failure → minimal `{ecosystem, package_name}` stub; releases/tags failure → stars and description still returned |
| Dispatch aliases | `swift` / `swifturl` / `swiftpackage` / `ios` / `macos` / `spm` all route to `_enrich_swift` |
| Output block | GitHub stars, Forks, Latest version, Total versions, First released + age, Description, Language, GitHub page |
| Ecosystem label | `_ECOSYSTEM_LABEL["SwiftURL"] = "Swift Package Index (Swift/Apple)"` |
| URL constants | `_GITHUB_REPO_URL`, `_GITHUB_RELEASES_URL`, `_GITHUB_TAGS_URL` |

### `tests/test_dependency_blast_radius.py`

+41 new tests across 4 classes (suite total: **1199 tests**, all passing):

| Class | Tests | Coverage |
|---|---|---|
| `TestParseSwiftTimestamp` | 5 | Z suffix, no time, offset, empty string, date preservation |
| `TestEnrichSwift` | 19 | Stars, downloads proxy, forks, description, language, GitHub page, latest version, total versions, first_release_date, age_years, internal key cleanup, tag fallback, repo fetch failure, releases failure, zero stars, None description, truncation, newline stripping |
| `TestEnrichPackageSwiftDispatch` | 7 | All ecosystem aliases: swift, swifturl, swiftpackage, ios, macos, spm + non-Swift ecosystem not dispatched |
| `TestGetDependencyBlastRadiusSwift` | 10 | Direct package query, stars in output, version in output, date in output, description in output, GitHub page in output, HIGH blast for Alamofire, CVE OSV query with SwiftURL package, ecosystem label "Swift" in output, LOW blast for tiny package |

## Usage

```bash
# Direct package query
manus-agent blast-radius swift:Alamofire/Alamofire
manus-agent blast-radius swift:apple/swift-nio
manus-agent blast-radius spm:SDWebImage/SDWebImage

# CVE query (auto-dispatches when OSV returns SwiftURL packages)
manus-agent blast-radius CVE-2025-XXXXX
```

## No duplicates — open PRs checked

Checked all open PRs before building to confirm no overlap:

#51 (silent-patches), #53 (cve-timeline), #54 (version-range), #58 (vendor-response), #60 (poc-freshness), #64 (sbom-scan), #65 (temporal-priority), #67 (cluster-variants), #74 (epss-decay), #75 (exploit-maturity), #76 (vulnerability-triage), #77 (cve-report), #78 (diff-report), #79 (reachability), #80 (epss-watchlist), #82 (attack-surface), #83 (watch-alert), #85 (cli-integration-tests), #86 (patch-lag), #87 (kev-context), #88 (readme-scoring), #89 (core-tools-tests), #90 (exploit-search-tests), #96 (maven-first-release), #98 (pypi-first-release), #100 (npm-first-release), #103 (crates.io), #104 (rubygems), #105 (nuget), #106 (go), #107 (packagist), #108 (hex), #109 (pub), #110 (conda), #111 (osv-package), #112 (cvss-vector), #113 (cran), #114 (conan)

None of the above cover Swift package enrichment.

## Quality

- ✅ `ruff check .` — clean
- ✅ `ruff format src/ tests/` — applied
- ✅ `pytest tests/ -q` — **1199 passed, 0 failures**
- ✅ 100% mocked tests — no real HTTP calls
- ✅ No new dependencies required (uses `requests` already present)
