### PR TITLE
feat(tools): get_version_range — affected version range resolver + CLI subcommand (+79 tests)

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "version-range",
 }
 
 
@@ -1935,6 +1936,140 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# version-range subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_version_range_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent version-range",
+        description=(
+            "Resolve a CVE to its affected version ranges.\n"
+            "Walks NVD CPE configurations and cross-references OSV.dev\n"
+            "ecosystem data (PyPI, npm, Maven, Go, etc.) to produce\n"
+            "structured vulnerable semver ranges, affected releases,\n"
+            "and the first patched release."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--ecosystem",
+        choices=["auto", "pypi", "npm", "maven", "go", "crates.io", "rubygems", "nuget", "packagist"],
+        default="auto",
+        help="Force a specific ecosystem (default: auto)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_version_range(argv: list[str]) -> int:
+    parser = _build_version_range_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.get_version_range import fetch_version_range
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    ecosystem = args.ecosystem if args.ecosystem != "auto" else None
+    payload = fetch_version_range(cve_id, ecosystem_filter=ecosystem)
+
+    if args.output == "json":
+        print(json.dumps(payload, indent=2))
+        return 0
+
+    # --- text output ---
+    print(f"\n{payload['summary']}\n")
+
+    # NVD CPE ranges
+    nvd_ranges = payload.get("nvd_ranges", [])
+    if nvd_ranges:
+        print(f"NVD CPE Ranges ({len(nvd_ranges)}):")
+        for i, r in enumerate(nvd_ranges, 1):
+            vendor = r.get("vendor", "*")
+            product = r.get("product", "*")
+            label = f"{vendor}:{product}"
+            if r.get("inferred_ecosystem"):
+                label += f" [{r['inferred_ecosystem']}]"
+            print(f"  {i}. {label}")
+
+            if r.get("exact_version"):
+                print(f"     Version: {r['exact_version']}")
+            else:
+                start = r.get("version_start")
+                end = r.get("version_end")
+                start_type = r.get("start_type", "")
+                end_type = r.get("end_type", "")
+                if start and end:
+                    s_bracket = "[" if start_type == "including" else "("
+                    e_bracket = "]" if end_type == "including" else ")"
+                    print(f"     Range: {s_bracket}{start}, {end}{e_bracket}")
+                elif start:
+                    s_bracket = ">=" if start_type == "including" else ">"
+                    print(f"     Range: {s_bracket} {start}")
+                elif end:
+                    e_bracket = "<=" if end_type == "including" else "<"
+                    print(f"     Range: {e_bracket} {end}")
+                else:
+                    print("     Range: all versions")
+        print()
+
+    # OSV packages
+    osv_packages = payload.get("osv_packages", [])
+    if osv_packages:
+        print(f"OSV.dev Packages ({len(osv_packages)}):")
+        for i, pkg in enumerate(osv_packages, 1):
+            eco = pkg.get("ecosystem", "unknown")
+            name = pkg.get("package", "unknown")
+            print(f"  {i}. {eco}/{name}")
+
+            if pkg.get("first_patched"):
+                print(f"     First patched: {pkg['first_patched']}")
+            if pkg.get("all_patched_versions") and len(pkg["all_patched_versions"]) > 1:
+                print(f"     All fixed: {', '.join(pkg['all_patched_versions'])}")
+
+            for rng in pkg.get("ranges", []):
+                introduced = rng.get("introduced", [])
+                fixed = rng.get("fixed", [])
+                last_aff = rng.get("last_affected", [])
+                if introduced:
+                    print(f"     Introduced: {', '.join(introduced)}")
+                if fixed:
+                    print(f"     Fixed: {', '.join(fixed)}")
+                if last_aff:
+                    print(f"     Last affected: {', '.join(last_aff)}")
+
+            if pkg.get("affected_versions"):
+                count = pkg.get("affected_version_count", len(pkg["affected_versions"]))
+                sample = pkg["affected_versions"][:5]
+                suffix = f" (showing 5 of {count})" if count > 5 else ""
+                print(f"     Affected versions{suffix}: {', '.join(sample)}")
+        print()
+
+    # First patched summary
+    if payload.get("first_patched"):
+        print(f"First patched version: {payload['first_patched']}")
+
+    if not nvd_ranges and not osv_packages:
+        if payload.get("nvd_error"):
+            print(f"NVD: {payload['nvd_error']}")
+        if payload.get("osv_error"):
+            print(f"OSV: {payload['osv_error']}")
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2403,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "version-range":
+        idx = argv.index("version-range")
+        sys.exit(_run_version_range(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_version_range.py
+++ b/src/manus_agent/tools/get_version_range.py
@@ -1,0 +1,517 @@
+#!/usr/bin/env python3
+"""
+Tool for resolving a CVE to its affected version ranges.
+
+Walks NVD CPE configurations and cross-references OSV.dev ecosystem data
+(PyPI, npm, Maven, Go, RustSec, etc.) to produce structured vulnerable
+version ranges, affected releases, and first-patched versions.
+
+Strategy:
+1. Query NVD for CPE match criteria (versionStart/versionEnd ranges).
+2. Query OSV.dev for ecosystem-specific affected packages with precise
+   introduced/fixed version events.
+3. Merge and deduplicate, optionally filtering by ecosystem.
+
+Both APIs are public; NVD_API_KEY is optional (higher rate limit).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Retry / back-off configuration
+# ---------------------------------------------------------------------------
+_MAX_RETRIES: int = int(os.environ.get("VERSION_RANGE_MAX_RETRIES", "3"))
+_RETRY_BASE_DELAY: float = float(os.environ.get("VERSION_RANGE_RETRY_BASE_DELAY", "2.0"))
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+_HTTP_TIMEOUT: int = 15
+
+# ---------------------------------------------------------------------------
+# NVD API
+# ---------------------------------------------------------------------------
+_NVD_CVE_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+
+
+def _build_nvd_headers() -> dict[str, str]:
+    """Return NVD request headers, injecting NVD_API_KEY when available."""
+    headers: dict[str, str] = {"Accept": "application/json"}
+    api_key = os.environ.get("NVD_API_KEY", "").strip()
+    if api_key:
+        headers["apiKey"] = api_key
+    return headers
+
+
+def _http_get_with_retry(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    timeout: int = _HTTP_TIMEOUT,
+) -> requests.Response:
+    """GET with exponential back-off on transient errors."""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.get(url, headers=headers or {}, timeout=timeout)
+            if resp.status_code in _RETRYABLE_STATUSES and attempt < _MAX_RETRIES - 1:
+                time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            return resp
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as exc:
+            last_exc = exc
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+                continue
+            raise
+    if last_exc is not None:
+        raise last_exc
+    raise RuntimeError("HTTP request failed without a specific exception")
+
+
+# ---------------------------------------------------------------------------
+# NVD CPE configuration parsing
+# ---------------------------------------------------------------------------
+def _parse_cpe_uri(cpe23_uri: str) -> dict[str, str]:
+    """Parse a CPE 2.3 URI into its component parts.
+
+    Format: cpe:2.3:part:vendor:product:version:update:edition:language:...
+    """
+    parts = cpe23_uri.split(":")
+    if len(parts) < 6:
+        return {"raw": cpe23_uri}
+    return {
+        "part": parts[2] if len(parts) > 2 else "*",
+        "vendor": parts[3] if len(parts) > 3 else "*",
+        "product": parts[4] if len(parts) > 4 else "*",
+        "version": parts[5] if len(parts) > 5 else "*",
+        "update": parts[6] if len(parts) > 6 else "*",
+    }
+
+
+def _extract_cpe_ranges(configurations: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Extract version ranges from NVD CPE configurations.
+
+    NVD configurations contain nested nodes with cpeMatch criteria that
+    specify versionStartIncluding/Excluding and versionEndIncluding/Excluding.
+    """
+    ranges: list[dict[str, Any]] = []
+
+    def _process_nodes(nodes: list[dict[str, Any]]) -> None:
+        for node in nodes:
+            for match in node.get("cpeMatch", []):
+                if not match.get("vulnerable", False):
+                    continue
+
+                cpe_uri = match.get("criteria", "")
+                parsed = _parse_cpe_uri(cpe_uri)
+
+                range_entry: dict[str, Any] = {
+                    "vendor": parsed.get("vendor", "*"),
+                    "product": parsed.get("product", "*"),
+                    "cpe": cpe_uri,
+                }
+
+                # Extract version constraints
+                if match.get("versionStartIncluding"):
+                    range_entry["version_start"] = match["versionStartIncluding"]
+                    range_entry["start_type"] = "including"
+                elif match.get("versionStartExcluding"):
+                    range_entry["version_start"] = match["versionStartExcluding"]
+                    range_entry["start_type"] = "excluding"
+
+                if match.get("versionEndIncluding"):
+                    range_entry["version_end"] = match["versionEndIncluding"]
+                    range_entry["end_type"] = "including"
+                elif match.get("versionEndExcluding"):
+                    range_entry["version_end"] = match["versionEndExcluding"]
+                    range_entry["end_type"] = "excluding"
+
+                # If the CPE has a specific version (not '*'), it's a single version match
+                if parsed.get("version") and parsed["version"] != "*":
+                    range_entry["exact_version"] = parsed["version"]
+
+                ranges.append(range_entry)
+
+            # Recurse into child nodes
+            if node.get("nodes"):
+                _process_nodes(node["nodes"])
+
+    _process_nodes(configurations)
+    return ranges
+
+
+def fetch_nvd_cpe_ranges(cve_id: str) -> dict[str, Any]:
+    """Fetch NVD CPE configurations and extract version ranges.
+
+    Returns a dict with keys: success (bool), cpe_ranges (list),
+    error (str | None).
+    """
+    url = f"{_NVD_CVE_URL}?cveId={cve_id.upper()}"
+    headers = _build_nvd_headers()
+
+    try:
+        resp = _http_get_with_retry(url, headers=headers)
+    except Exception as exc:
+        return {"success": False, "cpe_ranges": [], "error": f"NVD request failed: {exc}"}
+
+    if resp.status_code == 404:
+        return {"success": False, "cpe_ranges": [], "error": f"No NVD record for {cve_id}"}
+
+    try:
+        resp.raise_for_status()
+        data = resp.json()
+    except (requests.exceptions.HTTPError, ValueError) as exc:
+        return {"success": False, "cpe_ranges": [], "error": f"NVD response error: {exc}"}
+
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return {"success": False, "cpe_ranges": [], "error": f"No vulnerability data for {cve_id}"}
+
+    cve_item = vulns[0].get("cve", {})
+    configurations = cve_item.get("configurations", [])
+
+    cpe_ranges = _extract_cpe_ranges(configurations)
+
+    return {"success": True, "cpe_ranges": cpe_ranges, "error": None}
+
+
+# ---------------------------------------------------------------------------
+# OSV.dev version range fetching
+# ---------------------------------------------------------------------------
+_OSV_VULN_URL = "https://api.osv.dev/v1/vulns/{osv_id}"
+_OSV_MAX_ALIAS_FOLLOWS = 8
+
+
+def _fetch_osv_record(osv_id: str) -> dict[str, Any] | None:
+    """Fetch a single OSV record. Returns None on 404 or failure."""
+    url = _OSV_VULN_URL.format(osv_id=osv_id)
+    try:
+        resp = _http_get_with_retry(url, headers={"Accept": "application/json"})
+        if resp.status_code == 200:
+            return resp.json()
+    except Exception:
+        pass
+    return None
+
+
+def _parse_osv_affected(affected: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Parse OSV affected entries into structured version range data."""
+    packages: list[dict[str, Any]] = []
+    for entry in affected or []:
+        if not isinstance(entry, dict):
+            continue
+        pkg = entry.get("package") or {}
+        ecosystem = pkg.get("ecosystem") if isinstance(pkg, dict) else None
+        name = pkg.get("name") if isinstance(pkg, dict) else None
+        if ecosystem is None and name is None:
+            continue
+
+        ranges_data: list[dict[str, Any]] = []
+        for rng in entry.get("ranges", []) or []:
+            if not isinstance(rng, dict):
+                continue
+            range_type = rng.get("type", "ECOSYSTEM")
+            events = rng.get("events", []) or []
+
+            introduced: list[str] = []
+            fixed: list[str] = []
+            last_affected: list[str] = []
+            limit: list[str] = []
+
+            for ev in events:
+                if not isinstance(ev, dict):
+                    continue
+                if "introduced" in ev:
+                    introduced.append(str(ev["introduced"]))
+                if "fixed" in ev:
+                    fixed.append(str(ev["fixed"]))
+                if "last_affected" in ev:
+                    last_affected.append(str(ev["last_affected"]))
+                if "limit" in ev:
+                    limit.append(str(ev["limit"]))
+
+            ranges_data.append(
+                {
+                    "type": range_type,
+                    "introduced": introduced,
+                    "fixed": fixed,
+                    "last_affected": last_affected,
+                    "limit": limit,
+                }
+            )
+
+        versions = [str(v) for v in (entry.get("versions", []) or []) if v is not None]
+
+        # Derive first_patched from the fixed events
+        all_fixed = []
+        for r in ranges_data:
+            all_fixed.extend(r["fixed"])
+
+        packages.append(
+            {
+                "ecosystem": ecosystem,
+                "package": name,
+                "ranges": ranges_data,
+                "first_patched": all_fixed[0] if all_fixed else None,
+                "all_patched_versions": all_fixed,
+                "affected_version_count": len(versions),
+                "affected_versions": versions[:20],  # Cap for output size
+            }
+        )
+    return packages
+
+
+def fetch_osv_version_ranges(cve_id: str) -> dict[str, Any]:
+    """Fetch OSV.dev version ranges for a CVE.
+
+    Follows GHSA aliases when the primary CVE record lacks per-package data.
+    Returns a dict with: success (bool), packages (list), error (str | None).
+    """
+    record = _fetch_osv_record(cve_id)
+    if record is None:
+        return {"success": False, "packages": [], "error": f"No OSV record for {cve_id}"}
+
+    packages = _parse_osv_affected(record.get("affected", []))
+    seen_ids: set[str] = {record.get("id", "")}
+
+    # If no packages found, follow GHSA aliases
+    if not packages:
+        aliases = record.get("aliases", []) or []
+        ghsa_aliases = [a for a in aliases if isinstance(a, str) and a.startswith("GHSA-")]
+        for alias in ghsa_aliases[:_OSV_MAX_ALIAS_FOLLOWS]:
+            if alias in seen_ids:
+                continue
+            alias_record = _fetch_osv_record(alias)
+            if alias_record:
+                seen_ids.add(alias_record.get("id", ""))
+                alias_pkgs = _parse_osv_affected(alias_record.get("affected", []))
+                packages.extend(alias_pkgs)
+
+    return {"success": True, "packages": packages, "error": None}
+
+
+# ---------------------------------------------------------------------------
+# Ecosystem mapping: CPE vendor/product → ecosystem
+# ---------------------------------------------------------------------------
+_CPE_TO_ECOSYSTEM: dict[str, str] = {
+    "python": "PyPI",
+    "pip": "PyPI",
+    "pypi": "PyPI",
+    "django": "PyPI",
+    "flask": "PyPI",
+    "numpy": "PyPI",
+    "pandas": "PyPI",
+    "requests": "PyPI",
+    "node.js": "npm",
+    "nodejs": "npm",
+    "node": "npm",
+    "npm": "npm",
+    "express": "npm",
+    "lodash": "npm",
+    "webpack": "npm",
+    "react": "npm",
+    "maven": "Maven",
+    "apache": "Maven",
+    "spring": "Maven",
+    "log4j": "Maven",
+    "jackson": "Maven",
+    "go": "Go",
+    "golang": "Go",
+    "rust": "crates.io",
+    "cargo": "crates.io",
+    "rubygems": "RubyGems",
+    "ruby": "RubyGems",
+    "nuget": "NuGet",
+    ".net": "NuGet",
+    "dotnet": "NuGet",
+    "packagist": "Packagist",
+    "php": "Packagist",
+    "composer": "Packagist",
+    "linux": "Linux",
+    "kernel": "Linux",
+}
+
+
+def _infer_ecosystem_from_cpe(vendor: str, product: str) -> str | None:
+    """Attempt to infer ecosystem from CPE vendor/product names."""
+    for token in (vendor.lower(), product.lower()):
+        if token in _CPE_TO_ECOSYSTEM:
+            return _CPE_TO_ECOSYSTEM[token]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Core logic: merge NVD + OSV data
+# ---------------------------------------------------------------------------
+def fetch_version_range(cve_id: str, ecosystem_filter: str | None = None) -> dict[str, Any]:
+    """Resolve a CVE to its affected version ranges from NVD + OSV.
+
+    Args:
+        cve_id: CVE identifier (e.g., CVE-2021-44228).
+        ecosystem_filter: Optional ecosystem to restrict results to.
+            Accepted values: auto (default), pypi, npm, maven, go, crates.io,
+            rubygems, nuget, packagist, or any OSV ecosystem string.
+
+    Returns a comprehensive dict with:
+        - cve_id: normalised CVE identifier
+        - nvd_ranges: CPE-based version ranges from NVD
+        - osv_packages: ecosystem-specific packages from OSV.dev
+        - summary: human-readable summary
+        - first_patched: first patched version (from OSV, if available)
+    """
+    cve_id = (cve_id or "").strip().upper()
+    if not cve_id or not cve_id.startswith("CVE-"):
+        return {
+            "cve_id": cve_id,
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "summary": "Invalid CVE ID. Must match CVE-YYYY-NNNN format.",
+            "error": "Invalid CVE ID format.",
+        }
+
+    # Normalise ecosystem filter
+    eco_filter: str | None = None
+    if ecosystem_filter and ecosystem_filter.lower() != "auto":
+        eco_filter = ecosystem_filter
+
+    # 1. Fetch NVD CPE ranges
+    nvd_result = fetch_nvd_cpe_ranges(cve_id)
+    nvd_ranges = nvd_result.get("cpe_ranges", [])
+
+    # 2. Fetch OSV.dev ecosystem-level version ranges
+    osv_result = fetch_osv_version_ranges(cve_id)
+    osv_packages = osv_result.get("packages", [])
+
+    # 3. Apply ecosystem filter
+    if eco_filter:
+        eco_lower = eco_filter.lower()
+        osv_packages = [p for p in osv_packages if p.get("ecosystem", "").lower() == eco_lower]
+        nvd_ranges = [
+            r
+            for r in nvd_ranges
+            if _infer_ecosystem_from_cpe(r.get("vendor", ""), r.get("product", "")) is None
+            or (_infer_ecosystem_from_cpe(r.get("vendor", ""), r.get("product", "")) or "").lower() == eco_lower
+        ]
+
+    # 4. Enrich NVD ranges with inferred ecosystems
+    for r in nvd_ranges:
+        inferred = _infer_ecosystem_from_cpe(r.get("vendor", ""), r.get("product", ""))
+        if inferred:
+            r["inferred_ecosystem"] = inferred
+
+    # 5. Derive first_patched from OSV data
+    first_patched: str | None = None
+    for pkg in osv_packages:
+        if pkg.get("first_patched"):
+            first_patched = pkg["first_patched"]
+            break
+
+    # 6. Build summary
+    total_nvd = len(nvd_ranges)
+    total_osv = len(osv_packages)
+    ecosystems = sorted({p["ecosystem"] for p in osv_packages if p.get("ecosystem")})
+
+    parts: list[str] = []
+    if total_nvd:
+        parts.append(f"{total_nvd} NVD CPE range(s)")
+    if total_osv:
+        eco_str = ", ".join(ecosystems) if ecosystems else "unknown"
+        parts.append(f"{total_osv} OSV package(s) [{eco_str}]")
+    if first_patched:
+        parts.append(f"first patched: {first_patched}")
+
+    if parts:
+        summary = f"{cve_id}: {'; '.join(parts)}."
+    elif nvd_result.get("error") and osv_result.get("error"):
+        summary = f"{cve_id}: No version range data available (NVD: {nvd_result['error']}; OSV: {osv_result['error']})."
+    elif not total_nvd and not total_osv:
+        summary = f"{cve_id}: No affected version ranges found in NVD or OSV.dev."
+    else:
+        summary = f"{cve_id}: Version range lookup completed."
+
+    return {
+        "cve_id": cve_id,
+        "nvd_ranges": nvd_ranges,
+        "osv_packages": osv_packages,
+        "ecosystems": ecosystems,
+        "first_patched": first_patched,
+        "summary": summary,
+        "nvd_error": nvd_result.get("error"),
+        "osv_error": osv_result.get("error"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC (Strands SDK)
+# ---------------------------------------------------------------------------
+TOOL_SPEC = {
+    "name": "get_version_range",
+    "description": (
+        "Resolves a CVE to its affected version ranges by combining NVD CPE "
+        "configurations (versionStart/End ranges) with OSV.dev ecosystem-specific "
+        "package data (introduced/fixed version events). Returns structured vulnerable "
+        "ranges, the list of affected ecosystems, and the first-patched version. "
+        "Use this to answer 'what versions are vulnerable to this CVE and what "
+        "version fixes it?'. Optionally filter by ecosystem (pypi, npm, maven, go)."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier (e.g., 'CVE-2021-44228').",
+                },
+                "ecosystem": {
+                    "type": "string",
+                    "description": (
+                        "Optional ecosystem filter: auto (default), pypi, npm, maven, go, "
+                        "crates.io, rubygems, nuget, packagist."
+                    ),
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+def get_version_range(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands tool handler for get_version_range."""
+    import json
+
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool.get("input", {}) or {}
+    cve_id = tool_input.get("cve_id")
+    ecosystem = tool_input.get("ecosystem")
+
+    if not isinstance(cve_id, str) or not cve_id.strip():
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID. Must be a non-empty string."}],
+        }
+        log_tool_output_size("get_version_range", result)
+        return result
+
+    payload = fetch_version_range(cve_id, ecosystem_filter=ecosystem)
+    has_data = bool(payload.get("nvd_ranges") or payload.get("osv_packages"))
+    status = "success" if has_data else "error"
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": status,
+        "content": [{"text": json.dumps(payload, indent=2)}],
+    }
+    log_tool_output_size("get_version_range", result)
+    return result

--- a/tests/test_version_range.py
+++ b/tests/test_version_range.py
@@ -1,0 +1,1337 @@
+"""Comprehensive test suite for get_version_range module.
+
+Tests cover:
+- TOOL_SPEC contract validation
+- Input validation and edge cases
+- NVD CPE configuration parsing
+- OSV.dev version range parsing
+- Ecosystem filtering
+- CPE-to-ecosystem inference
+- Merged NVD + OSV output
+- CLI subcommand dispatch
+- Retry/back-off behaviour
+- Error handling and graceful degradation
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.get_version_range import (
+    _CPE_TO_ECOSYSTEM,
+    TOOL_SPEC,
+    _extract_cpe_ranges,
+    _fetch_osv_record,
+    _http_get_with_retry,
+    _infer_ecosystem_from_cpe,
+    _parse_cpe_uri,
+    _parse_osv_affected,
+    fetch_nvd_cpe_ranges,
+    fetch_osv_version_ranges,
+    fetch_version_range,
+    get_version_range,
+)
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def mock_nvd_response_log4j():
+    """NVD CVE-2021-44228 (Log4Shell) CPE configurations."""
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": "CVE-2021-44228",
+                    "configurations": [
+                        {
+                            "nodes": [
+                                {
+                                    "cpeMatch": [
+                                        {
+                                            "vulnerable": True,
+                                            "criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
+                                            "versionStartIncluding": "2.0",
+                                            "versionEndExcluding": "2.15.0",
+                                        }
+                                    ]
+                                }
+                            ]
+                        }
+                    ],
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def mock_osv_response_log4j():
+    """OSV response for CVE-2021-44228."""
+    return {
+        "id": "CVE-2021-44228",
+        "aliases": ["GHSA-jfh8-c2jp-5v3q"],
+        "affected": [
+            {
+                "package": {"ecosystem": "Maven", "name": "org.apache.logging.log4j:log4j-core"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "2.0"},
+                            {"fixed": "2.15.0"},
+                        ],
+                    }
+                ],
+                "versions": ["2.0", "2.1", "2.2", "2.3", "2.14.1"],
+            }
+        ],
+    }
+
+
+@pytest.fixture
+def mock_osv_response_no_affected():
+    """OSV response with no package-level affected data."""
+    return {
+        "id": "CVE-2024-1234",
+        "aliases": ["GHSA-abcd-efgh-ijkl"],
+        "affected": [],
+    }
+
+
+@pytest.fixture
+def mock_ghsa_response():
+    """GHSA alias response with package data."""
+    return {
+        "id": "GHSA-abcd-efgh-ijkl",
+        "aliases": ["CVE-2024-1234"],
+        "affected": [
+            {
+                "package": {"ecosystem": "PyPI", "name": "vulnerable-pkg"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "1.0.0"},
+                            {"fixed": "1.2.3"},
+                        ],
+                    }
+                ],
+                "versions": ["1.0.0", "1.1.0", "1.2.0"],
+            }
+        ],
+    }
+
+
+# ===========================================================================
+# TOOL_SPEC contract tests
+# ===========================================================================
+
+
+class TestToolSpec:
+    """TOOL_SPEC contract compliance."""
+
+    def test_has_required_keys(self):
+        assert "name" in TOOL_SPEC
+        assert "description" in TOOL_SPEC
+        assert "inputSchema" in TOOL_SPEC
+
+    def test_name_is_get_version_range(self):
+        assert TOOL_SPEC["name"] == "get_version_range"
+
+    def test_description_is_non_empty_string(self):
+        assert isinstance(TOOL_SPEC["description"], str)
+        assert len(TOOL_SPEC["description"]) > 50
+
+    def test_input_schema_requires_cve_id(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert "cve_id" in schema["properties"]
+        assert "cve_id" in schema["required"]
+
+    def test_input_schema_has_ecosystem_property(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert "ecosystem" in schema["properties"]
+
+
+# ===========================================================================
+# Input validation tests
+# ===========================================================================
+
+
+class TestInputValidation:
+    """Input validation and edge cases."""
+
+    def test_empty_cve_id_returns_error(self):
+        result = fetch_version_range("")
+        assert "error" in result
+        assert result["nvd_ranges"] == []
+        assert result["osv_packages"] == []
+
+    def test_none_cve_id_returns_error(self):
+        result = fetch_version_range(None)
+        assert "error" in result
+
+    def test_whitespace_cve_id_returns_error(self):
+        result = fetch_version_range("   ")
+        assert "error" in result
+
+    def test_invalid_format_returns_error(self):
+        result = fetch_version_range("not-a-cve")
+        assert "error" in result
+        assert "Invalid CVE ID" in result.get("summary", "")
+
+    def test_cve_id_normalised_to_uppercase(self):
+        with patch(
+            "manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges",
+            return_value={"success": True, "cpe_ranges": [], "error": None},
+        ):
+            with patch(
+                "manus_agent.tools.get_version_range.fetch_osv_version_ranges",
+                return_value={"success": True, "packages": [], "error": None},
+            ):
+                result = fetch_version_range("cve-2021-44228")
+                assert result["cve_id"] == "CVE-2021-44228"
+
+    def test_cve_id_with_leading_trailing_whitespace(self):
+        with patch(
+            "manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges",
+            return_value={"success": True, "cpe_ranges": [], "error": None},
+        ):
+            with patch(
+                "manus_agent.tools.get_version_range.fetch_osv_version_ranges",
+                return_value={"success": True, "packages": [], "error": None},
+            ):
+                result = fetch_version_range("  CVE-2021-44228  ")
+                assert result["cve_id"] == "CVE-2021-44228"
+
+
+# ===========================================================================
+# CPE URI parsing tests
+# ===========================================================================
+
+
+class TestCpeUriParsing:
+    """CPE 2.3 URI parsing."""
+
+    def test_full_cpe23_uri(self):
+        cpe = "cpe:2.3:a:apache:log4j:2.14.1:*:*:*:*:*:*:*"
+        parsed = _parse_cpe_uri(cpe)
+        assert parsed["part"] == "a"
+        assert parsed["vendor"] == "apache"
+        assert parsed["product"] == "log4j"
+        assert parsed["version"] == "2.14.1"
+
+    def test_wildcard_version(self):
+        cpe = "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*"
+        parsed = _parse_cpe_uri(cpe)
+        assert parsed["version"] == "*"
+
+    def test_short_cpe_uri_returns_raw(self):
+        cpe = "cpe:2.3:a"
+        parsed = _parse_cpe_uri(cpe)
+        assert "raw" in parsed
+
+    def test_os_type_cpe(self):
+        cpe = "cpe:2.3:o:linux:linux_kernel:*:*:*:*:*:*:*:*"
+        parsed = _parse_cpe_uri(cpe)
+        assert parsed["part"] == "o"
+        assert parsed["vendor"] == "linux"
+        assert parsed["product"] == "linux_kernel"
+
+
+# ===========================================================================
+# NVD CPE range extraction tests
+# ===========================================================================
+
+
+class TestExtractCpeRanges:
+    """NVD CPE configuration range extraction."""
+
+    def test_version_start_end_including(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                                "versionStartIncluding": "1.0",
+                                "versionEndIncluding": "1.5",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 1
+        assert ranges[0]["version_start"] == "1.0"
+        assert ranges[0]["start_type"] == "including"
+        assert ranges[0]["version_end"] == "1.5"
+        assert ranges[0]["end_type"] == "including"
+
+    def test_version_start_end_excluding(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                                "versionStartExcluding": "0.9",
+                                "versionEndExcluding": "2.0",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 1
+        assert ranges[0]["version_start"] == "0.9"
+        assert ranges[0]["start_type"] == "excluding"
+        assert ranges[0]["version_end"] == "2.0"
+        assert ranges[0]["end_type"] == "excluding"
+
+    def test_specific_version_match(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product:3.1.0:*:*:*:*:*:*:*",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 1
+        assert ranges[0]["exact_version"] == "3.1.0"
+
+    def test_non_vulnerable_cpe_skipped(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": False,
+                                "criteria": "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                                "versionStartIncluding": "1.0",
+                                "versionEndExcluding": "2.0",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 0
+
+    def test_multiple_nodes(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product_a:*:*:*:*:*:*:*:*",
+                                "versionEndExcluding": "1.0",
+                            }
+                        ]
+                    },
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product_b:*:*:*:*:*:*:*:*",
+                                "versionEndExcluding": "2.0",
+                            }
+                        ]
+                    },
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 2
+
+    def test_nested_child_nodes(self):
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [],
+                        "nodes": [
+                            {
+                                "cpeMatch": [
+                                    {
+                                        "vulnerable": True,
+                                        "criteria": "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                                        "versionEndExcluding": "3.0",
+                                    }
+                                ]
+                            }
+                        ],
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 1
+        assert ranges[0]["version_end"] == "3.0"
+
+    def test_empty_configurations(self):
+        ranges = _extract_cpe_ranges([])
+        assert ranges == []
+
+    def test_no_version_constraints(self):
+        """CPE with wildcard version and no start/end should produce range entry."""
+        configs = [
+            {
+                "nodes": [
+                    {
+                        "cpeMatch": [
+                            {
+                                "vulnerable": True,
+                                "criteria": "cpe:2.3:a:vendor:product:*:*:*:*:*:*:*:*",
+                            }
+                        ]
+                    }
+                ]
+            }
+        ]
+        ranges = _extract_cpe_ranges(configs)
+        assert len(ranges) == 1
+        assert "version_start" not in ranges[0]
+        assert "version_end" not in ranges[0]
+        assert "exact_version" not in ranges[0]
+
+
+# ===========================================================================
+# NVD fetch tests
+# ===========================================================================
+
+
+class TestFetchNvdCpeRanges:
+    """NVD CPE range fetching with mocked HTTP."""
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_successful_fetch(self, mock_get, mock_nvd_response_log4j):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = mock_nvd_response_log4j
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = fetch_nvd_cpe_ranges("CVE-2021-44228")
+        assert result["success"] is True
+        assert len(result["cpe_ranges"]) == 1
+        assert result["cpe_ranges"][0]["version_start"] == "2.0"
+        assert result["cpe_ranges"][0]["version_end"] == "2.15.0"
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_404_returns_error(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = fetch_nvd_cpe_ranges("CVE-9999-99999")
+        assert result["success"] is False
+        assert "No NVD record" in result["error"]
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_network_error(self, mock_get):
+        import requests
+
+        mock_get.side_effect = requests.exceptions.ConnectionError("timeout")
+
+        result = fetch_nvd_cpe_ranges("CVE-2021-44228")
+        assert result["success"] is False
+        assert "failed" in result["error"].lower()
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_empty_vulnerabilities(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = fetch_nvd_cpe_ranges("CVE-2021-44228")
+        assert result["success"] is False
+        assert "No vulnerability data" in result["error"]
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_http_error_response(self, mock_get):
+        import requests
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_resp.raise_for_status.side_effect = requests.exceptions.HTTPError("500 Server Error")
+        mock_get.return_value = mock_resp
+
+        result = fetch_nvd_cpe_ranges("CVE-2021-44228")
+        assert result["success"] is False
+
+
+# ===========================================================================
+# OSV affected parsing tests
+# ===========================================================================
+
+
+class TestParseOsvAffected:
+    """OSV affected entry parsing."""
+
+    def test_basic_affected_entry(self):
+        affected = [
+            {
+                "package": {"ecosystem": "PyPI", "name": "flask"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "0"}, {"fixed": "2.3.2"}],
+                    }
+                ],
+                "versions": ["2.3.0", "2.3.1"],
+            }
+        ]
+        packages = _parse_osv_affected(affected)
+        assert len(packages) == 1
+        assert packages[0]["ecosystem"] == "PyPI"
+        assert packages[0]["package"] == "flask"
+        assert packages[0]["first_patched"] == "2.3.2"
+        assert packages[0]["affected_version_count"] == 2
+
+    def test_multiple_ranges(self):
+        affected = [
+            {
+                "package": {"ecosystem": "npm", "name": "lodash"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [{"introduced": "0"}, {"fixed": "4.17.21"}],
+                    },
+                    {
+                        "type": "SEMVER",
+                        "events": [{"introduced": "0"}, {"fixed": "4.17.21"}],
+                    },
+                ],
+                "versions": [],
+            }
+        ]
+        packages = _parse_osv_affected(affected)
+        assert len(packages) == 1
+        assert len(packages[0]["ranges"]) == 2
+
+    def test_last_affected_event(self):
+        affected = [
+            {
+                "package": {"ecosystem": "Go", "name": "golang.org/x/net"},
+                "ranges": [
+                    {
+                        "type": "SEMVER",
+                        "events": [{"introduced": "0"}, {"last_affected": "0.17.0"}],
+                    }
+                ],
+                "versions": [],
+            }
+        ]
+        packages = _parse_osv_affected(affected)
+        assert packages[0]["ranges"][0]["last_affected"] == ["0.17.0"]
+
+    def test_no_package_data_skipped(self):
+        affected = [
+            {"package": {}, "ranges": [], "versions": []},
+            {"ranges": [], "versions": []},
+        ]
+        packages = _parse_osv_affected(affected)
+        assert len(packages) == 0
+
+    def test_non_dict_entries_skipped(self):
+        affected = [None, "invalid", 42]
+        packages = _parse_osv_affected(affected)
+        assert len(packages) == 0
+
+    def test_versions_capped_at_20(self):
+        versions = [f"1.0.{i}" for i in range(50)]
+        affected = [
+            {
+                "package": {"ecosystem": "PyPI", "name": "pkg"},
+                "ranges": [],
+                "versions": versions,
+            }
+        ]
+        packages = _parse_osv_affected(affected)
+        assert packages[0]["affected_version_count"] == 50
+        assert len(packages[0]["affected_versions"]) == 20
+
+    def test_multiple_fixed_versions(self):
+        affected = [
+            {
+                "package": {"ecosystem": "Maven", "name": "org.example:lib"},
+                "ranges": [
+                    {
+                        "type": "ECOSYSTEM",
+                        "events": [
+                            {"introduced": "1.0"},
+                            {"fixed": "1.5.1"},
+                            {"introduced": "2.0"},
+                            {"fixed": "2.1.0"},
+                        ],
+                    }
+                ],
+                "versions": [],
+            }
+        ]
+        packages = _parse_osv_affected(affected)
+        assert packages[0]["first_patched"] == "1.5.1"
+        assert packages[0]["all_patched_versions"] == ["1.5.1", "2.1.0"]
+
+
+# ===========================================================================
+# OSV fetch tests
+# ===========================================================================
+
+
+class TestFetchOsvVersionRanges:
+    """OSV version range fetching with mocked HTTP."""
+
+    @patch("manus_agent.tools.get_version_range._fetch_osv_record")
+    def test_successful_fetch(self, mock_fetch, mock_osv_response_log4j):
+        mock_fetch.return_value = mock_osv_response_log4j
+
+        result = fetch_osv_version_ranges("CVE-2021-44228")
+        assert result["success"] is True
+        assert len(result["packages"]) == 1
+        assert result["packages"][0]["ecosystem"] == "Maven"
+        assert result["packages"][0]["first_patched"] == "2.15.0"
+
+    @patch("manus_agent.tools.get_version_range._fetch_osv_record")
+    def test_not_found_returns_error(self, mock_fetch):
+        mock_fetch.return_value = None
+
+        result = fetch_osv_version_ranges("CVE-9999-99999")
+        assert result["success"] is False
+        assert "No OSV record" in result["error"]
+
+    @patch("manus_agent.tools.get_version_range._fetch_osv_record")
+    def test_follows_ghsa_aliases_when_no_affected(self, mock_fetch, mock_osv_response_no_affected, mock_ghsa_response):
+        """When CVE record has no packages, follow GHSA aliases."""
+        mock_fetch.side_effect = [mock_osv_response_no_affected, mock_ghsa_response]
+
+        result = fetch_osv_version_ranges("CVE-2024-1234")
+        assert result["success"] is True
+        assert len(result["packages"]) == 1
+        assert result["packages"][0]["ecosystem"] == "PyPI"
+        assert result["packages"][0]["first_patched"] == "1.2.3"
+
+    @patch("manus_agent.tools.get_version_range._fetch_osv_record")
+    def test_does_not_follow_aliases_when_packages_present(self, mock_fetch, mock_osv_response_log4j):
+        """When primary record has packages, don't chase aliases."""
+        mock_fetch.return_value = mock_osv_response_log4j
+
+        fetch_osv_version_ranges("CVE-2021-44228")
+        # Only called once (no alias following)
+        assert mock_fetch.call_count == 1
+
+
+# ===========================================================================
+# Ecosystem inference tests
+# ===========================================================================
+
+
+class TestEcosystemInference:
+    """CPE vendor/product to ecosystem mapping."""
+
+    def test_python_vendor(self):
+        assert _infer_ecosystem_from_cpe("python", "requests") == "PyPI"
+
+    def test_npm_product(self):
+        assert _infer_ecosystem_from_cpe("some_vendor", "npm") == "npm"
+
+    def test_apache_vendor(self):
+        assert _infer_ecosystem_from_cpe("apache", "log4j") == "Maven"
+
+    def test_linux_kernel(self):
+        assert _infer_ecosystem_from_cpe("linux", "linux_kernel") == "Linux"
+
+    def test_go_vendor(self):
+        assert _infer_ecosystem_from_cpe("golang", "some_module") == "Go"
+
+    def test_rust_vendor(self):
+        assert _infer_ecosystem_from_cpe("rust", "some_crate") == "crates.io"
+
+    def test_unknown_returns_none(self):
+        assert _infer_ecosystem_from_cpe("unknown_vendor", "unknown_product") is None
+
+    def test_case_insensitive(self):
+        assert _infer_ecosystem_from_cpe("PYTHON", "REQUESTS") == "PyPI"
+
+    def test_php_packagist(self):
+        assert _infer_ecosystem_from_cpe("php", "laravel") == "Packagist"
+
+
+# ===========================================================================
+# Core fetch_version_range integration tests
+# ===========================================================================
+
+
+class TestFetchVersionRange:
+    """Integration tests for the main fetch_version_range function."""
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_combined_nvd_and_osv(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {
+            "success": True,
+            "cpe_ranges": [
+                {
+                    "vendor": "apache",
+                    "product": "log4j",
+                    "cpe": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
+                    "version_start": "2.0",
+                    "start_type": "including",
+                    "version_end": "2.15.0",
+                    "end_type": "excluding",
+                }
+            ],
+            "error": None,
+        }
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "Maven",
+                    "package": "org.apache.logging.log4j:log4j-core",
+                    "ranges": [
+                        {
+                            "type": "ECOSYSTEM",
+                            "introduced": ["2.0"],
+                            "fixed": ["2.15.0"],
+                            "last_affected": [],
+                            "limit": [],
+                        }
+                    ],
+                    "first_patched": "2.15.0",
+                    "all_patched_versions": ["2.15.0"],
+                    "affected_version_count": 5,
+                    "affected_versions": ["2.0", "2.1", "2.14.1"],
+                }
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert result["cve_id"] == "CVE-2021-44228"
+        assert len(result["nvd_ranges"]) == 1
+        assert len(result["osv_packages"]) == 1
+        assert result["first_patched"] == "2.15.0"
+        assert "Maven" in result["ecosystems"]
+        assert "CVE-2021-44228" in result["summary"]
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_ecosystem_filter_applied(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {
+            "success": True,
+            "cpe_ranges": [
+                {"vendor": "apache", "product": "log4j", "cpe": "..."},
+                {"vendor": "python", "product": "django", "cpe": "..."},
+            ],
+            "error": None,
+        }
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "Maven",
+                    "package": "log4j",
+                    "ranges": [],
+                    "first_patched": "2.15.0",
+                    "all_patched_versions": ["2.15.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+                {
+                    "ecosystem": "PyPI",
+                    "package": "django",
+                    "ranges": [],
+                    "first_patched": "4.0.1",
+                    "all_patched_versions": ["4.0.1"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228", ecosystem_filter="pypi")
+        # Only PyPI packages remain
+        assert all(p["ecosystem"] == "PyPI" for p in result["osv_packages"])
+        assert result["first_patched"] == "4.0.1"
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_no_data_from_either_source(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {"success": True, "cpe_ranges": [], "error": None}
+        mock_osv.return_value = {"success": True, "packages": [], "error": None}
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert result["first_patched"] is None
+        assert "No affected version ranges" in result["summary"]
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_both_sources_fail(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {"success": False, "cpe_ranges": [], "error": "NVD down"}
+        mock_osv.return_value = {"success": False, "packages": [], "error": "OSV down"}
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert "NVD" in result["summary"]
+        assert "OSV" in result["summary"]
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_nvd_enriches_ecosystem(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {
+            "success": True,
+            "cpe_ranges": [
+                {"vendor": "python", "product": "django", "cpe": "..."},
+            ],
+            "error": None,
+        }
+        mock_osv.return_value = {"success": True, "packages": [], "error": None}
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert result["nvd_ranges"][0]["inferred_ecosystem"] == "PyPI"
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_auto_ecosystem_no_filter(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {
+            "success": True,
+            "cpe_ranges": [{"vendor": "x", "product": "y", "cpe": "..."}],
+            "error": None,
+        }
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "npm",
+                    "package": "p",
+                    "ranges": [],
+                    "first_patched": None,
+                    "all_patched_versions": [],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                }
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228", ecosystem_filter="auto")
+        # auto means no filtering
+        assert len(result["osv_packages"]) == 1
+        assert len(result["nvd_ranges"]) == 1
+
+
+# ===========================================================================
+# Strands tool entry point tests
+# ===========================================================================
+
+
+class TestGetVersionRangeTool:
+    """Strands tool handler tests."""
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_success_response(self, mock_fetch):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [{"vendor": "apache"}],
+            "osv_packages": [{"ecosystem": "Maven"}],
+            "ecosystems": ["Maven"],
+            "first_patched": "2.15.0",
+            "summary": "test",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        tool_use = {"toolUseId": "test-123", "input": {"cve_id": "CVE-2021-44228"}}
+        result = get_version_range(tool_use)
+        assert result["toolUseId"] == "test-123"
+        assert result["status"] == "success"
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_error_when_no_data(self, mock_fetch):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-9999-99999",
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "No data",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        tool_use = {"toolUseId": "test-456", "input": {"cve_id": "CVE-9999-99999"}}
+        result = get_version_range(tool_use)
+        assert result["status"] == "error"
+
+    def test_missing_cve_id(self):
+        tool_use = {"toolUseId": "test-789", "input": {}}
+        result = get_version_range(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid CVE ID" in result["content"][0]["text"]
+
+    def test_empty_string_cve_id(self):
+        tool_use = {"toolUseId": "test-000", "input": {"cve_id": ""}}
+        result = get_version_range(tool_use)
+        assert result["status"] == "error"
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_ecosystem_param_forwarded(self, mock_fetch):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [],
+            "osv_packages": [{"ecosystem": "PyPI"}],
+            "ecosystems": ["PyPI"],
+            "first_patched": "1.0.1",
+            "summary": "test",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        tool_use = {"toolUseId": "t1", "input": {"cve_id": "CVE-2021-44228", "ecosystem": "pypi"}}
+        get_version_range(tool_use)
+        mock_fetch.assert_called_once_with("CVE-2021-44228", ecosystem_filter="pypi")
+
+
+# ===========================================================================
+# CLI subcommand tests
+# ===========================================================================
+
+
+class TestCliVersionRange:
+    """CLI version-range subcommand tests."""
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_text_output(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [
+                {
+                    "vendor": "apache",
+                    "product": "log4j",
+                    "cpe": "...",
+                    "version_start": "2.0",
+                    "start_type": "including",
+                    "version_end": "2.15.0",
+                    "end_type": "excluding",
+                }
+            ],
+            "osv_packages": [
+                {
+                    "ecosystem": "Maven",
+                    "package": "org.apache.logging.log4j:log4j-core",
+                    "ranges": [{"introduced": ["2.0"], "fixed": ["2.15.0"], "last_affected": []}],
+                    "first_patched": "2.15.0",
+                    "all_patched_versions": ["2.15.0"],
+                    "affected_version_count": 3,
+                    "affected_versions": ["2.0", "2.1", "2.14.1"],
+                }
+            ],
+            "ecosystems": ["Maven"],
+            "first_patched": "2.15.0",
+            "summary": "CVE-2021-44228: 1 NVD CPE range(s); 1 OSV package(s) [Maven]; first patched: 2.15.0.",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        exit_code = _run_version_range(["CVE-2021-44228"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "CVE-2021-44228" in captured.out
+        assert "NVD CPE Ranges" in captured.out
+        assert "OSV.dev Packages" in captured.out
+        assert "2.15.0" in captured.out
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_json_output(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "No data.",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        exit_code = _run_version_range(["CVE-2021-44228", "--output", "json"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["cve_id"] == "CVE-2021-44228"
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_ecosystem_flag(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "No data.",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        _run_version_range(["CVE-2021-44228", "--ecosystem", "pypi"])
+        mock_fetch.assert_called_once_with("CVE-2021-44228", ecosystem_filter="pypi")
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_auto_ecosystem_passes_none(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "No data.",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        _run_version_range(["CVE-2021-44228", "--ecosystem", "auto"])
+        mock_fetch.assert_called_once_with("CVE-2021-44228", ecosystem_filter=None)
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_text_output_no_data(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-9999-99999",
+            "nvd_ranges": [],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "No data.",
+            "nvd_error": "NVD request failed: timeout",
+            "osv_error": "No OSV record for CVE-9999-99999",
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        exit_code = _run_version_range(["CVE-9999-99999"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "NVD" in captured.out
+        assert "OSV" in captured.out
+
+    def test_version_range_in_subcommands(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "version-range" in _SUBCOMMANDS
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_text_output_exact_version(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [
+                {
+                    "vendor": "vendor",
+                    "product": "product",
+                    "cpe": "...",
+                    "exact_version": "3.1.0",
+                }
+            ],
+            "osv_packages": [],
+            "ecosystems": [],
+            "first_patched": None,
+            "summary": "CVE-2021-44228: 1 NVD CPE range(s).",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        exit_code = _run_version_range(["CVE-2021-44228"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "3.1.0" in captured.out
+
+    @patch("manus_agent.tools.get_version_range.fetch_version_range")
+    def test_text_output_multiple_patched_versions(self, mock_fetch, capsys):
+        mock_fetch.return_value = {
+            "cve_id": "CVE-2021-44228",
+            "nvd_ranges": [],
+            "osv_packages": [
+                {
+                    "ecosystem": "Maven",
+                    "package": "lib",
+                    "ranges": [{"introduced": ["1.0"], "fixed": ["1.5.1", "2.1.0"], "last_affected": []}],
+                    "first_patched": "1.5.1",
+                    "all_patched_versions": ["1.5.1", "2.1.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                }
+            ],
+            "ecosystems": ["Maven"],
+            "first_patched": "1.5.1",
+            "summary": "CVE-2021-44228: 1 OSV package(s) [Maven]; first patched: 1.5.1.",
+            "nvd_error": None,
+            "osv_error": None,
+        }
+
+        from manus_agent.cli import _run_version_range
+
+        exit_code = _run_version_range(["CVE-2021-44228"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "1.5.1" in captured.out
+        assert "2.1.0" in captured.out
+
+
+# ===========================================================================
+# Retry/back-off tests
+# ===========================================================================
+
+
+class TestRetryBackoff:
+    """HTTP retry/back-off behaviour."""
+
+    @patch("manus_agent.tools.get_version_range.time.sleep")
+    @patch("manus_agent.tools.get_version_range.requests.get")
+    def test_retries_on_429(self, mock_get, mock_sleep):
+        mock_resp_429 = MagicMock()
+        mock_resp_429.status_code = 429
+        mock_resp_success = MagicMock()
+        mock_resp_success.status_code = 200
+        mock_get.side_effect = [mock_resp_429, mock_resp_success]
+
+        with patch("manus_agent.tools.get_version_range._MAX_RETRIES", 3):
+            with patch("manus_agent.tools.get_version_range._RETRY_BASE_DELAY", 0.0):
+                resp = _http_get_with_retry("http://example.com")
+                assert resp.status_code == 200
+
+    @patch("manus_agent.tools.get_version_range.time.sleep")
+    @patch("manus_agent.tools.get_version_range.requests.get")
+    def test_retries_on_connection_error(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_resp_success = MagicMock()
+        mock_resp_success.status_code = 200
+        mock_get.side_effect = [req.exceptions.ConnectionError("conn"), mock_resp_success]
+
+        with patch("manus_agent.tools.get_version_range._MAX_RETRIES", 3):
+            with patch("manus_agent.tools.get_version_range._RETRY_BASE_DELAY", 0.0):
+                resp = _http_get_with_retry("http://example.com")
+                assert resp.status_code == 200
+
+    @patch("manus_agent.tools.get_version_range.requests.get")
+    def test_raises_after_max_retries(self, mock_get):
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.Timeout("timeout")
+
+        with patch("manus_agent.tools.get_version_range._MAX_RETRIES", 2):
+            with patch("manus_agent.tools.get_version_range._RETRY_BASE_DELAY", 0.0):
+                with pytest.raises(req.exceptions.Timeout):
+                    _http_get_with_retry("http://example.com")
+
+    @patch("manus_agent.tools.get_version_range.requests.get")
+    def test_non_retryable_status_returned_immediately(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_get.return_value = mock_resp
+
+        resp = _http_get_with_retry("http://example.com")
+        assert resp.status_code == 403
+        assert mock_get.call_count == 1
+
+
+# ===========================================================================
+# OSV record fetch tests
+# ===========================================================================
+
+
+class TestFetchOsvRecord:
+    """_fetch_osv_record helper tests."""
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_returns_json_on_200(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "CVE-2021-44228"}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_osv_record("CVE-2021-44228")
+        assert result == {"id": "CVE-2021-44228"}
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_returns_none_on_404(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = _fetch_osv_record("CVE-9999-99999")
+        assert result is None
+
+    @patch("manus_agent.tools.get_version_range._http_get_with_retry")
+    def test_returns_none_on_exception(self, mock_get):
+        mock_get.side_effect = Exception("network error")
+
+        result = _fetch_osv_record("CVE-2021-44228")
+        assert result is None
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_nvd_only_data(self, mock_nvd, mock_osv):
+        """Only NVD has data; OSV has nothing."""
+        mock_nvd.return_value = {
+            "success": True,
+            "cpe_ranges": [{"vendor": "vendor", "product": "product", "cpe": "..."}],
+            "error": None,
+        }
+        mock_osv.return_value = {"success": True, "packages": [], "error": None}
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert len(result["nvd_ranges"]) == 1
+        assert result["first_patched"] is None
+        assert "NVD CPE range" in result["summary"]
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_osv_only_data(self, mock_nvd, mock_osv):
+        """Only OSV has data; NVD has nothing."""
+        mock_nvd.return_value = {"success": True, "cpe_ranges": [], "error": None}
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "PyPI",
+                    "package": "pkg",
+                    "ranges": [],
+                    "first_patched": "1.0.0",
+                    "all_patched_versions": ["1.0.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                }
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert result["first_patched"] == "1.0.0"
+        assert "OSV package" in result["summary"]
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_multiple_ecosystems(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {"success": True, "cpe_ranges": [], "error": None}
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "PyPI",
+                    "package": "a",
+                    "ranges": [],
+                    "first_patched": "1.0",
+                    "all_patched_versions": ["1.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+                {
+                    "ecosystem": "npm",
+                    "package": "b",
+                    "ranges": [],
+                    "first_patched": "2.0",
+                    "all_patched_versions": ["2.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+                {
+                    "ecosystem": "Maven",
+                    "package": "c",
+                    "ranges": [],
+                    "first_patched": "3.0",
+                    "all_patched_versions": ["3.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228")
+        assert sorted(result["ecosystems"]) == ["Maven", "PyPI", "npm"]
+
+    def test_cpe_to_ecosystem_dict_populated(self):
+        """Ensure the mapping dict has key ecosystem targets."""
+        assert "python" in _CPE_TO_ECOSYSTEM
+        assert "npm" in _CPE_TO_ECOSYSTEM
+        assert "maven" in _CPE_TO_ECOSYSTEM
+        assert "go" in _CPE_TO_ECOSYSTEM
+        assert "rust" in _CPE_TO_ECOSYSTEM
+
+    @patch("manus_agent.tools.get_version_range.fetch_osv_version_ranges")
+    @patch("manus_agent.tools.get_version_range.fetch_nvd_cpe_ranges")
+    def test_ecosystem_filter_case_insensitive(self, mock_nvd, mock_osv):
+        mock_nvd.return_value = {"success": True, "cpe_ranges": [], "error": None}
+        mock_osv.return_value = {
+            "success": True,
+            "packages": [
+                {
+                    "ecosystem": "PyPI",
+                    "package": "a",
+                    "ranges": [],
+                    "first_patched": "1.0",
+                    "all_patched_versions": ["1.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+                {
+                    "ecosystem": "npm",
+                    "package": "b",
+                    "ranges": [],
+                    "first_patched": "2.0",
+                    "all_patched_versions": ["2.0"],
+                    "affected_version_count": 0,
+                    "affected_versions": [],
+                },
+            ],
+            "error": None,
+        }
+
+        result = fetch_version_range("CVE-2021-44228", ecosystem_filter="PyPI")
+        # Filter should work case-insensitively
+        assert all(p["ecosystem"] == "PyPI" for p in result["osv_packages"])


### PR DESCRIPTION
## Summary

Implements the `manus-agent version-range` CLI subcommand and `get_version_range` tool — a README-documented-but-completely-unimplemented feature gap.

Resolves a CVE to its affected version ranges by combining:
1. **NVD CPE configurations** — walks `versionStartIncluding/Excluding` and `versionEndIncluding/Excluding` match criteria
2. **OSV.dev ecosystem data** — fetches per-package `introduced`/`fixed` version events from PyPI, npm, Maven, Go, RustSec, etc.

Outputs structured vulnerable ranges, affected ecosystems, and the first-patched version.

## Usage

```bash
manus-agent version-range CVE-2021-44228
manus-agent version-range CVE-2021-44228 --ecosystem pypi
manus-agent version-range CVE-2021-44228 --output json | jq .first_patched
```

## Features

- **Dual-source resolution**: NVD CPE ranges + OSV.dev ecosystem packages merged into one view
- **Ecosystem filtering**: `--ecosystem {auto,pypi,npm,maven,go,crates.io,rubygems,nuget,packagist}`
- **CPE-to-ecosystem inference**: Maps CPE vendor/product names to known ecosystems (13 mappings)
- **GHSA alias following**: When CVE record lacks package data, follows GHSA aliases to recover version ranges
- **Retry/back-off**: Exponential back-off on 429/5xx for both NVD and OSV APIs
- **NVD_API_KEY support**: Optional higher rate limit when key is set
- **Graceful degradation**: Reports partial data when one source fails
- **Strands @tool pattern**: Full TOOL_SPEC + handler for agent integration

## Test Coverage

79 fully-mocked tests covering:
- TOOL_SPEC contract validation (5)
- Input validation and edge cases (6)
- CPE URI parsing (4)
- NVD CPE range extraction (8)
- NVD fetch with mocked HTTP (5)
- OSV affected parsing (7)
- OSV fetch and alias following (4)
- Ecosystem inference (9)
- Core integration (fetch_version_range) (7)
- Strands tool entry point (5)
- CLI subcommand dispatch (8)
- Retry/back-off behaviour (4)
- OSV record fetch helper (3)
- Edge cases and boundaries (4)

**Full suite: 1237 passed, 0 failures** (baseline 1158 + 79 new)

## Files Changed

- `src/manus_agent/tools/get_version_range.py` — new tool module
- `src/manus_agent/cli.py` — CLI dispatch + parser + `_SUBCOMMANDS` entry
- `tests/test_version_range.py` — 79 tests

## Duplicate Check

Checked all 50 open PRs (#134–#183) and 30 merged PRs — **no overlap**. Closest PRs:
- #97 (merged) `get_osv_data` — single CVE OSV query (we build on top of it conceptually but with a different tool that combines NVD CPE + OSV and adds ecosystem filtering/inference)
- #170 (open) `cve-enrich` — multi-source enrichment (different purpose: enriches metadata, doesn't resolve version ranges)
- #63 (merged) `blast-radius` — dependency impact (different axis: downstream dependents, not upstream version ranges)

## Design Decisions

- Zero new dependencies (uses `requests` already in the project)
- Follows existing patterns: retry/back-off, `TOOL_SPEC`, `log_tool_output_size`, CLI parser structure
- 100% mocked tests — no real HTTP calls
- Output capped (20 affected versions per package) to bound response size
