### PR TITLE
feat(tools): get_cve_timeline — CVE event timeline reconstructor + CLI subcommand (+88 tests)

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "cve-timeline",
 }
 
 
@@ -1935,6 +1936,60 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# cve-timeline subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_cve_timeline_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent cve-timeline",
+        description=(
+            "Reconstruct the full event timeline for a CVE: NVD publication, "
+            "CVSS scoring, EPSS history and spikes, CISA KEV addition, and "
+            "patch/commit dates from NVD references and GitHub advisories."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_cve_timeline(argv: list[str]) -> int:
+
+    parser = _build_cve_timeline_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.get_cve_timeline import (
+            build_timeline,
+            format_timeline_json,
+            format_timeline_text,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    result = build_timeline(args.cve_id)
+
+    if "error" in result and not result.get("events"):
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(format_timeline_json(result))
+    else:
+        print(format_timeline_text(result))
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2323,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "cve-timeline":
+        idx = argv.index("cve-timeline")
+        sys.exit(_run_cve_timeline(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_cve_timeline.py
+++ b/src/manus_agent/tools/get_cve_timeline.py
@@ -1,0 +1,600 @@
+"""
+Tool for reconstructing the full event timeline of a CVE.
+
+Given a CVE identifier, this tool gathers chronological events from multiple
+sources:
+1. NVD — publish date, last modified date, CVSS score assignment
+2. EPSS — first appearance, significant spikes
+3. CISA KEV — date added to the Known Exploited Vulnerabilities catalog
+4. Patches — commit/release dates from NVD references and GitHub advisories
+
+The result is a sorted timeline of events showing how quickly a vulnerability
+was discovered, scored, weaponised, and patched.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from datetime import datetime
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_NVD_MAX_RETRIES = int(os.environ.get("NVD_MAX_RETRIES", "3"))
+_NVD_BACKOFF_BASE = float(os.environ.get("NVD_BACKOFF_BASE", "2.0"))
+_REQUEST_TIMEOUT = int(os.environ.get("CVE_TIMELINE_TIMEOUT", "20"))
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC (Strands SDK)
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "get_cve_timeline",
+    "description": (
+        "Reconstructs the full event timeline for a CVE: NVD publication date, "
+        "CVSS score assignment, EPSS first appearance and spikes, CISA KEV addition "
+        "date, and patch/commit dates from NVD references and GitHub advisories. "
+        "Returns a chronologically sorted list of events showing how quickly the "
+        "vulnerability was discovered, scored, weaponised, and patched."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to look up (e.g., 'CVE-2021-44228').",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_with_retry(
+    url: str,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    max_retries: int = _NVD_MAX_RETRIES,
+    backoff_base: float = _NVD_BACKOFF_BASE,
+    timeout: int = _REQUEST_TIMEOUT,
+) -> requests.Response:
+    """GET with exponential back-off on 429/5xx."""
+    last_exc: Exception | None = None
+    for attempt in range(max_retries + 1):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < max_retries:
+                    time.sleep(backoff_base ** (attempt + 1))
+                    continue
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt < max_retries:
+                time.sleep(backoff_base ** (attempt + 1))
+                continue
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Data fetchers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_events(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch NVD data and extract timeline events."""
+    url = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("NVD_API_KEY", "")
+    if api_key:
+        headers["apiKey"] = api_key
+
+    try:
+        resp = _get_with_retry(url, params={"cveId": cve_id.upper()}, headers=headers)
+        data = resp.json()
+    except Exception:
+        return []
+
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return []
+
+    cve_data = vulns[0].get("cve", {})
+    events: list[dict[str, Any]] = []
+
+    # Published date
+    published = cve_data.get("published", "")
+    if published:
+        events.append(
+            {
+                "date": _parse_iso(published),
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": f"{cve_id} published in National Vulnerability Database",
+            }
+        )
+
+    # Last modified
+    last_modified = cve_data.get("lastModified", "")
+    if last_modified and last_modified != published:
+        events.append(
+            {
+                "date": _parse_iso(last_modified),
+                "source": "NVD",
+                "event": "NVD record updated",
+                "detail": "NVD entry last modified (score/description/reference change)",
+            }
+        )
+
+    # CVSS score assignment — use the earliest metric we find
+    cvss_date = published  # CVSS is assigned at publication in most cases
+    cvss_score, cvss_version = _extract_cvss(cve_data)
+    if cvss_score is not None:
+        events.append(
+            {
+                "date": _parse_iso(cvss_date),
+                "source": "NVD",
+                "event": f"CVSS {cvss_version} score assigned",
+                "detail": f"Base score: {cvss_score}",
+            }
+        )
+
+    # CISA KEV from NVD cisaExploitAdd field (present in NVD 2.0 for KEV entries)
+    cisa_add = cve_data.get("cisaExploitAdd", "")
+    if cisa_add:
+        events.append(
+            {
+                "date": _parse_iso(cisa_add),
+                "source": "CISA KEV",
+                "event": "Added to CISA KEV",
+                "detail": "Confirmed active exploitation — added to Known Exploited Vulnerabilities catalog",
+            }
+        )
+
+    # Patch references from NVD references
+    patch_events = _extract_patch_references(cve_data)
+    events.extend(patch_events)
+
+    return events
+
+
+def _extract_cvss(cve_data: dict[str, Any]) -> tuple[float | None, str]:
+    """Extract the highest-priority CVSS score (3.1 > 3.0 > 2.0)."""
+    metrics = cve_data.get("metrics", {})
+
+    for key, version in [
+        ("cvssMetricV31", "3.1"),
+        ("cvssMetricV30", "3.0"),
+        ("cvssMetricV2", "2.0"),
+    ]:
+        metric_list = metrics.get(key, [])
+        if metric_list:
+            cvss_data = metric_list[0].get("cvssData", {})
+            score = cvss_data.get("baseScore")
+            if score is not None:
+                return float(score), version
+
+    return None, ""
+
+
+def _extract_patch_references(cve_data: dict[str, Any]) -> list[dict[str, Any]]:
+    """Extract patch/commit events from NVD references."""
+    events: list[dict[str, Any]] = []
+    references = cve_data.get("references", [])
+    seen_urls: set[str] = set()
+
+    for ref in references:
+        url = ref.get("url", "")
+        tags = ref.get("tags", [])
+
+        if url in seen_urls:
+            continue
+
+        is_patch = "Patch" in tags or "patch" in tags
+        is_commit = bool(re.search(r"github\.com/.+/commit/[0-9a-f]+", url))
+        is_release = bool(re.search(r"github\.com/.+/releases/tag/", url))
+
+        if is_patch or is_commit or is_release:
+            seen_urls.add(url)
+            event_type = "Patch commit" if is_commit else "Release" if is_release else "Patch"
+            events.append(
+                {
+                    "date": None,  # NVD references don't have dates; will be enriched
+                    "source": "NVD reference",
+                    "event": f"{event_type} published",
+                    "detail": url,
+                }
+            )
+
+    return events
+
+
+def _fetch_kev_date(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch CISA KEV catalog and extract the addition date for this CVE."""
+    try:
+        resp = _get_with_retry("https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json")
+        data = resp.json()
+    except Exception:
+        return []
+
+    events: list[dict[str, Any]] = []
+    for vuln in data.get("vulnerabilities", []):
+        if vuln.get("cveID", "").upper() == cve_id.upper():
+            date_added = vuln.get("dateAdded", "")
+            if date_added:
+                events.append(
+                    {
+                        "date": _parse_iso(date_added),
+                        "source": "CISA KEV",
+                        "event": "Added to CISA KEV",
+                        "detail": (
+                            f"Vulnerability: {vuln.get('vulnerabilityName', 'N/A')}. "
+                            f"Required action: {vuln.get('requiredAction', 'N/A')}. "
+                            f"Due date: {vuln.get('dueDate', 'N/A')}."
+                        ),
+                    }
+                )
+            break
+
+    return events
+
+
+def _fetch_epss_events(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch EPSS time series and extract first appearance + spike events."""
+    try:
+        resp = _get_with_retry(
+            "https://api.first.org/data/v1/epss",
+            params={"cve": cve_id.upper(), "scope": "time-series", "limit": "365"},
+        )
+        data = resp.json()
+    except Exception:
+        return []
+
+    series = data.get("data", [])
+    if not series:
+        return []
+
+    # The API may return data under a nested structure
+    if isinstance(series, list) and len(series) > 0 and "epss" in series[0]:
+        points = series
+    elif isinstance(series, list) and len(series) > 0 and "time-series" in series[0]:
+        points = series[0].get("time-series", [])
+    else:
+        # Try alternative response format
+        points = series[0].get("time-series", []) if isinstance(series, list) and series else []
+
+    if not points:
+        return []
+
+    # Sort oldest first
+    points_sorted = sorted(points, key=lambda p: p.get("date", ""))
+    events: list[dict[str, Any]] = []
+
+    # First EPSS entry
+    first = points_sorted[0]
+    first_score = float(first.get("epss", 0))
+    events.append(
+        {
+            "date": _parse_iso(first["date"]),
+            "source": "EPSS",
+            "event": "First EPSS score",
+            "detail": f"Initial score: {first_score:.4f} ({first_score * 100:.2f}%)",
+        }
+    )
+
+    # Detect spikes (jump > 10% absolute in a single day)
+    spike_threshold = 0.10
+    prev_score = first_score
+    for pt in points_sorted[1:]:
+        score = float(pt.get("epss", 0))
+        jump = score - prev_score
+        if jump >= spike_threshold:
+            events.append(
+                {
+                    "date": _parse_iso(pt["date"]),
+                    "source": "EPSS",
+                    "event": "EPSS spike detected",
+                    "detail": f"Score jumped {prev_score:.4f} → {score:.4f} (+{jump:.4f})",
+                }
+            )
+        prev_score = score
+
+    # Current/latest score
+    latest = points_sorted[-1]
+    latest_score = float(latest.get("epss", 0))
+    if latest["date"] != first["date"]:
+        events.append(
+            {
+                "date": _parse_iso(latest["date"]),
+                "source": "EPSS",
+                "event": "Latest EPSS score",
+                "detail": f"Current score: {latest_score:.4f} ({latest_score * 100:.2f}%)",
+            }
+        )
+
+    return events
+
+
+def _fetch_github_advisory_dates(cve_id: str) -> list[dict[str, Any]]:
+    """Query GitHub Advisory Database for publish/update dates."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        resp = _get_with_retry(
+            "https://api.github.com/advisories",
+            params={"cve_id": cve_id.upper()},
+            headers=headers,
+        )
+        advisories = resp.json()
+    except Exception:
+        return []
+
+    if not isinstance(advisories, list) or not advisories:
+        return []
+
+    events: list[dict[str, Any]] = []
+    adv = advisories[0]
+
+    published_at = adv.get("published_at", "")
+    if published_at:
+        events.append(
+            {
+                "date": _parse_iso(published_at),
+                "source": "GitHub Advisory",
+                "event": "GitHub advisory published",
+                "detail": f"GHSA: {adv.get('ghsa_id', 'N/A')} — {adv.get('summary', '')[:100]}",
+            }
+        )
+
+    updated_at = adv.get("updated_at", "")
+    if updated_at and updated_at != published_at:
+        events.append(
+            {
+                "date": _parse_iso(updated_at),
+                "source": "GitHub Advisory",
+                "event": "GitHub advisory updated",
+                "detail": f"GHSA {adv.get('ghsa_id', 'N/A')} last updated",
+            }
+        )
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Date parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_iso(date_str: str) -> str:
+    """Parse various date formats to ISO 8601 date string (YYYY-MM-DD)."""
+    if not date_str:
+        return ""
+
+    # Already a simple date
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", date_str):
+        return date_str
+
+    # ISO 8601 with time component
+    for fmt in (
+        "%Y-%m-%dT%H:%M:%S.%fZ",
+        "%Y-%m-%dT%H:%M:%SZ",
+        "%Y-%m-%dT%H:%M:%S.%f",
+        "%Y-%m-%dT%H:%M:%S",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%dT%H:%M:%S.%f%z",
+    ):
+        try:
+            dt = datetime.strptime(date_str, fmt)
+            return dt.strftime("%Y-%m-%d")
+        except ValueError:
+            continue
+
+    # Last resort: take first 10 chars if they look like a date
+    if len(date_str) >= 10 and re.match(r"^\d{4}-\d{2}-\d{2}", date_str):
+        return date_str[:10]
+
+    return date_str
+
+
+# ---------------------------------------------------------------------------
+# Timeline assembly
+# ---------------------------------------------------------------------------
+
+
+def build_timeline(cve_id: str) -> dict[str, Any]:
+    """Assemble the full CVE timeline from all sources."""
+    cve_id = cve_id.strip().upper()
+
+    if not re.match(r"^CVE-\d{4}-\d{4,}$", cve_id):
+        return {"error": f"Invalid CVE ID format: {cve_id}", "events": []}
+
+    all_events: list[dict[str, Any]] = []
+
+    # Gather events from all sources
+    all_events.extend(_fetch_nvd_events(cve_id))
+    all_events.extend(_fetch_epss_events(cve_id))
+
+    # Only fetch KEV if NVD didn't already give us the date
+    has_kev = any(e.get("source") == "CISA KEV" for e in all_events)
+    if not has_kev:
+        all_events.extend(_fetch_kev_date(cve_id))
+
+    all_events.extend(_fetch_github_advisory_dates(cve_id))
+
+    # Deduplicate KEV events (NVD may give us one, and direct KEV query too)
+    kev_events = [e for e in all_events if e.get("event") == "Added to CISA KEV"]
+    if len(kev_events) > 1:
+        # Keep the one with more detail
+        best = max(kev_events, key=lambda e: len(e.get("detail", "")))
+        all_events = [e for e in all_events if e.get("event") != "Added to CISA KEV"]
+        all_events.append(best)
+
+    # Filter out events without dates and sort chronologically
+    dated_events = [e for e in all_events if e.get("date")]
+    undated_events = [e for e in all_events if not e.get("date")]
+
+    dated_events.sort(key=lambda e: e["date"])
+
+    # Compute time deltas between key events
+    summary = _compute_summary(dated_events, cve_id)
+
+    return {
+        "cve_id": cve_id,
+        "events": dated_events,
+        "undated_references": undated_events,
+        "summary": summary,
+    }
+
+
+def _compute_summary(events: list[dict[str, Any]], cve_id: str) -> dict[str, Any]:
+    """Compute key time deltas between milestone events."""
+    summary: dict[str, Any] = {"cve_id": cve_id, "total_events": len(events)}
+
+    # Find key dates
+    nvd_publish = next((e["date"] for e in events if e["event"] == "CVE published"), None)
+    kev_date = next((e["date"] for e in events if "KEV" in e.get("event", "")), None)
+    ghsa_date = next((e["date"] for e in events if "advisory published" in e.get("event", "")), None)
+    first_epss = next((e["date"] for e in events if e["event"] == "First EPSS score"), None)
+
+    summary["nvd_published"] = nvd_publish
+    summary["kev_added"] = kev_date
+    summary["ghsa_published"] = ghsa_date
+    summary["first_epss"] = first_epss
+
+    # Time from publish to KEV (days to confirmed exploitation)
+    if nvd_publish and kev_date:
+        delta = _days_between(nvd_publish, kev_date)
+        summary["days_publish_to_kev"] = delta
+
+    # Time from publish to advisory
+    if nvd_publish and ghsa_date:
+        delta = _days_between(nvd_publish, ghsa_date)
+        summary["days_publish_to_ghsa"] = delta
+
+    # Has active exploitation
+    summary["in_kev"] = kev_date is not None
+
+    # Has EPSS spikes
+    summary["epss_spikes"] = sum(1 for e in events if "spike" in e.get("event", "").lower())
+
+    return summary
+
+
+def _days_between(date1: str, date2: str) -> int:
+    """Calculate days between two YYYY-MM-DD date strings."""
+    try:
+        d1 = datetime.strptime(date1, "%Y-%m-%d")
+        d2 = datetime.strptime(date2, "%Y-%m-%d")
+        return abs((d2 - d1).days)
+    except (ValueError, TypeError):
+        return -1
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def format_timeline_text(result: dict[str, Any]) -> str:
+    """Format the timeline result as human-readable text."""
+    if "error" in result and not result.get("events"):
+        return f"Error: {result['error']}"
+
+    lines: list[str] = []
+    cve_id = result.get("cve_id", "")
+    lines.append(f"╔══ CVE Timeline: {cve_id} ══╗")
+    lines.append("")
+
+    events = result.get("events", [])
+    if not events:
+        lines.append("  No timeline events found.")
+        return "\n".join(lines)
+
+    # Group by date for cleaner display
+    current_date = ""
+    for event in events:
+        date = event.get("date", "unknown")
+        if date != current_date:
+            current_date = date
+            lines.append(f"  ┌─ {date} ─────────────────────")
+
+        source = event.get("source", "")
+        evt = event.get("event", "")
+        detail = event.get("detail", "")
+        lines.append(f"  │ [{source}] {evt}")
+        if detail:
+            lines.append(f"  │   └─ {detail}")
+
+    lines.append("  └───────────────────────────────────")
+    lines.append("")
+
+    # Summary
+    summary = result.get("summary", {})
+    lines.append("  ── Summary ──")
+    if summary.get("days_publish_to_kev") is not None:
+        days = summary["days_publish_to_kev"]
+        lines.append(f"  • CVE publish → KEV: {days} days")
+    if summary.get("days_publish_to_ghsa") is not None:
+        days = summary["days_publish_to_ghsa"]
+        lines.append(f"  • CVE publish → GitHub advisory: {days} days")
+    lines.append(f"  • In CISA KEV: {'Yes' if summary.get('in_kev') else 'No'}")
+    lines.append(f"  • EPSS spikes: {summary.get('epss_spikes', 0)}")
+    lines.append(f"  • Total events: {summary.get('total_events', 0)}")
+
+    # Undated references
+    undated = result.get("undated_references", [])
+    if undated:
+        lines.append("")
+        lines.append("  ── Patch References (undated) ──")
+        for ref in undated:
+            lines.append(f"  • {ref.get('event', '')}: {ref.get('detail', '')}")
+
+    return "\n".join(lines)
+
+
+def format_timeline_json(result: dict[str, Any]) -> str:
+    """Format the timeline result as JSON."""
+    import json
+
+    return json.dumps(result, indent=2, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool handler
+# ---------------------------------------------------------------------------
+
+
+def handler(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands SDK tool handler entry point."""
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "")
+
+    result = build_timeline(cve_id)
+    output_text = format_timeline_text(result)
+    log_tool_output_size("get_cve_timeline", output_text)
+
+    return {
+        "toolUseId": tool["toolUseId"],
+        "status": "error" if "error" in result and not result.get("events") else "success",
+        "content": [{"text": output_text}],
+    }

--- a/tests/test_cve_timeline.py
+++ b/tests/test_cve_timeline.py
@@ -1,0 +1,1064 @@
+"""Comprehensive test suite for get_cve_timeline module."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.get_cve_timeline import (
+    TOOL_SPEC,
+    _compute_summary,
+    _days_between,
+    _extract_cvss,
+    _extract_patch_references,
+    _fetch_epss_events,
+    _fetch_github_advisory_dates,
+    _fetch_kev_date,
+    _fetch_nvd_events,
+    _get_with_retry,
+    _parse_iso,
+    build_timeline,
+    format_timeline_json,
+    format_timeline_text,
+    handler,
+)
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Verify TOOL_SPEC conforms to Strands SDK expectations."""
+
+    def test_has_name(self):
+        assert TOOL_SPEC["name"] == "get_cve_timeline"
+
+    def test_has_description(self):
+        assert "timeline" in TOOL_SPEC["description"].lower()
+
+    def test_input_schema_requires_cve_id(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert "cve_id" in schema["properties"]
+        assert "cve_id" in schema["required"]
+
+    def test_cve_id_is_string(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["properties"]["cve_id"]["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# _parse_iso tests
+# ---------------------------------------------------------------------------
+
+
+class TestParseIso:
+    """Test date parsing utility."""
+
+    def test_simple_date(self):
+        assert _parse_iso("2021-12-09") == "2021-12-09"
+
+    def test_iso_with_z(self):
+        assert _parse_iso("2021-12-09T14:30:00Z") == "2021-12-09"
+
+    def test_iso_with_microseconds_z(self):
+        assert _parse_iso("2021-12-09T14:30:00.123456Z") == "2021-12-09"
+
+    def test_iso_with_timezone(self):
+        assert _parse_iso("2021-12-09T14:30:00+00:00") == "2021-12-09"
+
+    def test_iso_no_z(self):
+        assert _parse_iso("2021-12-09T14:30:00") == "2021-12-09"
+
+    def test_empty_string(self):
+        assert _parse_iso("") == ""
+
+    def test_fallback_first_10(self):
+        assert _parse_iso("2021-12-09-some-garbage") == "2021-12-09"
+
+    def test_unparseable(self):
+        result = _parse_iso("not-a-date")
+        assert result == "not-a-date"
+
+
+# ---------------------------------------------------------------------------
+# _days_between tests
+# ---------------------------------------------------------------------------
+
+
+class TestDaysBetween:
+    """Test day-counting helper."""
+
+    def test_same_date(self):
+        assert _days_between("2021-12-09", "2021-12-09") == 0
+
+    def test_one_day_forward(self):
+        assert _days_between("2021-12-09", "2021-12-10") == 1
+
+    def test_one_day_backward(self):
+        assert _days_between("2021-12-10", "2021-12-09") == 1
+
+    def test_large_delta(self):
+        assert _days_between("2021-01-01", "2021-12-31") == 364
+
+    def test_invalid_date(self):
+        assert _days_between("not-a-date", "2021-12-09") == -1
+
+    def test_none_input(self):
+        assert _days_between(None, "2021-12-09") == -1
+
+
+# ---------------------------------------------------------------------------
+# _extract_cvss tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractCvss:
+    """Test CVSS score extraction from NVD data."""
+
+    def test_cvss_v31(self):
+        cve_data = {
+            "metrics": {
+                "cvssMetricV31": [{"cvssData": {"baseScore": 10.0}}],
+            }
+        }
+        score, version = _extract_cvss(cve_data)
+        assert score == 10.0
+        assert version == "3.1"
+
+    def test_cvss_v30_fallback(self):
+        cve_data = {
+            "metrics": {
+                "cvssMetricV30": [{"cvssData": {"baseScore": 7.5}}],
+            }
+        }
+        score, version = _extract_cvss(cve_data)
+        assert score == 7.5
+        assert version == "3.0"
+
+    def test_cvss_v2_fallback(self):
+        cve_data = {
+            "metrics": {
+                "cvssMetricV2": [{"cvssData": {"baseScore": 5.0}}],
+            }
+        }
+        score, version = _extract_cvss(cve_data)
+        assert score == 5.0
+        assert version == "2.0"
+
+    def test_no_metrics(self):
+        cve_data = {"metrics": {}}
+        score, version = _extract_cvss(cve_data)
+        assert score is None
+        assert version == ""
+
+    def test_prefers_v31_over_v2(self):
+        cve_data = {
+            "metrics": {
+                "cvssMetricV31": [{"cvssData": {"baseScore": 9.8}}],
+                "cvssMetricV2": [{"cvssData": {"baseScore": 7.0}}],
+            }
+        }
+        score, version = _extract_cvss(cve_data)
+        assert score == 9.8
+        assert version == "3.1"
+
+    def test_empty_metric_list(self):
+        cve_data = {"metrics": {"cvssMetricV31": []}}
+        score, version = _extract_cvss(cve_data)
+        assert score is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_patch_references tests
+# ---------------------------------------------------------------------------
+
+
+class TestExtractPatchReferences:
+    """Test patch reference extraction from NVD references."""
+
+    def test_commit_url(self):
+        cve_data = {"references": [{"url": "https://github.com/org/repo/commit/abc123def", "tags": []}]}
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 1
+        assert events[0]["event"] == "Patch commit published"
+
+    def test_release_url(self):
+        cve_data = {"references": [{"url": "https://github.com/org/repo/releases/tag/v1.2.3", "tags": []}]}
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 1
+        assert events[0]["event"] == "Release published"
+
+    def test_patch_tag(self):
+        cve_data = {"references": [{"url": "https://example.com/fix.patch", "tags": ["Patch"]}]}
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 1
+        assert events[0]["event"] == "Patch published"
+
+    def test_deduplicates_urls(self):
+        cve_data = {
+            "references": [
+                {"url": "https://github.com/org/repo/commit/abc123", "tags": ["Patch"]},
+                {"url": "https://github.com/org/repo/commit/abc123", "tags": []},
+            ]
+        }
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 1
+
+    def test_no_patch_references(self):
+        cve_data = {"references": [{"url": "https://example.com/advisory", "tags": ["Vendor Advisory"]}]}
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 0
+
+    def test_empty_references(self):
+        cve_data = {"references": []}
+        events = _extract_patch_references(cve_data)
+        assert len(events) == 0
+
+
+# ---------------------------------------------------------------------------
+# _get_with_retry tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetWithRetry:
+    """Test HTTP retry logic."""
+
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_success_on_first_try(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = _get_with_retry("https://example.com")
+        assert result == mock_resp
+        assert mock_get.call_count == 1
+
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_retries_on_429(self, mock_get, mock_sleep):
+        mock_fail = MagicMock()
+        mock_fail.status_code = 429
+        mock_fail.raise_for_status.side_effect = Exception("429")
+
+        mock_ok = MagicMock()
+        mock_ok.status_code = 200
+        mock_ok.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [mock_fail, mock_ok]
+        result = _get_with_retry("https://example.com", max_retries=2, backoff_base=1.0)
+        assert result == mock_ok
+
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_retries_on_500(self, mock_get, mock_sleep):
+        mock_fail = MagicMock()
+        mock_fail.status_code = 500
+        mock_fail.raise_for_status.side_effect = Exception("500")
+
+        mock_ok = MagicMock()
+        mock_ok.status_code = 200
+        mock_ok.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [mock_fail, mock_ok]
+        result = _get_with_retry("https://example.com", max_retries=2, backoff_base=1.0)
+        assert result == mock_ok
+
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_raises_after_max_retries(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ConnectionError("timeout")
+
+        with pytest.raises(req.exceptions.ConnectionError):
+            _get_with_retry("https://example.com", max_retries=2, backoff_base=1.0)
+
+        assert mock_get.call_count == 3  # initial + 2 retries
+
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_passes_headers_and_params(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        _get_with_retry(
+            "https://example.com",
+            params={"key": "val"},
+            headers={"Auth": "token"},
+        )
+        mock_get.assert_called_once_with(
+            "https://example.com",
+            params={"key": "val"},
+            headers={"Auth": "token"},
+            timeout=20,
+        )
+
+
+# ---------------------------------------------------------------------------
+# _fetch_nvd_events tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdEvents:
+    """Test NVD event extraction."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_extracts_published_date(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "published": "2021-12-10T10:15:00.000Z",
+                        "lastModified": "2022-01-15T10:00:00.000Z",
+                        "metrics": {"cvssMetricV31": [{"cvssData": {"baseScore": 10.0}}]},
+                        "references": [],
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events("CVE-2021-44228")
+        event_types = [e["event"] for e in events]
+        assert "CVE published" in event_types
+        assert "NVD record updated" in event_types
+        assert "CVSS 3.1 score assigned" in event_types
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_extracts_kev_from_nvd(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "published": "2021-12-10T10:15:00.000Z",
+                        "lastModified": "2021-12-10T10:15:00.000Z",
+                        "cisaExploitAdd": "2021-12-10",
+                        "metrics": {},
+                        "references": [],
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events("CVE-2021-44228")
+        kev_events = [e for e in events if "KEV" in e["event"]]
+        assert len(kev_events) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_empty_response(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events("CVE-9999-9999")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_network_error(self, mock_get):
+        mock_get.side_effect = Exception("network error")
+        events = _fetch_nvd_events("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_no_duplicate_modified_when_same_as_published(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "published": "2021-12-10T10:15:00.000Z",
+                        "lastModified": "2021-12-10T10:15:00.000Z",
+                        "metrics": {},
+                        "references": [],
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events("CVE-2021-44228")
+        modified_events = [e for e in events if e["event"] == "NVD record updated"]
+        assert len(modified_events) == 0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_epss_events tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEpssEvents:
+    """Test EPSS event extraction."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_extracts_first_score(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"epss": "0.001", "percentile": "0.3", "date": "2022-01-01"},
+                {"epss": "0.005", "percentile": "0.5", "date": "2022-01-10"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events("CVE-2021-44228")
+        first_events = [e for e in events if e["event"] == "First EPSS score"]
+        assert len(first_events) == 1
+        assert first_events[0]["date"] == "2022-01-01"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_detects_spike(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"epss": "0.05", "percentile": "0.5", "date": "2022-01-01"},
+                {"epss": "0.20", "percentile": "0.9", "date": "2022-01-02"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events("CVE-2021-44228")
+        spike_events = [e for e in events if "spike" in e["event"].lower()]
+        assert len(spike_events) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_no_spike_below_threshold(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"epss": "0.05", "percentile": "0.5", "date": "2022-01-01"},
+                {"epss": "0.08", "percentile": "0.6", "date": "2022-01-02"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events("CVE-2021-44228")
+        spike_events = [e for e in events if "spike" in e["event"].lower()]
+        assert len(spike_events) == 0
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_empty_data(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_network_error(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        events = _fetch_epss_events("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_latest_score_event(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {"epss": "0.001", "percentile": "0.3", "date": "2022-01-01"},
+                {"epss": "0.050", "percentile": "0.8", "date": "2022-06-01"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events("CVE-2021-44228")
+        latest_events = [e for e in events if e["event"] == "Latest EPSS score"]
+        assert len(latest_events) == 1
+        assert latest_events[0]["date"] == "2022-06-01"
+
+
+# ---------------------------------------------------------------------------
+# _fetch_kev_date tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchKevDate:
+    """Test CISA KEV date fetching."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_finds_cve_in_kev(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cveID": "CVE-2021-44228",
+                    "dateAdded": "2021-12-10",
+                    "vulnerabilityName": "Apache Log4j RCE",
+                    "requiredAction": "Apply updates",
+                    "dueDate": "2021-12-24",
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_date("CVE-2021-44228")
+        assert len(events) == 1
+        assert events[0]["date"] == "2021-12-10"
+        assert "Apache Log4j" in events[0]["detail"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_cve_not_in_kev(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": [{"cveID": "CVE-2020-1234", "dateAdded": "2020-05-01"}]}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_date("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_network_error(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        events = _fetch_kev_date("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_case_insensitive_matching(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cveID": "cve-2021-44228",
+                    "dateAdded": "2021-12-10",
+                    "vulnerabilityName": "Test",
+                    "requiredAction": "Fix",
+                    "dueDate": "2022-01-01",
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_date("CVE-2021-44228")
+        assert len(events) == 1
+
+
+# ---------------------------------------------------------------------------
+# _fetch_github_advisory_dates tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGithubAdvisoryDates:
+    """Test GitHub advisory date extraction."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_extracts_published_date(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {
+                "ghsa_id": "GHSA-jfh8-c2jp-5v3q",
+                "published_at": "2021-12-10T00:00:00Z",
+                "updated_at": "2022-01-05T00:00:00Z",
+                "summary": "Remote code execution in Log4j",
+            }
+        ]
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_dates("CVE-2021-44228")
+        assert len(events) == 2
+        pub_events = [e for e in events if "published" in e["event"]]
+        assert len(pub_events) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_no_advisory_found(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_dates("CVE-9999-9999")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_handles_network_error(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        events = _fetch_github_advisory_dates("CVE-2021-44228")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_no_duplicate_update_when_same_as_publish(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {
+                "ghsa_id": "GHSA-xxxx",
+                "published_at": "2021-12-10T00:00:00Z",
+                "updated_at": "2021-12-10T00:00:00Z",
+                "summary": "Test",
+            }
+        ]
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_dates("CVE-2021-44228")
+        assert len(events) == 1  # Only published, not updated
+
+
+# ---------------------------------------------------------------------------
+# _compute_summary tests
+# ---------------------------------------------------------------------------
+
+
+class TestComputeSummary:
+    """Test summary computation."""
+
+    def test_computes_publish_to_kev_delta(self):
+        events = [
+            {"date": "2021-12-10", "event": "CVE published", "source": "NVD"},
+            {"date": "2021-12-15", "event": "Added to CISA KEV", "source": "CISA KEV"},
+        ]
+        summary = _compute_summary(events, "CVE-2021-44228")
+        assert summary["days_publish_to_kev"] == 5
+
+    def test_computes_publish_to_ghsa_delta(self):
+        events = [
+            {"date": "2021-12-10", "event": "CVE published", "source": "NVD"},
+            {"date": "2021-12-12", "event": "GitHub advisory published", "source": "GitHub"},
+        ]
+        summary = _compute_summary(events, "CVE-2021-44228")
+        assert summary["days_publish_to_ghsa"] == 2
+
+    def test_counts_epss_spikes(self):
+        events = [
+            {"date": "2022-01-01", "event": "EPSS spike detected", "source": "EPSS"},
+            {"date": "2022-02-01", "event": "EPSS spike detected", "source": "EPSS"},
+        ]
+        summary = _compute_summary(events, "CVE-2021-44228")
+        assert summary["epss_spikes"] == 2
+
+    def test_no_kev(self):
+        events = [
+            {"date": "2021-12-10", "event": "CVE published", "source": "NVD"},
+        ]
+        summary = _compute_summary(events, "CVE-2021-44228")
+        assert summary["in_kev"] is False
+        assert "days_publish_to_kev" not in summary
+
+    def test_empty_events(self):
+        summary = _compute_summary([], "CVE-2021-44228")
+        assert summary["total_events"] == 0
+        assert summary["in_kev"] is False
+
+
+# ---------------------------------------------------------------------------
+# build_timeline integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimeline:
+    """Test the main timeline assembly function."""
+
+    def test_invalid_cve_format(self):
+        result = build_timeline("not-a-cve")
+        assert "error" in result
+        assert result["events"] == []
+
+    def test_invalid_format_partial(self):
+        result = build_timeline("CVE-2021")
+        assert "error" in result
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_assembles_all_sources(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test"}]
+        mock_epss.return_value = [
+            {"date": "2022-01-01", "source": "EPSS", "event": "First EPSS score", "detail": "0.5"}
+        ]
+        mock_kev.return_value = [
+            {"date": "2021-12-15", "source": "CISA KEV", "event": "Added to CISA KEV", "detail": "test"}
+        ]
+        mock_ghsa.return_value = [
+            {"date": "2021-12-11", "source": "GitHub Advisory", "event": "GitHub advisory published", "detail": "test"}
+        ]
+
+        result = build_timeline("CVE-2021-44228")
+        assert result["cve_id"] == "CVE-2021-44228"
+        assert len(result["events"]) == 4
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_sorts_chronologically(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""}]
+        mock_epss.return_value = [{"date": "2022-06-01", "source": "EPSS", "event": "First EPSS score", "detail": ""}]
+        mock_kev.return_value = []
+        mock_ghsa.return_value = [
+            {"date": "2021-12-09", "source": "GitHub Advisory", "event": "GitHub advisory published", "detail": ""}
+        ]
+
+        result = build_timeline("CVE-2021-44228")
+        dates = [e["date"] for e in result["events"]]
+        assert dates == sorted(dates)
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_deduplicates_kev_events(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = [
+            {"date": "2021-12-15", "source": "CISA KEV", "event": "Added to CISA KEV", "detail": "short"}
+        ]
+        mock_epss.return_value = []
+        # KEV fetch should be skipped since NVD already gave us a KEV event
+        mock_kev.return_value = []
+        mock_ghsa.return_value = []
+
+        result = build_timeline("CVE-2021-44228")
+        kev_events = [e for e in result["events"] if "KEV" in e["event"]]
+        assert len(kev_events) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_undated_references_separated(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = [
+            {"date": None, "source": "NVD reference", "event": "Patch commit published", "detail": "url"},
+            {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""},
+        ]
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_ghsa.return_value = []
+
+        result = build_timeline("CVE-2021-44228")
+        assert len(result["events"]) == 1  # Only dated events
+        assert len(result["undated_references"]) == 1
+
+    def test_normalizes_cve_id_uppercase(self):
+        with (
+            patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events") as mock_nvd,
+            patch("manus_agent.tools.get_cve_timeline._fetch_epss_events") as mock_epss,
+            patch("manus_agent.tools.get_cve_timeline._fetch_kev_date") as mock_kev,
+            patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates") as mock_ghsa,
+        ):
+            mock_nvd.return_value = []
+            mock_epss.return_value = []
+            mock_kev.return_value = []
+            mock_ghsa.return_value = []
+
+            result = build_timeline("cve-2021-44228")
+            assert result["cve_id"] == "CVE-2021-44228"
+
+    def test_strips_whitespace(self):
+        with (
+            patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events") as mock_nvd,
+            patch("manus_agent.tools.get_cve_timeline._fetch_epss_events") as mock_epss,
+            patch("manus_agent.tools.get_cve_timeline._fetch_kev_date") as mock_kev,
+            patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates") as mock_ghsa,
+        ):
+            mock_nvd.return_value = []
+            mock_epss.return_value = []
+            mock_kev.return_value = []
+            mock_ghsa.return_value = []
+
+            result = build_timeline("  CVE-2021-44228  ")
+            assert result["cve_id"] == "CVE-2021-44228"
+
+
+# ---------------------------------------------------------------------------
+# format_timeline_text tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTimelineText:
+    """Test text output formatting."""
+
+    def test_formats_events(self):
+        result = {
+            "cve_id": "CVE-2021-44228",
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test detail"},
+            ],
+            "undated_references": [],
+            "summary": {"total_events": 1, "in_kev": False, "epss_spikes": 0},
+        }
+        text = format_timeline_text(result)
+        assert "CVE-2021-44228" in text
+        assert "2021-12-10" in text
+        assert "CVE published" in text
+
+    def test_formats_error(self):
+        result = {"error": "Invalid CVE ID", "events": []}
+        text = format_timeline_text(result)
+        assert "Error" in text
+
+    def test_formats_no_events(self):
+        result = {
+            "cve_id": "CVE-9999-9999",
+            "events": [],
+            "undated_references": [],
+            "summary": {"total_events": 0, "in_kev": False, "epss_spikes": 0},
+        }
+        text = format_timeline_text(result)
+        assert "No timeline events found" in text
+
+    def test_formats_kev_summary(self):
+        result = {
+            "cve_id": "CVE-2021-44228",
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""},
+                {"date": "2021-12-15", "source": "CISA KEV", "event": "Added to CISA KEV", "detail": ""},
+            ],
+            "undated_references": [],
+            "summary": {
+                "total_events": 2,
+                "in_kev": True,
+                "epss_spikes": 0,
+                "days_publish_to_kev": 5,
+            },
+        }
+        text = format_timeline_text(result)
+        assert "KEV: 5 days" in text
+        assert "In CISA KEV: Yes" in text
+
+    def test_formats_undated_references(self):
+        result = {
+            "cve_id": "CVE-2021-44228",
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""},
+            ],
+            "undated_references": [
+                {"event": "Patch commit published", "detail": "https://github.com/org/repo/commit/abc"},
+            ],
+            "summary": {"total_events": 1, "in_kev": False, "epss_spikes": 0},
+        }
+        text = format_timeline_text(result)
+        assert "Patch References (undated)" in text
+        assert "github.com" in text
+
+
+# ---------------------------------------------------------------------------
+# format_timeline_json tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTimelineJson:
+    """Test JSON output formatting."""
+
+    def test_valid_json(self):
+        result = {
+            "cve_id": "CVE-2021-44228",
+            "events": [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""}],
+            "undated_references": [],
+            "summary": {"total_events": 1},
+        }
+        json_str = format_timeline_json(result)
+        parsed = json.loads(json_str)
+        assert parsed["cve_id"] == "CVE-2021-44228"
+
+    def test_includes_all_fields(self):
+        result = {
+            "cve_id": "CVE-2021-44228",
+            "events": [],
+            "undated_references": [],
+            "summary": {},
+        }
+        json_str = format_timeline_json(result)
+        parsed = json.loads(json_str)
+        assert "events" in parsed
+        assert "summary" in parsed
+        assert "undated_references" in parsed
+
+
+# ---------------------------------------------------------------------------
+# handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestHandler:
+    """Test the Strands tool handler entry point."""
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_success_response(self, mock_build):
+        mock_build.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "events": [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""}],
+            "undated_references": [],
+            "summary": {"total_events": 1, "in_kev": False, "epss_spikes": 0},
+        }
+        tool_use = {"toolUseId": "test-123", "input": {"cve_id": "CVE-2021-44228"}}
+        result = handler(tool_use)
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-123"
+        assert len(result["content"]) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_error_response(self, mock_build):
+        mock_build.return_value = {"error": "Invalid CVE ID format: bad", "events": []}
+        tool_use = {"toolUseId": "test-456", "input": {"cve_id": "bad"}}
+        result = handler(tool_use)
+        assert result["status"] == "error"
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_calls_build_timeline_with_cve_id(self, mock_build):
+        mock_build.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "events": [],
+            "undated_references": [],
+            "summary": {"total_events": 0, "in_kev": False, "epss_spikes": 0},
+        }
+        tool_use = {"toolUseId": "test-789", "input": {"cve_id": "CVE-2021-44228"}}
+        handler(tool_use)
+        mock_build.assert_called_once_with("CVE-2021-44228")
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliSubcommand:
+    """Test the CLI dispatch for cve-timeline."""
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_text_output(self, mock_build, capsys):
+        from manus_agent.cli import _run_cve_timeline
+
+        mock_build.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "events": [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test"}],
+            "undated_references": [],
+            "summary": {"total_events": 1, "in_kev": False, "epss_spikes": 0},
+        }
+        exit_code = _run_cve_timeline(["CVE-2021-44228"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "CVE-2021-44228" in captured.out
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_json_output(self, mock_build, capsys):
+        from manus_agent.cli import _run_cve_timeline
+
+        mock_build.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "events": [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""}],
+            "undated_references": [],
+            "summary": {"total_events": 1},
+        }
+        exit_code = _run_cve_timeline(["CVE-2021-44228", "--output", "json"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["cve_id"] == "CVE-2021-44228"
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_error_returns_nonzero(self, mock_build, capsys):
+        from manus_agent.cli import _run_cve_timeline
+
+        mock_build.return_value = {"error": "Invalid CVE ID format: bad", "events": []}
+        exit_code = _run_cve_timeline(["bad"])
+        assert exit_code == 1
+
+    def test_help_flag(self, capsys):
+        from manus_agent.cli import _build_cve_timeline_parser
+
+        parser = _build_cve_timeline_parser()
+        # Just ensure it parses without error
+        args = parser.parse_args(["CVE-2021-44228"])
+        assert args.cve_id == "CVE-2021-44228"
+        assert args.output == "text"
+
+    def test_json_flag(self):
+        from manus_agent.cli import _build_cve_timeline_parser
+
+        parser = _build_cve_timeline_parser()
+        args = parser.parse_args(["CVE-2021-44228", "--output", "json"])
+        assert args.output == "json"
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    def test_cve_with_long_number(self):
+        with (
+            patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events") as mock_nvd,
+            patch("manus_agent.tools.get_cve_timeline._fetch_epss_events") as mock_epss,
+            patch("manus_agent.tools.get_cve_timeline._fetch_kev_date") as mock_kev,
+            patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates") as mock_ghsa,
+        ):
+            mock_nvd.return_value = []
+            mock_epss.return_value = []
+            mock_kev.return_value = []
+            mock_ghsa.return_value = []
+
+            result = build_timeline("CVE-2024-123456")
+            assert result["cve_id"] == "CVE-2024-123456"
+            assert "error" not in result
+
+    def test_cve_4_digit_suffix(self):
+        with (
+            patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events") as mock_nvd,
+            patch("manus_agent.tools.get_cve_timeline._fetch_epss_events") as mock_epss,
+            patch("manus_agent.tools.get_cve_timeline._fetch_kev_date") as mock_kev,
+            patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates") as mock_ghsa,
+        ):
+            mock_nvd.return_value = []
+            mock_epss.return_value = []
+            mock_kev.return_value = []
+            mock_ghsa.return_value = []
+
+            result = build_timeline("CVE-2021-1234")
+            assert "error" not in result
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_all_sources_fail_gracefully(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = []
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_ghsa.return_value = []
+
+        result = build_timeline("CVE-2021-44228")
+        assert result["events"] == []
+        assert "error" not in result
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_api_key_in_headers(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        with patch.dict("os.environ", {"NVD_API_KEY": "test-key-123"}):
+            _fetch_nvd_events("CVE-2021-44228")
+
+        call_kwargs = mock_get.call_args
+        assert call_kwargs[1]["headers"]["apiKey"] == "test-key-123"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_github_token_in_headers(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        with patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_test123"}):
+            _fetch_github_advisory_dates("CVE-2021-44228")
+
+        call_kwargs = mock_get.call_args
+        assert "Bearer ghp_test123" in call_kwargs[1]["headers"]["Authorization"]
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_dates")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_date")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_summary_present_in_result(self, mock_nvd, mock_epss, mock_kev, mock_ghsa):
+        mock_nvd.return_value = [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": ""}]
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_ghsa.return_value = []
+
+        result = build_timeline("CVE-2021-44228")
+        assert "summary" in result
+        assert result["summary"]["nvd_published"] == "2021-12-10"


### PR DESCRIPTION
## Summary

Implements the `get_cve_timeline` tool and `manus-agent cve-timeline` CLI subcommand — both documented in the README but previously unimplemented.

## What it does

Reconstructs the full event timeline for a CVE by gathering chronological events from multiple sources:

1. **NVD** — publish date, last modified date, CVSS score assignment
2. **EPSS** — first appearance date, significant spike events (>10% jump)
3. **CISA KEV** — date added to Known Exploited Vulnerabilities catalog
4. **GitHub Advisory** — advisory publish/update dates
5. **Patches** — commit/release URLs from NVD references

All events are sorted chronologically and a summary computes key time deltas (e.g., days from CVE publication to KEV addition).

## Usage

```bash
manus-agent cve-timeline CVE-2021-44228
manus-agent cve-timeline CVE-2021-44228 --output json
```

## Design

- **Zero new dependencies** — uses only `requests` (already in deps)
- **Retry/back-off** on all HTTP calls (configurable via `NVD_MAX_RETRIES`, `NVD_BACKOFF_BASE`, `CVE_TIMELINE_TIMEOUT` env vars)
- **NVD_API_KEY** and **GITHUB_TOKEN** support for higher rate limits
- **Graceful degradation** — each source fails independently; partial timelines still returned
- **Strands TOOL_SPEC interface** — fully compatible with the agent framework
- **KEV deduplication** — NVD sometimes embeds KEV dates; avoids duplicate KEV fetch
- **Rich CLI output** — date-grouped timeline with box-drawing characters + summary section

## Test coverage

88 fully mocked tests covering:
- TOOL_SPEC contract (4)
- Date parsing (8)
- Days-between helper (6)
- CVSS extraction (6)
- Patch reference extraction (6)
- HTTP retry logic (5)
- NVD event fetching (5)
- EPSS event fetching (6)
- KEV date fetching (4)
- GitHub advisory dates (4)
- Summary computation (5)
- Timeline assembly integration (8)
- Text formatting (5)
- JSON formatting (2)
- Handler entry point (3)
- CLI subcommand (5)
- Edge cases (6)

## Files changed

- `src/manus_agent/tools/get_cve_timeline.py` (new)
- `src/manus_agent/cli.py` (dispatch + parser + `_SUBCOMMANDS` set)
- `tests/test_cve_timeline.py` (new, 88 tests)

## No duplicate check

Checked all 50 open PRs (#136–#185) and 30 merged PRs — no existing open or merged PR implements `cve-timeline`. Closest related:
- #170 (cve-enrich — multi-source enrichment dump, not timeline reconstruction)
- #45 (merged, epss-trend — EPSS-only history, not full multi-source timeline)
- #149 (vendor-response — vendor patch tracking, not chronological event assembly)
