### PR TITLE
feat: add _enrich_opam for OCaml OPAM blast-radius enrichment

### DIFF
--- a/src/manus_agent/tools/get_dependency_blast_radius.py
+++ b/src/manus_agent/tools/get_dependency_blast_radius.py
@@ -14,6 +14,8 @@ Data sources (all free, no API key required):
   5. PyPI JSON API     — package metadata (PyPI only; download counts from
                          pypistats.org with graceful degradation on 429)
   6. Maven Central     — artifact metadata + version count (Maven only)
+  7. OPAM (OCaml)      — opam-repository GitHub API; version count, synopsis,
+                         homepage, license, depends count, reverse-dep proxy
 
 The tool deliberately avoids paid/rate-limited APIs so it works without
 configuration.  When a source is unavailable the result degrades gracefully.
@@ -24,6 +26,7 @@ CLI: ``manus-agent blast-radius requests@2.28.0``
 
 from __future__ import annotations
 
+import base64
 import logging
 import re
 from typing import Any
@@ -54,6 +57,20 @@ _MAVEN_SEARCH_URL = "https://search.maven.org/solrsearch/select"
 
 _TIMEOUT = 20
 
+# OPAM / opam-repository constants
+_OPAM_REPO_URL = "https://api.github.com/repos/ocaml/opam-repository/contents/packages/{name}"
+_OPAM_FILE_URL = (
+    "https://api.github.com/repos/ocaml/opam-repository/contents/"
+    "packages/{name}/{name}.{version}/opam"
+)
+_OPAM_PKG_PAGE = "https://opam.ocaml.org/packages/{name}/"
+
+# Regex helpers for parsing opam file fields
+_OPAM_SYNOPSIS_RE = re.compile(r'^synopsis:\s+"(.+?)"', re.MULTILINE)
+_OPAM_HOMEPAGE_RE = re.compile(r'^homepage:\s+"(.+?)"', re.MULTILINE)
+_OPAM_LICENSE_RE = re.compile(r'^license:\s+"(.+?)"', re.MULTILINE)
+_OPAM_DEPENDS_RE = re.compile(r'^depends:\s*\[(.+?)^\]', re.MULTILINE | re.DOTALL)
+
 # OSV ecosystem → display name mapping
 _ECOSYSTEM_LABEL: dict[str, str] = {
     "PyPI": "PyPI (Python)",
@@ -66,6 +83,7 @@ _ECOSYSTEM_LABEL: dict[str, str] = {
     "Packagist": "Packagist (PHP)",
     "Hex": "Hex (Elixir/Erlang)",
     "Pub": "Pub (Dart/Flutter)",
+    "OPAM": "OPAM (OCaml)",
 }
 
 
@@ -373,6 +391,181 @@ def _enrich_maven(name: str) -> dict[str, Any]:
     return result
 
 
+# ---------------------------------------------------------------------------
+# OPAM (OCaml) enrichment
+# ---------------------------------------------------------------------------
+
+
+def _parse_opam_versions(entries: list[dict[str, Any]], name: str) -> list[str]:
+    """
+    Extract version strings from a GitHub Contents API directory listing.
+
+    Each entry has a ``name`` field like ``tls.2.1.1``; we strip the package
+    prefix and return a list of bare version strings (newest-first via reverse
+    lexicographic sort as a cheap approximation — semver-correct ordering is
+    handled separately when we need the actual latest version).
+    """
+    prefix = f"{name.lower()}."
+    versions: list[str] = []
+    for entry in entries:
+        entry_name: str = entry.get("name", "")
+        if entry_name.lower().startswith(prefix):
+            ver = entry_name[len(prefix) :]
+            if ver:
+                versions.append(ver)
+    # Reverse-sort so that the first element is a good "latest" candidate.
+    # We prefer this over a full semver sort to avoid importing packaging.
+    versions.sort(reverse=True)
+    return versions
+
+
+def _pick_latest_opam_version(versions: list[str]) -> str:
+    """
+    Return the best "latest" version from the list returned by
+    ``_parse_opam_versions``.  Prefers versions that look like plain semver
+    (digits and dots only) over dev/rc/alpha/beta suffixes.
+    """
+    stable = [v for v in versions if re.match(r"^\d+(\.\d+)*$", v)]
+    return (stable[0] if stable else versions[0]) if versions else ""
+
+
+def _parse_opam_file(content: str) -> dict[str, str | int]:
+    """
+    Extract key fields from a raw opam file string.
+
+    Returns a dict with zero or more of:
+      synopsis, homepage, license, depends_count
+    """
+    result: dict[str, str | int] = {}
+
+    m = _OPAM_SYNOPSIS_RE.search(content)
+    if m:
+        result["synopsis"] = m.group(1).strip()
+
+    m = _OPAM_HOMEPAGE_RE.search(content)
+    if m:
+        result["homepage"] = m.group(1).strip()
+
+    m = _OPAM_LICENSE_RE.search(content)
+    if m:
+        result["license"] = m.group(1).strip()
+
+    m = _OPAM_DEPENDS_RE.search(content)
+    if m:
+        deps_block = m.group(1)
+        # Each dependency is a quoted package name (possibly with version constraints).
+        # Count distinct quoted names, excluding build-tool meta-deps.
+        dep_names = re.findall(r'"([^"]+?)"', deps_block)
+        # Strip conditional suffixes like " {with-test}"
+        dep_names = [d.split()[0] for d in dep_names]
+        # Filter out version constraint strings (e.g. "4.13.0") and
+        # OCaml meta-packages that are always present.
+        # Opam package names start with a letter: [A-Za-z][A-Za-z0-9._-]*
+        _pkg_name_re = re.compile(r'^[A-Za-z][A-Za-z0-9._-]*$')
+        _meta = {"ocaml", "dune", "ocamlfind", "base", "jbuilder"}
+        real_deps = [
+            d for d in dep_names
+            if _pkg_name_re.match(d) and d not in _meta and not d.startswith("{")
+        ]
+        result["depends_count"] = len(set(real_deps))
+
+    return result
+
+
+def _enrich_opam(name: str) -> dict[str, Any]:  # noqa: C901
+    """
+    Fetch OCaml OPAM package metadata from the opam-repository on GitHub.
+
+    Three-step enrichment:
+      1. List ``packages/{name}/`` in the opam-repository to get available
+         versions and total version count.
+      2. Fetch the opam file for the latest version to extract synopsis,
+         homepage, license, and the number of declared dependencies.
+      3. Use the GitHub code-search API (authenticated via ``gh`` token or
+         ``GITHUB_TOKEN`` env var) to count opam files that mention the
+         package name in a ``depends`` block — a proxy for reverse-dependency
+         count.  Fails gracefully when unauthenticated (HTTP 401/403/422).
+
+    The ``dependent_packages_count`` field drives ``_blast_score``.
+    """
+    result: dict[str, Any] = {"ecosystem": "OPAM", "package_name": name}
+
+    # --- Step 1: version list ---
+    try:
+        versions_data = _get(
+            _OPAM_REPO_URL.format(name=name),
+            headers={"Accept": "application/vnd.github.v3+json"},
+        )
+        if not isinstance(versions_data, list):
+            # Might be a 404 dict or error
+            logger.debug("OPAM version list unexpected response for %s", name)
+            return result
+
+        versions = _parse_opam_versions(versions_data, name)
+        result["version_count"] = len(versions)
+        latest = _pick_latest_opam_version(versions)
+        if latest:
+            result["latest_version"] = latest
+    except Exception as exc:
+        logger.debug("OPAM version list failed for %s: %s", name, exc)
+        return result
+
+    if not versions:
+        logger.debug("OPAM: no versions found for %s", name)
+        return result
+
+    # --- Step 2: opam file metadata ---
+    try:
+        opam_data = _get(
+            _OPAM_FILE_URL.format(name=name, version=latest),
+            headers={"Accept": "application/vnd.github.v3+json"},
+        )
+        if isinstance(opam_data, dict) and opam_data.get("content"):
+            raw_content = base64.b64decode(opam_data["content"]).decode("utf-8", errors="replace")
+            meta = _parse_opam_file(raw_content)
+            result.update(meta)
+    except Exception as exc:
+        logger.debug("OPAM opam-file fetch failed for %s@%s: %s", name, latest, exc)
+        # Non-fatal: continue without file metadata
+
+    # --- Step 3: reverse-dependency proxy via GitHub code search ---
+    # Search for opam files in opam-repository that mention the package name
+    # inside a depends block.  Uses the authenticated GitHub Search API via
+    # the ``gh`` CLI token stored in ~/.config/gh/hosts.yml.
+    try:
+        import subprocess
+        from urllib.parse import quote
+
+        # Build a search query: look for \"name\" in opam files in opam-repository.
+        # The query uses URL-encoded double-quoted name to match exact package deps.
+        # Example: search/code?q=%22%5C%22tls%5C%22%22+repo:ocaml/opam-repository+filename:opam
+        quoted_name = quote(f'"\\\"{ name }\\\""', safe="")
+        api_path = (
+            f"search/code?q={quoted_name}"
+            "+repo:ocaml/opam-repository+filename:opam&per_page=1"
+        )
+        proc = subprocess.run(
+            ["gh", "api", api_path],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            import json as _json
+
+            search_result = _json.loads(proc.stdout)
+            total = search_result.get("total_count")
+            if isinstance(total, int):
+                # Subtract 1 for the package's own opam file(s)
+                result["dependent_packages_count"] = max(0, total - len(versions))
+    except Exception as exc:
+        logger.debug("OPAM reverse-dep search failed for %s: %s", name, exc)
+        # Non-fatal: blast score will be UNKNOWN without this
+
+    result["opam_page"] = _OPAM_PKG_PAGE.format(name=name)
+    return result
+
+
 def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
     """Dispatch to the right enrichment function based on ecosystem."""
     eco_lower = (ecosystem or "").lower()
@@ -382,6 +575,8 @@ def _enrich_package(name: str, ecosystem: str) -> dict[str, Any]:
         return _enrich_pypi(name)
     elif eco_lower in ("maven", "java", "gradle"):
         return _enrich_maven(name)
+    elif eco_lower in ("opam", "ocaml", "caml"):
+        return _enrich_opam(name)
     # Unknown ecosystem — return minimal record
     return {"ecosystem": ecosystem, "package_name": name}
 
@@ -558,6 +753,25 @@ def get_dependency_blast_radius(  # noqa: C901
                 lines.append(f"    Latest version:   {r['latest_version']}")
             if r.get("version_count"):
                 lines.append(f"    Version count:    {r['version_count']}")
+
+        # OPAM (OCaml) specific stats
+        if eco.lower() in ("opam", "ocaml", "caml"):
+            if r.get("latest_version"):
+                lines.append(f"    Latest version:   {r['latest_version']}")
+            if r.get("version_count"):
+                lines.append(f"    Total versions:   {r['version_count']}")
+            if r.get("dependent_packages_count") is not None:
+                lines.append(f"    OPAM rev-deps:    {r['dependent_packages_count']:,}")
+            if r.get("depends_count"):
+                lines.append(f"    Direct depends:   {r['depends_count']}")
+            if r.get("synopsis"):
+                lines.append(f"    Synopsis:         {str(r['synopsis'])[:80]}")
+            if r.get("license"):
+                lines.append(f"    License:          {r['license']}")
+            if r.get("homepage"):
+                lines.append(f"    Homepage:         {r['homepage']}")
+            if r.get("opam_page"):
+                lines.append(f"    OPAM page:        {r['opam_page']}")
 
         if source:
             lines.append(f"    Data sources:     {source}")

--- a/tests/test_enrich_opam.py
+++ b/tests/test_enrich_opam.py
@@ -1,0 +1,447 @@
+"""
+Tests for OPAM (OCaml) enrichment in get_dependency_blast_radius.
+
+All external HTTP calls and subprocess calls are mocked — no real network I/O.
+100%% mocked: GitHub Contents API, GitHub opam file fetch, gh CLI subprocess.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.get_dependency_blast_radius import (
+    _enrich_opam,
+    _enrich_package,
+    _parse_opam_file,
+    _parse_opam_versions,
+    _pick_latest_opam_version,
+)
+
+# ---------------------------------------------------------------------------
+# Sample fixtures
+# ---------------------------------------------------------------------------
+
+_TLS_VERSIONS = [
+    {"name": "tls.0.10.4", "type": "dir"},
+    {"name": "tls.0.11.0", "type": "dir"},
+    {"name": "tls.1.0.4", "type": "dir"},
+    {"name": "tls.2.0.1", "type": "dir"},
+    {"name": "tls.2.0.4", "type": "dir"},
+    {"name": "tls.2.1.0", "type": "dir"},
+    {"name": "tls.2.1.1", "type": "dir"},
+]
+
+_TLS_OPAM_CONTENT = """opam-version: "2.0"
+homepage:     "https://github.com/mirleft/ocaml-tls"
+license:      "BSD-2-Clause"
+synopsis:     "Transport Layer Security purely in OCaml"
+depends: [
+  "ocaml" {>= "4.13.0"}
+  "dune" {>= "3.0"}
+  "mirage-crypto" {>= "1.1.0"}
+  "x509" {>= "1.0.0"}
+  "fmt" {>= "0.8.7"}
+  "logs"
+  "ipaddr"
+  "digestif" {>= "1.2.0"}
+  "alcotest" {with-test}
+  "cmdliner" {with-test & >= "1.3.0"}
+]
+"""
+
+
+def _make_opam_file_response(content: str) -> dict:
+    """Simulate the GitHub Contents API response for a single file."""
+    encoded = base64.b64encode(content.encode()).decode()
+    return {"content": encoded, "encoding": "base64"}
+
+
+# ===========================================================================
+# TestParseOpamVersions
+# ===========================================================================
+
+
+class TestParseOpamVersions:
+    def test_extracts_versions_from_directory_entries(self):
+        versions = _parse_opam_versions(_TLS_VERSIONS, "tls")
+        assert "2.1.1" in versions
+        assert "0.10.4" in versions
+        assert len(versions) == 7
+
+    def test_case_insensitive_prefix_match(self):
+        entries = [{"name": "TLS.2.1.1", "type": "dir"}]
+        versions = _parse_opam_versions(entries, "tls")
+        assert "2.1.1" in versions
+
+    def test_skips_unrelated_entries(self):
+        entries = [
+            {"name": "tls.2.1.1", "type": "dir"},
+            {"name": "tls-utils.0.1.0", "type": "dir"},
+            {"name": "mirage-tls.1.0.0", "type": "dir"},
+        ]
+        versions = _parse_opam_versions(entries, "tls")
+        assert versions == ["2.1.1"]
+
+    def test_returns_sorted_descending(self):
+        versions = _parse_opam_versions(_TLS_VERSIONS, "tls")
+        assert versions[0] == "2.1.1"
+        assert versions[-1] == "0.10.4"
+
+    def test_empty_directory(self):
+        versions = _parse_opam_versions([], "tls")
+        assert versions == []
+
+    def test_skips_entries_without_version(self):
+        entries = [{"name": "tls.", "type": "dir"}]
+        versions = _parse_opam_versions(entries, "tls")
+        assert versions == []
+
+    def test_handles_missing_name_field(self):
+        entries = [{"type": "dir"}]
+        versions = _parse_opam_versions(entries, "tls")
+        assert versions == []
+
+# ===========================================================================
+# TestPickLatestOpamVersion
+# ===========================================================================
+
+
+class TestPickLatestOpamVersion:
+    def test_picks_latest_stable(self):
+        versions = ["2.1.1", "2.1.0", "2.0.4", "0.10.4"]
+        assert _pick_latest_opam_version(versions) == "2.1.1"
+
+    def test_prefers_stable_over_rc(self):
+        versions = ["2.2.0-beta1", "2.1.1", "2.1.0"]
+        # 2.2.0-beta1 is not stable (has a dash), so 2.1.1 is preferred
+        assert _pick_latest_opam_version(versions) == "2.1.1"
+
+    def test_falls_back_to_first_if_no_stable(self):
+        versions = ["2.0.0-alpha", "1.0.0-rc1"]
+        assert _pick_latest_opam_version(versions) == "2.0.0-alpha"
+
+    def test_empty_list_returns_empty_string(self):
+        assert _pick_latest_opam_version([]) == ""
+
+    def test_single_version(self):
+        assert _pick_latest_opam_version(["1.2.3"]) == "1.2.3"
+
+    def test_all_stable_picks_first(self):
+        versions = ["3.0.0", "2.9.9", "1.0.0"]
+        assert _pick_latest_opam_version(versions) == "3.0.0"
+
+# ===========================================================================
+# TestParseOpamFile
+# ===========================================================================
+
+
+class TestParseOpamFile:
+    def test_extracts_synopsis(self):
+        meta = _parse_opam_file(_TLS_OPAM_CONTENT)
+        assert meta["synopsis"] == "Transport Layer Security purely in OCaml"
+
+    def test_extracts_homepage(self):
+        meta = _parse_opam_file(_TLS_OPAM_CONTENT)
+        assert meta["homepage"] == "https://github.com/mirleft/ocaml-tls"
+
+    def test_extracts_license(self):
+        meta = _parse_opam_file(_TLS_OPAM_CONTENT)
+        assert meta["license"] == "BSD-2-Clause"
+
+    def test_counts_real_depends_excludes_meta(self):
+        meta = _parse_opam_file(_TLS_OPAM_CONTENT)
+        # ocaml, dune excluded; mirage-crypto, x509, fmt, logs, ipaddr,
+        # digestif, alcotest, cmdliner = 8
+        assert meta["depends_count"] == 8
+
+    def test_empty_content_returns_empty_dict(self):
+        meta = _parse_opam_file("")
+        assert meta == {}
+
+    def test_missing_synopsis_not_in_result(self):
+        meta = _parse_opam_file("opam-version: \"2.0\"\n")
+        assert "synopsis" not in meta
+
+    def test_depends_with_only_meta_packages(self):
+        content = "depends: [\n  \"ocaml\"\n  \"dune\"\n  \"jbuilder\"\n]\n"
+        meta = _parse_opam_file(content)
+        assert meta.get("depends_count", 0) == 0
+
+    def test_depends_excludes_conditional_marker_strings(self):
+        content = "depends: [\n  \"foo\" {>= \"1.0\"}\n  \"{fake}\"\n]\n"
+        meta = _parse_opam_file(content)
+        # "{fake}" should be excluded (starts with "{")
+        assert meta.get("depends_count", 0) == 1
+
+# ===========================================================================
+# TestEnrichOpam
+# ===========================================================================
+
+
+class TestEnrichOpam:
+    """Tests for _enrich_opam — all HTTP and subprocess calls are mocked."""
+
+    def _make_mock_get(self, versions_resp, opam_file_resp=None):
+        """Build a side_effect list for patched _get."""
+        side_effects = [versions_resp]
+        if opam_file_resp is not None:
+            side_effects.append(opam_file_resp)
+        return side_effects
+
+    def test_basic_enrichment_returns_dict(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["ecosystem"] == "OPAM"
+        assert result["package_name"] == "tls"
+
+    def test_version_count_extracted(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["version_count"] == 7
+
+    def test_latest_version_picked(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["latest_version"] == "2.1.1"
+
+    def test_synopsis_extracted_from_opam_file(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["synopsis"] == "Transport Layer Security purely in OCaml"
+
+    def test_homepage_extracted(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["homepage"] == "https://github.com/mirleft/ocaml-tls"
+
+    def test_license_extracted(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        assert result["license"] == "BSD-2-Clause"
+
+    def test_reverse_dep_count_from_github_search(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[
+                _TLS_VERSIONS,
+                _make_opam_file_response(_TLS_OPAM_CONTENT),
+            ],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 20}))
+            result = _enrich_opam("tls")
+        # 20 total - 7 own versions = 13
+        assert result["dependent_packages_count"] == 13
+
+    def test_opam_page_url_present(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, _make_opam_file_response(_TLS_OPAM_CONTENT)],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 5}))
+            result = _enrich_opam("tls")
+        assert "opam.ocaml.org" in result["opam_page"]
+        assert "tls" in result["opam_page"]
+
+    def test_version_list_fetch_failure_returns_minimal(self):
+        """If the GitHub API returns an error, we return a minimal dict."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=Exception("network error"),
+        ):
+            result = _enrich_opam("tls")
+        assert result["ecosystem"] == "OPAM"
+        assert result["package_name"] == "tls"
+        assert "version_count" not in result
+
+    def test_not_a_list_response_returns_minimal(self):
+        """GitHub Contents API returning a dict (e.g. 404 message) is handled."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            return_value={"message": "Not Found"},
+        ):
+            result = _enrich_opam("unknown-pkg-xyz")
+        assert result["ecosystem"] == "OPAM"
+        assert "version_count" not in result
+
+    def test_opam_file_fetch_failure_does_not_crash(self):
+        """opam file fetch failing is non-fatal; version_count still populated."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, Exception("404 Not Found")],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 10}))
+            result = _enrich_opam("tls")
+        assert result["version_count"] == 7
+        assert "synopsis" not in result
+
+    def test_subprocess_failure_does_not_crash(self):
+        """gh CLI unavailable is non-fatal; dependent_packages_count not set."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, _make_opam_file_response(_TLS_OPAM_CONTENT)],
+        ), patch("subprocess.run", side_effect=Exception("gh not found")):
+            result = _enrich_opam("tls")
+        assert result["version_count"] == 7
+        assert "dependent_packages_count" not in result
+
+    def test_subprocess_nonzero_returncode_does_not_set_dep_count(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, _make_opam_file_response(_TLS_OPAM_CONTENT)],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1, stdout="")
+            result = _enrich_opam("tls")
+        assert "dependent_packages_count" not in result
+
+    def test_github_search_total_count_none_does_not_set_dep_count(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, _make_opam_file_response(_TLS_OPAM_CONTENT)],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": None}))
+            result = _enrich_opam("tls")
+        assert "dependent_packages_count" not in result
+
+    def test_dep_count_cannot_go_below_zero(self):
+        """total_count < own version count should clamp to 0."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, _make_opam_file_response(_TLS_OPAM_CONTENT)],
+        ), patch("subprocess.run") as mock_run:
+            # total_count=3 < 7 versions => max(0, 3-7) = 0
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 3}))
+            result = _enrich_opam("tls")
+        assert result["dependent_packages_count"] == 0
+
+    def test_opam_file_without_content_key_handled(self):
+        """GitHub Contents response without content field is handled gracefully."""
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            side_effect=[_TLS_VERSIONS, {"encoding": "base64"}],
+        ), patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=0, stdout=json.dumps({"total_count": 10}))
+            result = _enrich_opam("tls")
+        assert result["version_count"] == 7
+        assert "synopsis" not in result
+
+    def test_empty_version_list_returns_early(self):
+        """Package directory exists but has no valid version entries."""
+        empty_versions = [{"name": "other-pkg.1.0", "type": "dir"}]
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._get",
+            return_value=empty_versions,
+        ):
+            result = _enrich_opam("tls")
+        # version_count=0, no further calls
+        assert result["version_count"] == 0
+        assert "latest_version" not in result
+
+# ===========================================================================
+# TestEnrichPackageDispatch
+# ===========================================================================
+
+
+class TestEnrichPackageDispatchOpam:
+    """Verify that _enrich_package routes OPAM ecosystem aliases correctly."""
+
+    @pytest.mark.parametrize("ecosystem", ["opam", "OPAM", "ocaml", "caml"])
+    def test_opam_aliases_routed(self, ecosystem):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_opam"
+        ) as mock:
+            mock.return_value = {"ecosystem": "OPAM", "package_name": "tls"}
+            result = _enrich_package("tls", ecosystem)
+        mock.assert_called_once_with("tls")
+        assert result["ecosystem"] == "OPAM"
+
+    def test_non_opam_ecosystem_not_routed(self):
+        with patch(
+            "manus_agent.tools.get_dependency_blast_radius._enrich_opam"
+        ) as mock:
+            _enrich_package("requests", "pypi")
+        mock.assert_not_called()
+
+
+# ===========================================================================
+# TestBlastScoreOpam
+# ===========================================================================
+
+
+class TestBlastScoreOpam:
+    """Verify blast-radius scoring with OPAM-style dependent_packages_count."""
+
+    def test_high_rev_dep_count_scores_critical(self):
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score
+
+        result = _blast_score({"ecosystem": "OPAM", "dependent_packages_count": 60000})
+        assert result == "CRITICAL"
+
+    def test_medium_rev_dep_count_scores_high(self):
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score
+
+        result = _blast_score({"ecosystem": "OPAM", "dependent_packages_count": 10000})
+        assert result == "HIGH"
+
+    def test_small_rev_dep_count_scores_medium(self):
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score
+
+        result = _blast_score({"ecosystem": "OPAM", "dependent_packages_count": 600})
+        assert result == "MEDIUM"
+
+    def test_tiny_rev_dep_count_scores_low(self):
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score
+
+        result = _blast_score({"ecosystem": "OPAM", "dependent_packages_count": 5})
+        assert result == "LOW"
+
+    def test_zero_rev_dep_count_scores_unknown(self):
+        from manus_agent.tools.get_dependency_blast_radius import _blast_score
+
+        result = _blast_score({"ecosystem": "OPAM", "dependent_packages_count": 0})
+        assert result == "UNKNOWN"


