### PR TITLE
feat(cli): add manus-agent exploit-search subcommand for unified exploit database search

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [variants](#manus-agent-variants-cve-id--variant-analysis)
   - [compare](#manus-agent-compare-cve-a-cve-b--side-by-side-comparison)
   - [exploit-complexity](#manus-agent-exploit-complexity-cve-id--exploit-complexity-scorer)
+  - [exploit-search](#manus-agent-exploit-search-query--unified-exploit-database-search)
   - [poc-search](#manus-agent-poc-search-cve-id--multi-source-poc-aggregator)
   - [blast-radius](#manus-agent-blast-radius-spec--dependency-blast-radius)
   - [silent-patches](#manus-agent-silent-patches-ownerrepo--silent-patch-detector)
@@ -280,6 +281,25 @@ Outputs a `complexity_score` (1–5), a label (*trivial / low / moderate / high 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--output {text,json}` | `text` | Output format |
+
+---
+
+### `manus-agent exploit-search <QUERY>` — Unified exploit database search
+
+```bash
+manus-agent exploit-search CVE-2024-3094
+manus-agent exploit-search CVE-2024-3094 --sources exploitdb,packetstorm
+manus-agent exploit-search "apache struts" --max-results 10
+manus-agent exploit-search CVE-2024-3094 --output json | jq '.results[].exploits[]'
+```
+
+Searches both [Exploit-DB](https://www.exploit-db.com) and [Packet Storm Security](https://packetstormsecurity.com) for public exploits matching a CVE ID or keyword. Presents a unified view across both databases in a single command.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format |
+| `--sources LIST` | all | Comma-separated subset: `exploitdb,packetstorm` |
+| `--max-results N` | `5` | Maximum results per source (max: 20) |
 
 ---
 

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1054,6 +1054,7 @@ _SUBCOMMANDS = {
     "osv",
     "compare",
     "exploit-complexity",
+    "exploit-search",
     "poc-search",
     "changelog",
     "blast-radius",
@@ -1423,6 +1424,135 @@ def _run_exploit_complexity(argv: list[str]) -> int:
 # ---------------------------------------------------------------------------
 # poc-search subcommand
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# exploit-search subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_exploit_search_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent exploit-search",
+        description=(
+            "Search public exploit databases (Exploit-DB, Packet Storm Security) for\n"
+            "known exploits matching a CVE ID or keyword. Queries both sources by default\n"
+            "and presents a unified view."
+        ),
+        add_help=True,
+    )
+    p.add_argument("query", metavar="QUERY", help="CVE ID (e.g. CVE-2024-3094) or keyword to search")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    p.add_argument(
+        "--sources",
+        default="",
+        metavar="LIST",
+        help="Comma-separated sources to query (default: all). Valid: exploitdb,packetstorm",
+    )
+    p.add_argument(
+        "--max-results",
+        type=int,
+        default=5,
+        metavar="N",
+        help="Maximum results per source (default: 5, max: 20)",
+    )
+    return p
+
+
+def _run_exploit_search(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_exploit_search_parser()
+    args = parser.parse_args(argv)
+
+    query: str = args.query.strip()
+    if not query:
+        parser.error("Query must not be empty.")
+
+    max_results = min(max(args.max_results, 1), 20)
+
+    # Determine which sources to query
+    valid_sources = {"exploitdb", "packetstorm"}
+    if args.sources:
+        requested = {s.strip().lower() for s in args.sources.split(",") if s.strip()}
+        unknown = requested - valid_sources
+        if unknown:
+            parser.error(f"Unknown source(s): {', '.join(sorted(unknown))}. Valid: exploitdb, packetstorm")
+        sources = requested
+    else:
+        sources = valid_sources
+
+    results: list[dict] = []
+    errors: list[str] = []
+
+    if "exploitdb" in sources:
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        data = fetch_exploitdb(query, max_results=max_results)
+        if data.get("error"):
+            errors.append(f"Exploit-DB: {data['error']}")
+        else:
+            results.append(data)
+
+    if "packetstorm" in sources:
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        data = fetch_packetstorm(query, max_results=max_results)
+        if data.get("error"):
+            errors.append(f"Packet Storm: {data['error']}")
+        else:
+            results.append(data)
+
+    # JSON output
+    if args.output == "json":
+        output = {
+            "query": query,
+            "sources_queried": sorted(sources),
+            "results": results,
+            "errors": errors,
+        }
+        print(_json.dumps(output, indent=2))
+        return 1 if (not results and errors) else 0
+
+    # Text output
+    total_exploits = sum(len(r["exploits"]) for r in results)
+    print(f"\n{'=' * 60}")
+    print(f"  Exploit Search: {query}")
+    print(f"{'=' * 60}")
+    print(f"  Sources queried: {', '.join(sorted(sources))}")
+    print(f"  Total exploits found: {total_exploits}")
+    if errors:
+        print(f"  Errors: {len(errors)}")
+    print(f"{'=' * 60}\n")
+
+    for source_data in results:
+        source_name = source_data["source"]
+        exploits = source_data["exploits"]
+        header = f"[{source_name.upper()}]"
+        if not exploits:
+            print(f"{header} No exploits found.\n")
+            continue
+
+        print(f"{header} {len(exploits)} exploit(s):\n")
+        for i, exploit in enumerate(exploits, 1):
+            print(f"  {i}. {exploit['title']}")
+            print(f"     Link: {exploit['link']}")
+            if exploit.get("type") and exploit["type"] != "N/A":
+                print(f"     Type: {exploit['type']}")
+            print()
+
+    if errors:
+        print("ERRORS:")
+        for err in errors:
+            print(f"  ! {err}")
+        print()
+
+    return 1 if (not results and errors) else 0
 
 
 def _build_poc_search_parser() -> argparse.ArgumentParser:
@@ -2256,6 +2386,10 @@ def main() -> None:
     if first_positional == "exploit-complexity":
         idx = argv.index("exploit-complexity")
         sys.exit(_run_exploit_complexity(argv[idx + 1 :]))
+
+    if first_positional == "exploit-search":
+        idx = argv.index("exploit-search")
+        sys.exit(_run_exploit_search(argv[idx + 1 :]))
 
     if first_positional == "poc-search":
         idx = argv.index("poc-search")

--- a/src/manus_agent/tools/search_exploit_db.py
+++ b/src/manus_agent/tools/search_exploit_db.py
@@ -4,6 +4,8 @@ Custom tool for searching the Exploit-DB database for exploits.
 This module follows the Strands SDK's module-based tool specification.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import requests
@@ -32,6 +34,72 @@ TOOL_SPEC = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Reusable library function (called by both the Strands tool and the CLI)
+# ---------------------------------------------------------------------------
+
+
+def fetch_exploitdb(query: str, *, max_results: int = 5) -> dict[str, Any]:
+    """Search Exploit-DB for *query* and return structured results.
+
+    Returns a dict with keys:
+      - ``source``: always ``"exploit-db"``
+      - ``query``: the original query
+      - ``exploits``: list of dicts with ``title``, ``link``, ``type``
+      - ``error``: optional error string (only on failure)
+    """
+    base_url = "https://www.exploit-db.com/search"
+    url = f"{base_url}?q={requests.utils.quote(query)}"
+
+    try:
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+
+        html_content = response.text
+        results: list[dict[str, Any]] = []
+
+        exploit_entries = html_content.split('<tr class="stripe" data-row-id=')
+
+        for entry in exploit_entries[1:]:
+            title_start = entry.find('<a href="/exploits/')
+            if title_start == -1:
+                continue
+            title_end = entry.find("</a>", title_start)
+            if title_end == -1:
+                continue
+
+            link_start = entry.find('href="', title_start) + len('href="')
+            link_end = entry.find('"', link_start)
+
+            title = entry[title_start:title_end].split(">")[-1].strip()
+            link = "https://www.exploit-db.com" + entry[link_start:link_end].strip()
+
+            type_start = entry.find('<a href="/exploits/tags/')
+            exploit_type = "N/A"
+            if type_start != -1:
+                type_start = entry.find(">", type_start) + 1
+                type_end = entry.find("</a>", type_start)
+                if type_end != -1:
+                    exploit_type = entry[type_start:type_end].strip()
+
+            results.append({"title": title, "link": link, "type": exploit_type})
+
+            if len(results) >= max_results:
+                break
+
+        return {"source": "exploit-db", "query": query, "exploits": results}
+
+    except requests.exceptions.RequestException as exc:
+        return {"source": "exploit-db", "query": query, "exploits": [], "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        return {"source": "exploit-db", "query": query, "exploits": [], "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
 def search_exploit_db(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
@@ -46,81 +114,27 @@ def search_exploit_db(tool: ToolUse, **kwargs: Any) -> ToolResult:
         log_tool_output_size("search_exploit_db", result)
         return result
 
-    base_url = "https://www.exploit-db.com/search"
-    # Exploit-DB uses a simple GET parameter for search
-    url = f"{base_url}?q={requests.utils.quote(query)}"
+    data = fetch_exploitdb(query)
 
-    try:
-        response = requests.get(url, timeout=15)
-        response.raise_for_status()  # Raise an exception for bad status codes
-
-        html_content = response.text
-        results: list[dict[str, Any]] = []
-
-        # Basic parsing: Look for table rows that contain exploit links
-        # This is a very fragile method and depends heavily on Exploit-DB's HTML structure.
-        # A more robust solution would use BeautifulSoup.
-        exploit_entries = html_content.split('<tr class="stripe" data-row-id=')
-
-        for entry in exploit_entries[1:]:  # Skip the first split which is before the first <tr>
-            title_start = entry.find('<a href="/exploits/')
-            if title_start == -1:
-                continue
-            title_end = entry.find("</a>", title_start)
-            if title_end == -1:
-                continue
-
-            link_start = entry.find('href="', title_start) + len('href="')
-            link_end = entry.find('"', link_start)
-
-            title = entry[title_start:title_end].split(">")[-1].strip()
-            link = "https://www.exploit-db.com" + entry[link_start:link_end].strip()
-
-            # Extract type (e.g., webapps, local, remote)
-            type_start = entry.find('<a href="/exploits/tags/')
-            exploit_type = "N/A"
-            if type_start != -1:
-                type_start = entry.find(">", type_start) + 1
-                type_end = entry.find("</a>", type_start)
-                if type_end != -1:
-                    exploit_type = entry[type_start:type_end].strip()
-
-            results.append({"title": title, "link": link, "type": exploit_type})
-
-            if len(results) >= 5:  # Limit to top 5 results for brevity
-                break
-
-        if not results:
-            result = {
-                "toolUseId": tool_use_id,
-                "status": "success",
-                "content": [{"json": {"summary": f"No exploits found on Exploit-DB for '{query}'.", "exploits": []}}],
-            }
-            log_tool_output_size("search_exploit_db", result)
-            return result
-
-        summary = f"Found {len(results)} potential exploits on Exploit-DB for '{query}'."
-        result = {
-            "toolUseId": tool_use_id,
-            "status": "success",
-            "content": [{"json": {"summary": summary, "exploits": results}}],
-        }
-        log_tool_output_size("search_exploit_db", result)
-        return result
-
-    except requests.exceptions.RequestException as e:
+    if data.get("error"):
         result = {
             "toolUseId": tool_use_id,
             "status": "error",
-            "content": [{"text": f"Request to Exploit-DB failed: {e}"}],
+            "content": [{"text": f"Request to Exploit-DB failed: {data['error']}"}],
         }
         log_tool_output_size("search_exploit_db", result)
         return result
-    except Exception as e:
-        result = {
-            "toolUseId": tool_use_id,
-            "status": "error",
-            "content": [{"text": f"An unexpected error occurred during Exploit-DB search: {e}"}],
-        }
-        log_tool_output_size("search_exploit_db", result)
-        return result
+
+    exploits = data["exploits"]
+    if not exploits:
+        summary = f"No exploits found on Exploit-DB for '{query}'."
+    else:
+        summary = f"Found {len(exploits)} potential exploits on Exploit-DB for '{query}'."
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"json": {"summary": summary, "exploits": exploits}}],
+    }
+    log_tool_output_size("search_exploit_db", result)
+    return result

--- a/src/manus_agent/tools/search_packetstorm.py
+++ b/src/manus_agent/tools/search_packetstorm.py
@@ -4,6 +4,8 @@ Custom tool for searching Packet Storm Security for exploits.
 This module follows the Strands SDK's module-based tool specification.
 """
 
+from __future__ import annotations
+
 from typing import Any
 
 import requests
@@ -32,6 +34,61 @@ TOOL_SPEC = {
 }
 
 
+# ---------------------------------------------------------------------------
+# Reusable library function (called by both the Strands tool and the CLI)
+# ---------------------------------------------------------------------------
+
+
+def fetch_packetstorm(query: str, *, max_results: int = 5) -> dict[str, Any]:
+    """Search Packet Storm Security for *query* and return structured results.
+
+    Returns a dict with keys:
+      - ``source``: always ``"packetstorm"``
+      - ``query``: the original query
+      - ``exploits``: list of dicts with ``title``, ``link``
+      - ``error``: optional error string (only on failure)
+    """
+    base_url = "https://packetstormsecurity.com/search/files/"
+    url = f"{base_url}?q={requests.utils.quote(query)}"
+
+    try:
+        response = requests.get(url, timeout=15)
+        response.raise_for_status()
+
+        html_content = response.text
+        results: list[dict[str, Any]] = []
+
+        exploit_entries = html_content.split('<dl class="file">')
+
+        for entry in exploit_entries[1:]:
+            title_start = entry.find('<dt><a href="')
+            if title_start == -1:
+                continue
+
+            link_start = entry.find('">', title_start) + 2
+            link_end = entry.find("</a></dt>", link_start)
+
+            title = entry[link_start:link_end].strip()
+            link = "https://packetstormsecurity.com" + entry[title_start + len('<dt><a href="') : link_start - 2]
+
+            results.append({"title": title, "link": link})
+
+            if len(results) >= max_results:
+                break
+
+        return {"source": "packetstorm", "query": query, "exploits": results}
+
+    except requests.exceptions.RequestException as exc:
+        return {"source": "packetstorm", "query": query, "exploits": [], "error": str(exc)}
+    except Exception as exc:  # noqa: BLE001
+        return {"source": "packetstorm", "query": query, "exploits": [], "error": str(exc)}
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
 def search_packetstorm(tool: ToolUse, **kwargs: Any) -> ToolResult:
     tool_use_id = tool["toolUseId"]
     tool_input = tool["input"]
@@ -46,71 +103,27 @@ def search_packetstorm(tool: ToolUse, **kwargs: Any) -> ToolResult:
         log_tool_output_size("search_packetstorm", result)
         return result
 
-    base_url = "https://packetstormsecurity.com/search/files/"
-    url = f"{base_url}?q={requests.utils.quote(query)}"
+    data = fetch_packetstorm(query)
 
-    try:
-        response = requests.get(url, timeout=15)
-        response.raise_for_status()
-
-        html_content = response.text
-        results: list[dict[str, Any]] = []
-
-        # Basic parsing to find exploit links
-        exploit_entries = html_content.split('<dl class="file">')
-
-        for entry in exploit_entries[1:]:
-            title_start = entry.find('<dt><a href="')
-            if title_start == -1:
-                continue
-
-            link_start = entry.find('">', title_start) + 2
-            link_end = entry.find("</a></dt>", link_start)
-
-            title = entry[link_start:link_end].strip()
-            link = "https://packetstormsecurity.com" + entry[title_start + len('<dt><a href="') : link_start - 2]
-
-            results.append(
-                {
-                    "title": title,
-                    "link": link,
-                }
-            )
-
-            if len(results) >= 5:  # Limit to top 5 results
-                break
-
-        if not results:
-            result = {
-                "toolUseId": tool_use_id,
-                "status": "success",
-                "content": [{"json": {"summary": f"No exploits found on Packet Storm for '{query}'.", "exploits": []}}],
-            }
-            log_tool_output_size("search_packetstorm", result)
-            return result
-
-        summary = f"Found {len(results)} potential exploits on Packet Storm for '{query}'."
-        result = {
-            "toolUseId": tool_use_id,
-            "status": "success",
-            "content": [{"json": {"summary": summary, "exploits": results}}],
-        }
-        log_tool_output_size("search_packetstorm", result)
-        return result
-
-    except requests.exceptions.RequestException as e:
+    if data.get("error"):
         result = {
             "toolUseId": tool_use_id,
             "status": "error",
-            "content": [{"text": f"Request to Packet Storm failed: {e}"}],
+            "content": [{"text": f"Request to Packet Storm failed: {data['error']}"}],
         }
         log_tool_output_size("search_packetstorm", result)
         return result
-    except Exception as e:
-        result = {
-            "toolUseId": tool_use_id,
-            "status": "error",
-            "content": [{"text": f"An unexpected error occurred during Packet Storm search: {e}"}],
-        }
-        log_tool_output_size("search_packetstorm", result)
-        return result
+
+    exploits = data["exploits"]
+    if not exploits:
+        summary = f"No exploits found on Packet Storm for '{query}'."
+    else:
+        summary = f"Found {len(exploits)} potential exploits on Packet Storm for '{query}'."
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"json": {"summary": summary, "exploits": exploits}}],
+    }
+    log_tool_output_size("search_packetstorm", result)
+    return result

--- a/tests/test_cli_exploit_search.py
+++ b/tests/test_cli_exploit_search.py
@@ -1,0 +1,445 @@
+"""Tests for `manus-agent exploit-search` CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+import sys
+from unittest import mock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_EXPLOITDB_HTML_RESULTS = (
+    "<html><body><table>"
+    '<tr class="stripe" data-row-id="12345">'
+    '<td><a href="/exploits/12345" class=""><a href="/exploits/12345">Buffer Overflow in libfoo</a></td>'
+    '<td><a href="/exploits/tags/remote">remote</a></td>'
+    "</tr>"
+    '<tr class="stripe" data-row-id="12346">'
+    '<td><a href="/exploits/12346" class=""><a href="/exploits/12346">XSS via param injection</a></td>'
+    '<td><a href="/exploits/tags/webapps">webapps</a></td>'
+    "</tr>"
+    "</table></body></html>"
+)
+
+_PACKETSTORM_HTML_RESULTS = (
+    "<html><body>"
+    '<dl class="file">'
+    '<dt><a href="/files/180001/vuln-poc.py.txt">CVE-2024-1234 PoC</a></dt>'
+    "</dl>"
+    '<dl class="file">'
+    '<dt><a href="/files/180002/remote-exploit.rb.txt">Remote Code Execution</a></dt>'
+    "</dl>"
+    "</body></html>"
+)
+
+_EXPLOITDB_EMPTY = "<html><body><table></table></body></html>"
+_PACKETSTORM_EMPTY = "<html><body></body></html>"
+
+
+def _run_cli(argv: list[str]) -> int:
+    """Run CLI main() and return exit code."""
+    from manus_agent import cli
+
+    with mock.patch.object(sys, "argv", ["manus-agent"] + argv):
+        with pytest.raises(SystemExit) as exc_info:
+            cli.main()
+    return exc_info.value.code if isinstance(exc_info.value.code, int) else 0
+
+
+def _mock_response(text: str, status_code: int = 200):
+    """Create a mock requests.Response."""
+    resp = mock.Mock()
+    resp.text = text
+    resp.status_code = status_code
+    resp.raise_for_status = mock.Mock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# fetch_exploitdb unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchExploitdb:
+    def test_returns_results(self):
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+            data = fetch_exploitdb("CVE-2024-1234")
+
+        assert data["source"] == "exploit-db"
+        assert data["query"] == "CVE-2024-1234"
+        assert len(data["exploits"]) == 2
+        assert "error" not in data
+
+    def test_returns_empty_on_no_results(self):
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.return_value = _mock_response(_EXPLOITDB_EMPTY)
+            data = fetch_exploitdb("CVE-9999-0001")
+
+        assert data["exploits"] == []
+        assert "error" not in data
+
+    def test_returns_error_on_http_failure(self):
+        import requests
+
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.side_effect = requests.exceptions.ConnectionError("timeout")
+            data = fetch_exploitdb("CVE-2024-1234")
+
+        assert data["exploits"] == []
+        assert "error" in data
+        assert "timeout" in data["error"]
+
+    def test_max_results_limits_output(self):
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+            data = fetch_exploitdb("CVE-2024-1234", max_results=1)
+
+        assert len(data["exploits"]) == 1
+
+    def test_exploit_fields(self):
+        from manus_agent.tools.search_exploit_db import fetch_exploitdb
+
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+            data = fetch_exploitdb("CVE-2024-1234")
+
+        exploit = data["exploits"][0]
+        assert "title" in exploit
+        assert "link" in exploit
+        assert "type" in exploit
+        assert exploit["link"].startswith("https://www.exploit-db.com")
+
+
+# ---------------------------------------------------------------------------
+# fetch_packetstorm unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchPacketstorm:
+    def test_returns_results(self):
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+            data = fetch_packetstorm("CVE-2024-1234")
+
+        assert data["source"] == "packetstorm"
+        assert data["query"] == "CVE-2024-1234"
+        assert len(data["exploits"]) == 2
+        assert "error" not in data
+
+    def test_returns_empty_on_no_results(self):
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.return_value = _mock_response(_PACKETSTORM_EMPTY)
+            data = fetch_packetstorm("CVE-9999-0001")
+
+        assert data["exploits"] == []
+        assert "error" not in data
+
+    def test_returns_error_on_http_failure(self):
+        import requests
+
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.side_effect = requests.exceptions.Timeout("read timeout")
+            data = fetch_packetstorm("CVE-2024-1234")
+
+        assert data["exploits"] == []
+        assert "error" in data
+        assert "read timeout" in data["error"]
+
+    def test_max_results_limits_output(self):
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+            data = fetch_packetstorm("CVE-2024-1234", max_results=1)
+
+        assert len(data["exploits"]) == 1
+
+    def test_exploit_fields(self):
+        from manus_agent.tools.search_packetstorm import fetch_packetstorm
+
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+            data = fetch_packetstorm("CVE-2024-1234")
+
+        exploit = data["exploits"][0]
+        assert "title" in exploit
+        assert "link" in exploit
+        assert exploit["link"].startswith("https://packetstormsecurity.com")
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TestExploitSearchCLI:
+    """Tests for `manus-agent exploit-search` subcommand."""
+
+    def test_text_output_both_sources(self, capsys):
+        """exploit-search queries both sources and produces text."""
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_edb:
+            with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_ps:
+                m_edb.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+                m_ps.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+                rc = _run_cli(["exploit-search", "CVE-2024-1234"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "EXPLOIT-DB" in out
+        assert "PACKETSTORM" in out
+        assert "CVE-2024-1234" in out
+
+    def test_json_output(self, capsys):
+        """exploit-search --output json returns valid JSON."""
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_edb:
+            with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_ps:
+                m_edb.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+                m_ps.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+                rc = _run_cli(["exploit-search", "CVE-2024-1234", "--output", "json"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["query"] == "CVE-2024-1234"
+        assert "exploitdb" in data["sources_queried"]
+        assert "packetstorm" in data["sources_queried"]
+        assert len(data["results"]) == 2
+
+    def test_single_source_exploitdb(self, capsys):
+        """exploit-search --sources exploitdb queries only Exploit-DB."""
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_edb:
+            m_edb.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+            rc = _run_cli(["exploit-search", "CVE-2024-1234", "--sources", "exploitdb"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "EXPLOIT-DB" in out
+        assert "PACKETSTORM" not in out
+
+    def test_single_source_packetstorm(self, capsys):
+        """exploit-search --sources packetstorm queries only Packet Storm."""
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_ps:
+            m_ps.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+            rc = _run_cli(["exploit-search", "CVE-2024-1234", "--sources", "packetstorm"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PACKETSTORM" in out
+        assert "EXPLOIT-DB" not in out
+
+    def test_no_results_found(self, capsys):
+        """exploit-search shows 'no exploits found' message."""
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_edb:
+            with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_ps:
+                m_edb.return_value = _mock_response(_EXPLOITDB_EMPTY)
+                m_ps.return_value = _mock_response(_PACKETSTORM_EMPTY)
+                rc = _run_cli(["exploit-search", "CVE-9999-0001"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Total exploits found: 0" in out
+
+    def test_partial_failure_still_succeeds(self, capsys):
+        """If one source fails but other succeeds, exit 0."""
+        # Patch fetch_exploitdb directly to simulate a source error
+        edb_error = {"source": "exploit-db", "query": "CVE-2024-1234", "exploits": [], "error": "Connection refused"}
+        ps_ok = {
+            "source": "packetstorm",
+            "query": "CVE-2024-1234",
+            "exploits": [{"title": "Test PoC", "link": "https://packetstormsecurity.com/files/1/test.txt"}],
+        }
+
+        with mock.patch("manus_agent.tools.search_exploit_db.fetch_exploitdb", return_value=edb_error):
+            with mock.patch("manus_agent.tools.search_packetstorm.fetch_packetstorm", return_value=ps_ok):
+                rc = _run_cli(["exploit-search", "CVE-2024-1234"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PACKETSTORM" in out
+        assert "ERRORS" in out
+        assert "Exploit-DB" in out
+
+    def test_all_sources_fail_exits_1(self, capsys):
+        """If all sources fail, exit 1."""
+        edb_error = {"source": "exploit-db", "query": "CVE-2024-1234", "exploits": [], "error": "Connection refused"}
+        ps_error = {"source": "packetstorm", "query": "CVE-2024-1234", "exploits": [], "error": "Timeout"}
+
+        with mock.patch("manus_agent.tools.search_exploit_db.fetch_exploitdb", return_value=edb_error):
+            with mock.patch("manus_agent.tools.search_packetstorm.fetch_packetstorm", return_value=ps_error):
+                rc = _run_cli(["exploit-search", "CVE-2024-1234"])
+
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "ERRORS" in out
+
+    def test_invalid_source_name(self):
+        """exploit-search with unknown --sources errors out."""
+        with pytest.raises(SystemExit) as exc_info:
+            with mock.patch.object(
+                sys, "argv", ["manus-agent", "exploit-search", "CVE-2024-1234", "--sources", "badname"]
+            ):
+                from manus_agent import cli
+
+                cli.main()
+
+        assert exc_info.value.code == 2  # argparse error
+
+    def test_max_results_option(self, capsys):
+        """exploit-search --max-results limits per-source output."""
+        # Each source gets max_results=1
+        edb_one = {
+            "source": "exploit-db",
+            "query": "CVE-2024-1234",
+            "exploits": [{"title": "Exploit One", "link": "https://www.exploit-db.com/exploits/1", "type": "remote"}],
+        }
+        ps_one = {
+            "source": "packetstorm",
+            "query": "CVE-2024-1234",
+            "exploits": [{"title": "PoC One", "link": "https://packetstormsecurity.com/files/1/poc.txt"}],
+        }
+
+        with mock.patch("manus_agent.tools.search_exploit_db.fetch_exploitdb", return_value=edb_one) as m_edb:
+            with mock.patch("manus_agent.tools.search_packetstorm.fetch_packetstorm", return_value=ps_one) as m_ps:
+                rc = _run_cli(["exploit-search", "CVE-2024-1234", "--max-results", "1"])
+
+        assert rc == 0
+        # Verify max_results=1 was passed to both functions
+        m_edb.assert_called_once_with("CVE-2024-1234", max_results=1)
+        m_ps.assert_called_once_with("CVE-2024-1234", max_results=1)
+
+    def test_json_output_with_errors(self, capsys):
+        """JSON output includes errors array."""
+        edb_error = {"source": "exploit-db", "query": "CVE-2024-1234", "exploits": [], "error": "Connection refused"}
+        ps_ok = {
+            "source": "packetstorm",
+            "query": "CVE-2024-1234",
+            "exploits": [{"title": "Test PoC", "link": "https://packetstormsecurity.com/files/1/test.txt"}],
+        }
+
+        with mock.patch("manus_agent.tools.search_exploit_db.fetch_exploitdb", return_value=edb_error):
+            with mock.patch("manus_agent.tools.search_packetstorm.fetch_packetstorm", return_value=ps_ok):
+                rc = _run_cli(["exploit-search", "CVE-2024-1234", "--output", "json"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data["errors"]) == 1
+        assert "Exploit-DB" in data["errors"][0]
+        assert len(data["results"]) == 1
+
+    def test_keyword_query(self, capsys):
+        """exploit-search works with keyword queries (not just CVE IDs)."""
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_edb:
+            with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_ps:
+                m_edb.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+                m_ps.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+                rc = _run_cli(["exploit-search", "apache struts"])
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "apache struts" in out
+
+    def test_help_flag(self):
+        """exploit-search --help exits 0."""
+        with pytest.raises(SystemExit) as exc_info:
+            with mock.patch.object(sys, "argv", ["manus-agent", "exploit-search", "--help"]):
+                from manus_agent import cli
+
+                cli.main()
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Strands tool backward compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestStrandsToolCompat:
+    """Verify the Strands tool entry points still work after refactoring."""
+
+    def test_search_exploit_db_tool_success(self):
+        from manus_agent.tools.search_exploit_db import search_exploit_db
+
+        tool_use = {"toolUseId": "test-123", "input": {"query": "CVE-2024-1234"}}
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.return_value = _mock_response(_EXPLOITDB_HTML_RESULTS)
+            result = search_exploit_db(tool_use)
+
+        assert result["toolUseId"] == "test-123"
+        assert result["status"] == "success"
+        assert "exploits" in result["content"][0]["json"]
+
+    def test_search_exploit_db_tool_invalid_query(self):
+        from manus_agent.tools.search_exploit_db import search_exploit_db
+
+        tool_use = {"toolUseId": "test-456", "input": {"query": ""}}
+        result = search_exploit_db(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid query" in result["content"][0]["text"]
+
+    def test_search_exploit_db_tool_error(self):
+        import requests
+
+        from manus_agent.tools.search_exploit_db import search_exploit_db
+
+        tool_use = {"toolUseId": "test-789", "input": {"query": "CVE-2024-1234"}}
+        with mock.patch("manus_agent.tools.search_exploit_db.requests.get") as m_get:
+            m_get.side_effect = requests.exceptions.ConnectionError("refused")
+            result = search_exploit_db(tool_use)
+
+        assert result["status"] == "error"
+        assert "failed" in result["content"][0]["text"].lower()
+
+    def test_search_packetstorm_tool_success(self):
+        from manus_agent.tools.search_packetstorm import search_packetstorm
+
+        tool_use = {"toolUseId": "test-abc", "input": {"query": "CVE-2024-1234"}}
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.return_value = _mock_response(_PACKETSTORM_HTML_RESULTS)
+            result = search_packetstorm(tool_use)
+
+        assert result["toolUseId"] == "test-abc"
+        assert result["status"] == "success"
+        assert "exploits" in result["content"][0]["json"]
+
+    def test_search_packetstorm_tool_invalid_query(self):
+        from manus_agent.tools.search_packetstorm import search_packetstorm
+
+        tool_use = {"toolUseId": "test-def", "input": {"query": "   "}}
+        result = search_packetstorm(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid query" in result["content"][0]["text"]
+
+    def test_search_packetstorm_tool_error(self):
+        import requests
+
+        from manus_agent.tools.search_packetstorm import search_packetstorm
+
+        tool_use = {"toolUseId": "test-ghi", "input": {"query": "CVE-2024-1234"}}
+        with mock.patch("manus_agent.tools.search_packetstorm.requests.get") as m_get:
+            m_get.side_effect = requests.exceptions.Timeout("timeout")
+            result = search_packetstorm(tool_use)
+
+        assert result["status"] == "error"
+        assert "failed" in result["content"][0]["text"].lower()


### PR DESCRIPTION
## Summary

Adds a new `exploit-search` CLI subcommand that queries both [Exploit-DB](https://www.exploit-db.com) and [Packet Storm Security](https://packetstormsecurity.com) in a single command, presenting a unified view of public exploits for a CVE ID or keyword.

### What it does

```bash
manus-agent exploit-search CVE-2024-3094
manus-agent exploit-search CVE-2024-3094 --sources exploitdb,packetstorm
manus-agent exploit-search "apache struts" --max-results 10
manus-agent exploit-search CVE-2024-3094 --output json
```

- Queries both exploit databases by default (configurable via `--sources`)
- Supports both CVE IDs and free-text keyword queries
- `--max-results N` controls per-source limit (default: 5, max: 20)
- Graceful partial failure: if one source errors, the other still returns results (exit 0)
- Exit 1 only when ALL sources fail
- Text and JSON output formats

### Refactoring

Also refactors `search_exploit_db.py` and `search_packetstorm.py` to extract reusable library functions:
- `fetch_exploitdb(query, *, max_results=5)` → structured dict
- `fetch_packetstorm(query, *, max_results=5)` → structured dict

These functions return a clean `{"source": ..., "query": ..., "exploits": [...], "error": ...}` structure that both the Strands tool entry points and the CLI can consume. The Strands tool interfaces are fully backward-compatible.

### Tests

28 new tests in `tests/test_cli_exploit_search.py`:
- `TestFetchExploitdb` (5 tests): unit tests for the extracted library function
- `TestFetchPacketstorm` (5 tests): unit tests for the extracted library function
- `TestExploitSearchCLI` (12 tests): CLI subcommand integration tests (text/json output, source filtering, error handling, partial failure, max-results, help flag)
- `TestStrandsToolCompat` (6 tests): backward compatibility verification for the refactored Strands tool entry points

All tests are 100% mocked (no real HTTP calls). Full suite: **1186 passed**, 0 failures.

### Files changed

- `src/manus_agent/tools/search_exploit_db.py` — refactored: extracted `fetch_exploitdb()` + kept Strands tool compat
- `src/manus_agent/tools/search_packetstorm.py` — refactored: extracted `fetch_packetstorm()` + kept Strands tool compat
- `src/manus_agent/cli.py` — added `exploit-search` subcommand (+120 lines: parser, runner, `_SUBCOMMANDS`, main dispatch)
- `README.md` — added TOC entry + CLI reference section
- `tests/test_cli_exploit_search.py` — new test file (28 tests)

### Open PRs checked for overlap (none)

Checked all 48 open PRs: #51, #53, #54, #58, #60, #64, #65, #67, #74–90, #96, #98, #100, #103–126.

- PR #90 adds *tool-level tests* for `search_exploit_db` and `search_packetstorm` but no CLI subcommand
- PR #126 adds `threat-feeds` CLI (different tool)
- `poc-search` (already merged in #62) is a multi-source aggregator that *includes* Exploit-DB among 5 sources — `exploit-search` is a dedicated, standalone subcommand focused exclusively on exploit database search with per-source filtering and unified output

No existing open or merged PR provides a dedicated `exploit-search` CLI subcommand.
