### PR TITLE
feat(cli): add manus-agent advisory subcommand for GitHub Security Advisory lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [exploit-complexity](#manus-agent-exploit-complexity-cve-id--exploit-complexity-scorer)
   - [poc-search](#manus-agent-poc-search-cve-id--multi-source-poc-aggregator)
   - [blast-radius](#manus-agent-blast-radius-spec--dependency-blast-radius)
+  - [advisory](#manus-agent-advisory-cve-id--github-security-advisory)
   - [silent-patches](#manus-agent-silent-patches-ownerrepo--silent-patch-detector)
   - [cve-timeline](#manus-agent-cve-timeline-cve-id--cve-timeline)
   - [version-range](#manus-agent-version-range-cve-id--affected-version-ranges)
@@ -341,6 +342,17 @@ Blast-radius labels per package:
 |------|---------|-------------|
 | `--max-packages N` | `10` | Max affected packages to enrich |
 | `--output {text,json}` | `text` | Output format |
+
+---
+
+### `manus-agent advisory <CVE-ID>` — GitHub Security Advisory
+
+```bash
+manus-agent advisory CVE-2024-3094
+manus-agent advisory CVE-2023-44487 --output json | jq .vulnerabilities
+```
+
+Fetches the GitHub Security Advisory (GHSA) for a CVE from the public GitHub Advisory Database. Displays severity, CVSS score/vector, affected packages with vulnerable version ranges and patched versions, CWE classifications, references, and credits.
 
 ---
 

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "advisory",
 }
 
 
@@ -1935,6 +1936,167 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# advisory subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_advisory_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent advisory",
+        description=(
+            "Fetch GitHub Security Advisory (GHSA) details for a CVE.\n"
+            "Queries the public GitHub Advisory Database and displays\n"
+            "severity, affected packages, CVSS score, CWEs, and references."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _print_advisory_text(data: dict) -> None:  # noqa: C901
+    """Pretty-print a GitHub advisory to stdout."""
+    ghsa_id = data.get("ghsa_id", "N/A")
+    cve_id = data.get("cve_id", "N/A")
+    severity = data.get("severity", "unknown")
+    summary = data.get("summary", "")
+    description = data.get("description", "")
+    published = data.get("published_at", "N/A")
+    updated = data.get("updated_at", "N/A")
+    withdrawn = data.get("withdrawn_at")
+    html_url = data.get("html_url", "")
+
+    print(f"\n{'=' * 70}")
+    print(f"  GitHub Advisory: {ghsa_id}")
+    print(f"{'=' * 70}")
+    print(f"  CVE:        {cve_id}")
+    print(f"  Severity:   {severity.upper()}")
+    print(f"  Published:  {published}")
+    print(f"  Updated:    {updated}")
+    if withdrawn:
+        print(f"  Withdrawn:  {withdrawn}")
+    if html_url:
+        print(f"  URL:        {html_url}")
+    print()
+
+    # CVSS
+    cvss = data.get("cvss") or {}
+    if cvss.get("score"):
+        print(f"  CVSS Score:  {cvss['score']}")
+    if cvss.get("vector_string"):
+        print(f"  CVSS Vector: {cvss['vector_string']}")
+    if cvss:
+        print()
+
+    # CWEs
+    cwes = data.get("cwes") or []
+    if cwes:
+        cwe_strs = [f"{c.get('cwe_id', '?')} — {c.get('name', '')}" for c in cwes]
+        print("  CWEs:")
+        for c in cwe_strs:
+            print(f"    • {c}")
+        print()
+
+    # Summary + description
+    if summary:
+        print(f"  Summary:\n    {summary}")
+        print()
+    if description:
+        # Truncate very long descriptions for terminal readability
+        desc_lines = description.strip().splitlines()
+        if len(desc_lines) > 20:
+            desc_lines = desc_lines[:20] + ["    ... (truncated, use --output json for full text)"]
+        print("  Description:")
+        for line in desc_lines:
+            print(f"    {line}")
+        print()
+
+    # Affected packages (vulnerabilities)
+    vulnerabilities = data.get("vulnerabilities") or []
+    if vulnerabilities:
+        print("  Affected Packages:")
+        print(f"  {'-' * 50}")
+        for vuln in vulnerabilities:
+            pkg = vuln.get("package") or {}
+            ecosystem = pkg.get("ecosystem", "?")
+            name = pkg.get("name", "?")
+            vr = vuln.get("vulnerable_version_range", "N/A")
+            patched = vuln.get("patched_versions") or vuln.get("first_patched_version")
+            if isinstance(patched, dict):
+                patched = patched.get("identifier", "N/A")
+            if not patched:
+                patched = "(no patch available)"
+            print(f"    {ecosystem}/{name}")
+            print(f"      Vulnerable: {vr}")
+            print(f"      Patched:    {patched}")
+        print()
+
+    # References
+    references = data.get("references") or []
+    if references:
+        print("  References:")
+        for ref in references[:10]:
+            if isinstance(ref, str):
+                print(f"    • {ref}")
+            elif isinstance(ref, dict):
+                print(f"    • {ref.get('url', ref)}")
+        if len(references) > 10:
+            print(f"    ... and {len(references) - 10} more")
+        print()
+
+    # Credits
+    credits_list = data.get("credits") or []
+    if credits_list:
+        print("  Credits:")
+        for credit in credits_list[:5]:
+            login = credit.get("login", "unknown") if isinstance(credit, dict) else str(credit)
+            ctype = credit.get("type", "") if isinstance(credit, dict) else ""
+            suffix = f" ({ctype})" if ctype else ""
+            print(f"    • {login}{suffix}")
+        print()
+
+
+def _run_advisory(argv: list[str]) -> int:
+    parser = _build_advisory_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    data = fetch_github_advisory(cve_id)
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(data, indent=2))
+        return 0
+
+    # --- text output ---
+    if data.get("error"):
+        print(f"[error] {data['error']}", file=sys.stderr)
+        return 1
+
+    if not data.get("found"):
+        print(data.get("message", f"No advisory found for {cve_id}."))
+        return 0
+
+    _print_advisory_text(data)
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2430,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "advisory":
+        idx = argv.index("advisory")
+        sys.exit(_run_advisory(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_github_advisory.py
+++ b/src/manus_agent/tools/get_github_advisory.py
@@ -9,6 +9,73 @@ from strands.tools import tool
 from manus_agent.config import Config
 from manus_agent.tools.tool_output_logger import log_tool_output_size
 
+# ---------------------------------------------------------------------------
+# Reusable library function (no Strands dependency)
+# ---------------------------------------------------------------------------
+
+
+def fetch_github_advisory(cve_id: str, *, github_token: str | None = None) -> dict[str, Any]:
+    """Fetch advisory data from the GitHub Advisory Database for a CVE.
+
+    Args:
+        cve_id: CVE identifier (e.g. "CVE-2023-1234").
+        github_token: Optional GitHub personal access token. If *None*, the
+            function attempts to read from ``GITHUB_TOKEN`` env var or the
+            manus-agent config file.
+
+    Returns:
+        A dictionary with keys:
+        - On success: full advisory payload from GitHub (first match).
+        - Not found: ``{"found": False, "message": "..."}``
+        - Error: ``{"error": "..."}``
+    """
+    if not cve_id or not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
+        return {"error": "Invalid CVE ID format. It must be a string starting with 'CVE-'."}
+
+    # Resolve token
+    if github_token is None:
+        try:
+            config = Config.from_file()
+            github_token = os.environ.get("GITHUB_TOKEN") or (config.github.api_token if config.github else None)
+        except Exception:
+            github_token = os.environ.get("GITHUB_TOKEN")
+
+    url = f"https://api.github.com/advisories?cve_id={cve_id}"
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if github_token:
+        headers["Authorization"] = f"token {github_token}"
+
+    try:
+        response = requests.get(url, headers=headers, timeout=15)
+        response.raise_for_status()
+        data = response.json()
+
+        if not data:
+            return {"found": False, "message": f"No advisory found on GitHub for {cve_id}."}
+
+        # The API returns a list; return the first (most relevant) advisory
+        # plus a convenience flag.
+        advisory = data[0]
+        advisory["found"] = True
+        return advisory
+
+    except requests.exceptions.HTTPError as http_err:
+        if http_err.response.status_code == 404:
+            return {"found": False, "message": f"No advisory found on GitHub for {cve_id}."}
+        return {"error": f"HTTP error occurred while querying GitHub Advisory API: {http_err}"}
+    except requests.exceptions.RequestException as req_err:
+        return {"error": f"An error occurred while querying the GitHub Advisory API: {req_err}"}
+    except (KeyError, IndexError, ValueError):
+        return {"error": "Received an unexpected response format from the GitHub Advisory API."}
+
+
+# ---------------------------------------------------------------------------
+# Strands tool wrapper (agent-facing)
+# ---------------------------------------------------------------------------
+
 
 @tool
 def get_github_advisory(cve_id: str) -> dict[str, Any]:
@@ -23,52 +90,6 @@ def get_github_advisory(cve_id: str) -> dict[str, Any]:
     Returns:
         A dictionary containing the advisory data from GitHub if found, otherwise a message indicating it was not found or an error.
     """
-    if not cve_id or not isinstance(cve_id, str) or not cve_id.upper().startswith("CVE-"):
-        result = {"error": "Invalid CVE ID format. It must be a string starting with 'CVE-'."}
-        log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-        return result
-
-    # Use the official GitHub REST API endpoint for getting advisories by CVE ID.
-    url = f"https://api.github.com/advisories?cve_id={cve_id}"
-
-    try:
-        config = Config.from_file()
-        github_token = os.environ.get("GITHUB_TOKEN") or (config.github.api_token if config.github else None)
-    except Exception:
-        github_token = os.environ.get("GITHUB_TOKEN")
-
-    headers = {"Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
-    if github_token:
-        headers["Authorization"] = f"token {github_token}"
-
-    try:
-        response = requests.get(url, headers=headers, timeout=15)
-        response.raise_for_status()  # Raise an HTTPError for bad responses (4xx or 5xx)
-        data = response.json()
-
-        if not data:
-            result = {"message": f"No advisory found on GitHub for {cve_id}."}
-            log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-            return result
-
-        # The API returns a list of advisories; we will return the first and most relevant one.
-        result = data[0]
-        log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-        return result
-
-    except requests.exceptions.HTTPError as http_err:
-        if http_err.response.status_code == 404:
-            result = {"message": f"No advisory found on GitHub for {cve_id}."}
-            log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-            return result
-        result = {"error": f"HTTP error occurred while querying GitHub Advisory API: {http_err}"}
-        log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-        return result
-    except requests.exceptions.RequestException as req_err:
-        result = {"error": f"An error occurred while querying the GitHub Advisory API: {req_err}"}
-        log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-        return result
-    except (KeyError, IndexError, ValueError):
-        result = {"error": "Received an unexpected response format from the GitHub Advisory API."}
-        log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
-        return result
+    result = fetch_github_advisory(cve_id)
+    log_tool_output_size("get_github_advisory", {"content": [{"json": result}]})
+    return result

--- a/tests/test_cli_advisory.py
+++ b/tests/test_cli_advisory.py
@@ -1,0 +1,444 @@
+"""Tests for the `manus-agent advisory` CLI subcommand."""
+
+import json
+from unittest.mock import patch
+
+from manus_agent.cli import _run_advisory
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_ADVISORY = {
+    "found": True,
+    "ghsa_id": "GHSA-abcd-1234-efgh",
+    "cve_id": "CVE-2024-3094",
+    "severity": "critical",
+    "summary": "XZ Utils backdoor allowing remote code execution",
+    "description": "A malicious backdoor was discovered in XZ Utils versions 5.6.0 and 5.6.1.",
+    "published_at": "2024-03-29T00:00:00Z",
+    "updated_at": "2024-04-01T12:00:00Z",
+    "withdrawn_at": None,
+    "html_url": "https://github.com/advisories/GHSA-abcd-1234-efgh",
+    "cvss": {
+        "score": 10.0,
+        "vector_string": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+    },
+    "cwes": [
+        {"cwe_id": "CWE-506", "name": "Embedded Malicious Code"},
+    ],
+    "vulnerabilities": [
+        {
+            "package": {"ecosystem": "deb", "name": "xz-utils"},
+            "vulnerable_version_range": ">= 5.6.0, <= 5.6.1",
+            "patched_versions": None,
+            "first_patched_version": {"identifier": "5.6.1+really5.4.5-1"},
+        },
+    ],
+    "references": [
+        {"url": "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"},
+        {"url": "https://www.openwall.com/lists/oss-security/2024/03/29/4"},
+    ],
+    "credits": [
+        {"login": "AndresFreundTec", "type": "reporter"},
+    ],
+}
+
+NOT_FOUND_RESULT = {
+    "found": False,
+    "message": "No advisory found on GitHub for CVE-2099-99999.",
+}
+
+ERROR_RESULT = {
+    "error": "HTTP error occurred while querying GitHub Advisory API: 500 Server Error",
+}
+
+
+# ---------------------------------------------------------------------------
+# Text output tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryTextOutput:
+    """Test advisory subcommand text output."""
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_header(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "GHSA-abcd-1234-efgh" in out
+        assert "CVE-2024-3094" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_severity(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "CRITICAL" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_cvss(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "10.0" in out
+        assert "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_cwes(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "CWE-506" in out
+        assert "Embedded Malicious Code" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_affected_packages(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "deb/xz-utils" in out
+        assert ">= 5.6.0, <= 5.6.1" in out
+        assert "5.6.1+really5.4.5-1" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_references(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "nvd.nist.gov" in out
+        assert "openwall.com" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_credits(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "AndresFreundTec" in out
+        assert "reporter" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_dates(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "2024-03-29" in out
+        assert "2024-04-01" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_found_prints_url(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        _run_advisory(["CVE-2024-3094"])
+        out = capsys.readouterr().out
+        assert "https://github.com/advisories/GHSA-abcd-1234-efgh" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_not_found(self, mock_fetch, capsys):
+        mock_fetch.return_value = NOT_FOUND_RESULT
+        rc = _run_advisory(["CVE-2099-99999"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No advisory found" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_error(self, mock_fetch, capsys):
+        mock_fetch.return_value = ERROR_RESULT
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "HTTP error" in err
+
+
+# ---------------------------------------------------------------------------
+# JSON output tests
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryJsonOutput:
+    """Test advisory subcommand JSON output."""
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_json_output_valid(self, mock_fetch, capsys):
+        mock_fetch.return_value = SAMPLE_ADVISORY
+        rc = _run_advisory(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["ghsa_id"] == "GHSA-abcd-1234-efgh"
+        assert data["found"] is True
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_json_output_not_found(self, mock_fetch, capsys):
+        mock_fetch.return_value = NOT_FOUND_RESULT
+        rc = _run_advisory(["CVE-2099-99999", "--output", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["found"] is False
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_json_output_error(self, mock_fetch, capsys):
+        mock_fetch.return_value = ERROR_RESULT
+        rc = _run_advisory(["CVE-2024-3094", "--output", "json"])
+        # JSON output always returns 0 for structured output
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert "error" in data
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestAdvisoryEdgeCases:
+    """Test edge cases and unusual payloads."""
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_no_cvss(self, mock_fetch, capsys):
+        data = {**SAMPLE_ADVISORY, "cvss": None}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "GHSA-abcd-1234-efgh" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_empty_vulnerabilities(self, mock_fetch, capsys):
+        data = {**SAMPLE_ADVISORY, "vulnerabilities": []}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "GHSA-abcd-1234-efgh" in out
+        assert "Affected Packages" not in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_no_cwes(self, mock_fetch, capsys):
+        data = {**SAMPLE_ADVISORY, "cwes": []}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CWEs" not in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_withdrawn(self, mock_fetch, capsys):
+        data = {**SAMPLE_ADVISORY, "withdrawn_at": "2024-05-01T00:00:00Z"}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Withdrawn" in out
+        assert "2024-05-01" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_patched_versions_string(self, mock_fetch, capsys):
+        """Test when patched_versions is a string instead of a dict."""
+        data = {
+            **SAMPLE_ADVISORY,
+            "vulnerabilities": [
+                {
+                    "package": {"ecosystem": "npm", "name": "express"},
+                    "vulnerable_version_range": "< 4.19.2",
+                    "patched_versions": "4.19.2",
+                    "first_patched_version": None,
+                },
+            ],
+        }
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "npm/express" in out
+        assert "4.19.2" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_no_patched_version(self, mock_fetch, capsys):
+        """Test when no patched version is available."""
+        data = {
+            **SAMPLE_ADVISORY,
+            "vulnerabilities": [
+                {
+                    "package": {"ecosystem": "pip", "name": "some-pkg"},
+                    "vulnerable_version_range": "< 2.0",
+                    "patched_versions": None,
+                    "first_patched_version": None,
+                },
+            ],
+        }
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "no patch available" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_long_description_truncated(self, mock_fetch, capsys):
+        """Test that very long descriptions are truncated in text mode."""
+        long_desc = "\n".join([f"Line {i}: detail" for i in range(50)])
+        data = {**SAMPLE_ADVISORY, "description": long_desc}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "truncated" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_many_references_truncated(self, mock_fetch, capsys):
+        """References beyond 10 show a count."""
+        refs = [{"url": f"https://example.com/{i}"} for i in range(15)]
+        data = {**SAMPLE_ADVISORY, "references": refs}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "and 5 more" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_references_as_strings(self, mock_fetch, capsys):
+        """Some API responses return references as plain strings."""
+        data = {**SAMPLE_ADVISORY, "references": ["https://example.com/ref1"]}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "https://example.com/ref1" in out
+
+    @patch("manus_agent.tools.get_github_advisory.fetch_github_advisory")
+    def test_advisory_credits_as_strings(self, mock_fetch, capsys):
+        """Credits may be plain strings."""
+        data = {**SAMPLE_ADVISORY, "credits": ["researcher1", "researcher2"]}
+        mock_fetch.return_value = data
+        rc = _run_advisory(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "researcher1" in out
+
+
+# ---------------------------------------------------------------------------
+# Library function tests (fetch_github_advisory)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGithubAdvisory:
+    """Test the reusable fetch_github_advisory library function."""
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_success_returns_advisory(self, mock_config, mock_get):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = [{"ghsa_id": "GHSA-test", "cve_id": "CVE-2024-0001"}]
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert result["found"] is True
+        assert result["ghsa_id"] == "GHSA-test"
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_empty_list_returns_not_found(self, mock_config, mock_get):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = []
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert result["found"] is False
+
+    def test_invalid_cve_id(self):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        result = fetch_github_advisory("not-a-cve")
+        assert "error" in result
+        assert "Invalid CVE ID" in result["error"]
+
+    def test_empty_cve_id(self):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        result = fetch_github_advisory("")
+        assert "error" in result
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_uses_provided_token(self, mock_config, mock_get):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = [{"ghsa_id": "GHSA-test"}]
+
+        fetch_github_advisory("CVE-2024-0001", github_token="ghp_test123")
+        call_kwargs = mock_get.call_args
+        assert "token ghp_test123" in call_kwargs.kwargs.get("headers", {}).get("Authorization", "")
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_http_error_404(self, mock_config, mock_get):
+        import requests as req
+
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 404
+        http_err = req.exceptions.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_err
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert result["found"] is False
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_http_error_500(self, mock_config, mock_get):
+        import requests as req
+
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 500
+        http_err = req.exceptions.HTTPError(response=mock_response)
+        mock_response.raise_for_status.side_effect = http_err
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert "error" in result
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_connection_error(self, mock_config, mock_get):
+        import requests as req
+
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_get.side_effect = req.exceptions.ConnectionError("Network unreachable")
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert "error" in result
+        assert "Network unreachable" in result["error"]
+
+    @patch("manus_agent.tools.get_github_advisory.requests.get")
+    @patch("manus_agent.tools.get_github_advisory.Config.from_file")
+    def test_malformed_json(self, mock_config, mock_get):
+        from manus_agent.tools.get_github_advisory import fetch_github_advisory
+
+        mock_config.side_effect = Exception("no config")
+        mock_response = mock_get.return_value
+        mock_response.status_code = 200
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.side_effect = ValueError("bad json")
+
+        result = fetch_github_advisory("CVE-2024-0001")
+        assert "error" in result
+        assert "unexpected response format" in result["error"]


### PR DESCRIPTION
## Summary

Add `manus-agent advisory <CVE-ID>` CLI subcommand that fetches GitHub Security Advisory (GHSA) details for a given CVE from the public GitHub Advisory Database.

## What this PR does

1. **Refactors `get_github_advisory.py`** — extracts a reusable `fetch_github_advisory()` library function (no Strands dependency) that the CLI and the agent tool both call. The `@tool`-decorated wrapper now delegates to this function.

2. **Adds `advisory` CLI subcommand** — users can look up GHSA data from the terminal without spinning up the full agent:
   ```bash
   manus-agent advisory CVE-2024-3094
   manus-agent advisory CVE-2023-44487 --output json | jq .vulnerabilities
   ```

3. **Rich text output** displays:
   - GHSA ID, severity, published/updated/withdrawn dates
   - CVSS score and vector string
   - CWE classifications
   - Affected packages with vulnerable version ranges and patched versions
   - References (truncated at 10)
   - Credits

4. **33 new tests** (`tests/test_cli_advisory.py`) — 100% mocked, no real HTTP calls. Covers text output, JSON output, edge cases (no CVSS, no CWEs, withdrawn advisories, long descriptions, string references), and the library function directly.

5. **README updates** — TOC entry + documentation section for the new subcommand.

## Test results

```
1191 passed, 3 deselected, 3 warnings in 25.48s
```

All existing tests continue to pass. Zero failures.

## Duplicate check

Checked all 46 open PRs (#53, #54, #58, #60, #64, #65, #67, #74-90, #96, #98, #100, #103-127) and 30 most recent merged PRs. No existing open or merged PR adds an `advisory` CLI subcommand. PR #92 (merged) adds tool-level tests for `get_github_advisory` but does not touch the CLI.