### PR DESCRIPTION
## Summary

Adds OPAM (OCaml) ecosystem support to the dependency blast-radius tool, via a new `_enrich_opam()` function.

## Approach

Three-step enrichment using only free, unauthenticated (or GH token) APIs:

**Step 1 — Version list** via GitHub Contents API:
```
GET https://api.github.com/repos/ocaml/opam-repository/contents/packages/{name}
```
Returns a directory listing with entries like `tls.2.1.1/`. Extracts version count and picks the latest stable release with `_pick_latest_opam_version()` (prefers plain `X.Y.Z` over RC/beta/alpha suffixes).

**Step 2 — Metadata** from the opam file (base64-decoded via GitHub Contents API):
Parses `synopsis`, `homepage`, `license`, and `depends_count`. The depends parser strips version constraint strings (e.g. `"4.13.0"`) and always-present meta-packages (`ocaml`, `dune`, `ocamlfind`, `base`, `jbuilder`).

**Step 3 — Reverse-dependency count** via GitHub code search (authenticated with local `gh` CLI token):
```
gh api 'search/code?q=%22%5C%22{name}%5C%22%22+repo:ocaml/opam-repository+filename:opam&per_page=1'
```
Subtracts own version files to get `dependent_packages_count`. Fails gracefully when `gh` is unavailable or unauthenticated.

## Dispatch aliases

`opam`, `ocaml`, `caml`

## Test coverage

New `tests/test_enrich_opam.py` with **48 tests** (100% mocked, no real network I/O):

| Class | Tests |
|---|---|
| `TestParseOpamVersions` | 7 |
| `TestPickLatestOpamVersion` | 6 |
| `TestParseOpamFile` | 8 |
| `TestEnrichOpam` | 16 |
| `TestEnrichPackageDispatchOpam` | 5 |
| `TestBlastScoreOpam` | 5 |

Full suite: **1206 passed, 0 failures**.

## Ecosystem notes

- OSV.dev has no dedicated OCaml ecosystem — blast score relies on the GitHub code-search reverse-dep count
- OPAM has no public download stats API; `weekly_downloads` is not set (omitted rather than guessing)
- The `opam_page` field links to `opam.ocaml.org/packages/{name}`