### PR TITLE
feat(cli): add manus-agent cwe subcommand for CWE weakness lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [exploit-complexity](#manus-agent-exploit-complexity-cve-id--exploit-complexity-scorer)
   - [poc-search](#manus-agent-poc-search-cve-id--multi-source-poc-aggregator)
   - [blast-radius](#manus-agent-blast-radius-spec--dependency-blast-radius)
+  - [cwe](#manus-agent-cwe-cwe-id--cwe-weakness-lookup)
   - [silent-patches](#manus-agent-silent-patches-ownerrepo--silent-patch-detector)
   - [cve-timeline](#manus-agent-cve-timeline-cve-id--cve-timeline)
   - [version-range](#manus-agent-version-range-cve-id--affected-version-ranges)
@@ -341,6 +342,26 @@ Blast-radius labels per package:
 |------|---------|-------------|
 | `--max-packages N` | `10` | Max affected packages to enrich |
 | `--output {text,json}` | `text` | Output format |
+
+---
+
+### `manus-agent cwe <CWE-ID>` — CWE weakness lookup
+
+```bash
+manus-agent cwe CWE-79
+manus-agent cwe 787
+manus-agent cwe CWE-89 --output json | jq .description
+```
+
+Looks up a Common Weakness Enumeration (CWE) identifier from the MITRE CWE
+database and displays its description and reference URL. Accepts both `CWE-NNN`
+and plain numeric formats.
+
+| Field | Description |
+|-------|-------------|
+| CWE ID | Normalised identifier (e.g. CWE-79) |
+| URL | Direct link to MITRE CWE definition page |
+| Description | Human-readable weakness description from MITRE |
 
 ---
 

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "cwe",
 }
 
 
@@ -1935,6 +1936,93 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# cwe subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_cwe_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent cwe",
+        description=(
+            "Look up a CWE (Common Weakness Enumeration) identifier and display\n"
+            "its description, related weaknesses, and MITRE reference URL.\n"
+            "Useful for understanding the class of vulnerability behind a CVE."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "cwe_id",
+        metavar="CWE-ID",
+        help="CWE identifier, e.g. CWE-79 or 79",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_cwe(argv: list[str]) -> int:
+    parser = _build_cwe_parser()
+    args = parser.parse_args(argv)
+    raw_id = args.cwe_id.strip()
+
+    # Normalise: accept both "CWE-79" and plain "79"
+    if raw_id.upper().startswith("CWE-"):
+        cwe_id = raw_id.upper()
+    elif raw_id.isdigit():
+        cwe_id = f"CWE-{raw_id}"
+    else:
+        print(f"[error] Invalid CWE ID: {raw_id!r}. Expected CWE-NNN or a number.", file=sys.stderr)
+        return 1
+
+    try:
+        from manus_agent.tools.get_cwe_details import get_cwe_details
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    # Build a synthetic ToolUse payload matching the Strands SDK contract
+    tool_use = {
+        "toolUseId": "cli-cwe-lookup",
+        "input": {"cwe_id": cwe_id},
+    }
+    result = get_cwe_details(tool_use)
+
+    status = result.get("status", "error")
+    content = result.get("content", [])
+
+    if status == "error":
+        error_text = content[0].get("text", "Unknown error") if content else "Unknown error"
+        print(f"[error] {error_text}", file=sys.stderr)
+        return 1
+
+    # Extract payload from the successful result
+    payload = content[0].get("json", {}) if content else {}
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    # --- text output ---
+    print(f"\n  CWE ID : {payload.get('cwe_id', cwe_id)}")
+    print(f"  URL    : {payload.get('url', 'N/A')}")
+    print()
+    description = payload.get("description", "No description available.")
+    # Wrap description at ~78 chars for terminal readability
+    import textwrap
+
+    wrapped = textwrap.fill(description, width=78, initial_indent="  ", subsequent_indent="  ")
+    print(wrapped)
+    print()
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2356,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "cwe":
+        idx = argv.index("cwe")
+        sys.exit(_run_cwe(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/tests/test_cli_cwe.py
+++ b/tests/test_cli_cwe.py
@@ -1,0 +1,407 @@
+"""Comprehensive tests for the `manus-agent cwe` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from manus_agent.cli import _SUBCOMMANDS, _build_cwe_parser, _run_cwe, main
+
+# ---------------------------------------------------------------------------
+# _build_cwe_parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildCweParser:
+    """Verify _build_cwe_parser() flag definitions and defaults."""
+
+    def test_prog_name(self):
+        p = _build_cwe_parser()
+        assert p.prog == "manus-agent cwe"
+
+    def test_positional_cwe_id(self):
+        p = _build_cwe_parser()
+        args = p.parse_args(["CWE-79"])
+        assert args.cwe_id == "CWE-79"
+
+    def test_output_default_text(self):
+        p = _build_cwe_parser()
+        args = p.parse_args(["CWE-79"])
+        assert args.output == "text"
+
+    def test_output_json(self):
+        p = _build_cwe_parser()
+        args = p.parse_args(["CWE-79", "--output", "json"])
+        assert args.output == "json"
+
+    def test_output_invalid_choice(self):
+        p = _build_cwe_parser()
+        with pytest.raises(SystemExit):
+            p.parse_args(["CWE-79", "--output", "yaml"])
+
+    def test_missing_cwe_id_fails(self):
+        p = _build_cwe_parser()
+        with pytest.raises(SystemExit):
+            p.parse_args([])
+
+    def test_numeric_cwe_id(self):
+        p = _build_cwe_parser()
+        args = p.parse_args(["79"])
+        assert args.cwe_id == "79"
+
+    def test_help_flag(self):
+        p = _build_cwe_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            p.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# _run_cwe text output tests
+# ---------------------------------------------------------------------------
+
+
+_MOCK_SUCCESS_RESULT = {
+    "toolUseId": "cli-cwe-lookup",
+    "status": "success",
+    "content": [
+        {
+            "json": {
+                "cwe_id": "CWE-79",
+                "description": "Improper Neutralization of Input During Web Page Generation",
+                "url": "https://cwe.mitre.org/data/definitions/79.html",
+            }
+        }
+    ],
+}
+
+
+class TestRunCweTextOutput:
+    """Verify _run_cwe() text output mode."""
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_basic_text_output(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CWE-79" in out
+        assert "https://cwe.mitre.org/data/definitions/79.html" in out
+        assert "Improper Neutralization" in out
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_numeric_input_normalised(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        rc = _run_cwe(["79"])
+        assert rc == 0
+        # Verify get_cwe_details was called with CWE-79 (normalised)
+        call_args = mock_cwe.call_args[0][0]
+        assert call_args["input"]["cwe_id"] == "CWE-79"
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_lowercase_input_normalised(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        rc = _run_cwe(["cwe-79"])
+        assert rc == 0
+        call_args = mock_cwe.call_args[0][0]
+        assert call_args["input"]["cwe_id"] == "CWE-79"
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_text_output_contains_url(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79"])
+        out = capsys.readouterr().out
+        assert "URL" in out
+        assert "https://cwe.mitre.org/data/definitions/79.html" in out
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_text_output_contains_description(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79"])
+        out = capsys.readouterr().out
+        assert "Improper Neutralization" in out
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_text_output_wraps_long_description(self, mock_cwe, capsys):
+        long_desc = "A" * 200
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "cwe_id": "CWE-787",
+                        "description": long_desc,
+                        "url": "https://cwe.mitre.org/data/definitions/787.html",
+                    }
+                }
+            ],
+        }
+        rc = _run_cwe(["CWE-787"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Long text should be wrapped (multi-line)
+        lines = [line for line in out.split("\n") if "A" in line]
+        assert len(lines) > 1
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_text_output_no_description_fallback(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "cwe_id": "CWE-79",
+                        "url": "https://cwe.mitre.org/data/definitions/79.html",
+                    }
+                }
+            ],
+        }
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No description available" in out
+
+
+# ---------------------------------------------------------------------------
+# _run_cwe JSON output tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCweJsonOutput:
+    """Verify _run_cwe() JSON output mode."""
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_json_output_valid(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        rc = _run_cwe(["CWE-79", "--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["cwe_id"] == "CWE-79"
+        assert "description" in data
+        assert "url" in data
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_json_output_includes_url(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79", "--output", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert data["url"] == "https://cwe.mitre.org/data/definitions/79.html"
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_json_output_description(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79", "--output", "json"])
+        data = json.loads(capsys.readouterr().out)
+        assert "Improper Neutralization" in data["description"]
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_json_numeric_id_input(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "success",
+            "content": [
+                {
+                    "json": {
+                        "cwe_id": "CWE-787",
+                        "description": "Out-of-bounds Write",
+                        "url": "https://cwe.mitre.org/data/definitions/787.html",
+                    }
+                }
+            ],
+        }
+        rc = _run_cwe(["787", "--output", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["cwe_id"] == "CWE-787"
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_json_output_is_valid_json(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79", "--output", "json"])
+        out = capsys.readouterr().out
+        # Should not raise
+        parsed = json.loads(out)
+        assert isinstance(parsed, dict)
+
+
+# ---------------------------------------------------------------------------
+# _run_cwe error handling tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCweErrors:
+    """Verify _run_cwe() handles errors correctly."""
+
+    def test_invalid_cwe_id_non_numeric(self, capsys):
+        rc = _run_cwe(["XSS"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Invalid CWE ID" in err
+
+    def test_invalid_cwe_id_empty_string(self, capsys):
+        rc = _run_cwe(["   "])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Invalid CWE ID" in err
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_tool_returns_error(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "error",
+            "content": [{"text": "Could not find description for CWE-99999 on the page."}],
+        }
+        rc = _run_cwe(["CWE-99999"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Could not find description" in err
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_tool_network_error(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "error",
+            "content": [{"text": "Request to CWE website failed: ConnectionError"}],
+        }
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Request to CWE website failed" in err
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_tool_returns_empty_content(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "error",
+            "content": [],
+        }
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Unknown error" in err
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_tool_unexpected_exception(self, mock_cwe, capsys):
+        mock_cwe.return_value = {
+            "toolUseId": "cli-cwe-lookup",
+            "status": "error",
+            "content": [{"text": "An unexpected error occurred during CWE details fetching: timeout"}],
+        }
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "unexpected error" in err.lower() or "timeout" in err.lower()
+
+    def test_import_error_in_run(self, capsys, monkeypatch):
+        """Simulate ImportError when importing get_cwe_details module."""
+        monkeypatch.setitem(sys.modules, "manus_agent.tools.get_cwe_details", None)
+        rc = _run_cwe(["CWE-79"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "missing dependencies" in err
+
+
+# ---------------------------------------------------------------------------
+# _SUBCOMMANDS registry tests
+# ---------------------------------------------------------------------------
+
+
+class TestSubcommandsRegistry:
+    """Verify 'cwe' is in the _SUBCOMMANDS set."""
+
+    def test_cwe_in_subcommands(self):
+        assert "cwe" in _SUBCOMMANDS
+
+    def test_subcommands_is_set(self):
+        assert isinstance(_SUBCOMMANDS, set)
+
+    def test_cwe_not_duplicate_entry(self):
+        # Ensure no accidental double-registration
+        count = list(_SUBCOMMANDS).count("cwe")
+        assert count == 1
+
+
+# ---------------------------------------------------------------------------
+# main() dispatch tests
+# ---------------------------------------------------------------------------
+
+
+class TestMainDispatchCwe:
+    """Verify main() routes 'cwe' to _run_cwe."""
+
+    @patch("manus_agent.cli._run_cwe", return_value=0)
+    def test_basic_dispatch(self, mock_run, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["manus-agent", "cwe", "CWE-79"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["CWE-79"])
+
+    @patch("manus_agent.cli._run_cwe", return_value=0)
+    def test_dispatch_with_output_flag(self, mock_run, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["manus-agent", "cwe", "CWE-79", "--output", "json"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["CWE-79", "--output", "json"])
+
+    @patch("manus_agent.cli._run_cwe", return_value=0)
+    def test_dispatch_numeric_id(self, mock_run, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["manus-agent", "cwe", "787"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["787"])
+
+    @patch("manus_agent.cli._run_cwe", return_value=1)
+    def test_dispatch_nonzero_rc(self, mock_run, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["manus-agent", "cwe", "CWE-99999"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+
+    @patch("manus_agent.cli._run_cwe", return_value=0)
+    def test_dispatch_lowercase(self, mock_run, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["manus-agent", "cwe", "cwe-79"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+        mock_run.assert_called_once_with(["cwe-79"])
+
+
+# ---------------------------------------------------------------------------
+# Import path tests
+# ---------------------------------------------------------------------------
+
+
+class TestRunCweImportPath:
+    """Verify the internal import inside _run_cwe works correctly."""
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_calls_get_cwe_details_with_correct_payload(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79"])
+        mock_cwe.assert_called_once()
+        tool_use = mock_cwe.call_args[0][0]
+        assert tool_use["toolUseId"] == "cli-cwe-lookup"
+        assert tool_use["input"]["cwe_id"] == "CWE-79"
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_tool_use_id_is_string(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79"])
+        tool_use = mock_cwe.call_args[0][0]
+        assert isinstance(tool_use["toolUseId"], str)
+
+    @patch("manus_agent.tools.get_cwe_details.get_cwe_details")
+    def test_input_dict_has_cwe_id_key(self, mock_cwe, capsys):
+        mock_cwe.return_value = _MOCK_SUCCESS_RESULT
+        _run_cwe(["CWE-79"])
+        tool_use = mock_cwe.call_args[0][0]
+        assert "cwe_id" in tool_use["input"]


### PR DESCRIPTION
## Summary

Adds a `manus-agent cwe <CWE-ID>` CLI subcommand that wires up the existing `get_cwe_details` Strands tool for direct terminal use.

## What was added

- **`_build_cwe_parser()`** — argparse setup: positional `CWE-ID`, `--output {text,json}`
- **`_run_cwe(argv)`** — CLI runner with:
  - Input normalisation: accepts `CWE-79`, `cwe-79`, or plain `79`
  - Text output: formatted CWE ID, MITRE URL, wrapped description
  - JSON output: structured dict with `cwe_id`, `description`, `url`
  - Error handling: invalid input → exit 1, tool errors → exit 1, import failures → exit 1
- **`_SUBCOMMANDS` registration** + `main()` dispatch wiring
- **README.md**: TOC entry + CLI reference section between blast-radius and silent-patches
- **`tests/test_cli_cwe.py`**: 38 tests across 7 suites (parser, text output, JSON output, errors, registry, dispatch, import path)

## Usage

```bash
manus-agent cwe CWE-79
manus-agent cwe 787
manus-agent cwe CWE-89 --output json | jq .description
```

## Test results

Full suite: **1196 passed** (baseline 1158 + 38 new), 0 failures.

## Duplicate check

Checked all 50 open PRs (#51, #53, #54, #58, #60, #64, #65, #67, #74–90, #96, #98, #100, #103–123) and 30 merged PRs — no existing open or merged PR adds a `cwe` CLI subcommand. PR #89 adds *tool-level* tests for `get_cwe_details` but does not wire it to the CLI. PR #112 adds a `cvss` subcommand (different tool, different purpose).

## Mock strategy

All tests patch `manus_agent.tools.get_cwe_details.get_cwe_details` — no real HTTP calls.
