### PR TITLE
feat(cli): add manus-agent poc-week subcommand for trending CVE digest

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1055,6 +1055,7 @@ _SUBCOMMANDS = {
     "compare",
     "exploit-complexity",
     "poc-search",
+    "poc-week",
     "changelog",
     "blast-radius",
 }
@@ -1524,6 +1525,129 @@ def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
         date = (r.get("published") or "")[:col_date]
         url = (r.get("url") or "")[:col_url]
         print(f"{src:<{col_src}}  {eaw_flag:<{col_eaw}}  {title:<{col_title}}  {date:<{col_date}}  {url}")
+
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# poc-week subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_poc_week_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent poc-week",
+        description=(
+            "Fetch the PoC Week digest — a curated list of trending CVEs with\n"
+            "public Proof-of-Concept exploits, ranked by community mention count.\n"
+            "Data sourced from tonyharris.io/poc-week/."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "date",
+        nargs="?",
+        default=None,
+        metavar="YYYY-MM-DD",
+        help="Target date (auto-rounds to nearest Sunday). Defaults to latest available.",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    p.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        metavar="N",
+        help="Show only the top N entries (0 = all, default: all)",
+    )
+    p.add_argument(
+        "--new-only",
+        action="store_true",
+        default=False,
+        help="Show only entries marked NEW this week",
+    )
+    return p
+
+
+def _run_poc_week(argv: list[str]) -> int:  # noqa: C901
+    import json as _json
+
+    parser = _build_poc_week_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.get_poc_week import get_poc_week
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    result = get_poc_week(args.date)
+
+    if "error" in result:
+        print(f"Error: {result['error']}", file=sys.stderr)
+        return 1
+
+    cves = result.get("cves", [])
+
+    # Apply filters
+    if args.new_only:
+        cves = [c for c in cves if c.get("is_new")]
+
+    if args.limit > 0:
+        cves = cves[: args.limit]
+
+    if args.output == "json":
+        output = {
+            "week_date": result.get("week_date"),
+            "url": result.get("url"),
+            "total": result.get("total", 0),
+            "shown": len(cves),
+            "cves": cves,
+        }
+        print(_json.dumps(output, indent=2))
+        return 0
+
+    # ---- text output ----
+    week_date = result.get("week_date", "unknown")
+    url = result.get("url", "")
+    total = result.get("total", 0)
+
+    print(f"PoC Week Digest — {week_date}")
+    print(f"  Source: {url}")
+    print(f"  Total CVEs this week: {total}")
+    if args.new_only:
+        print(f"  Showing: NEW entries only ({len(cves)})")
+    elif args.limit > 0:
+        print(f"  Showing: top {len(cves)} of {total}")
+    print()
+
+    if not cves:
+        print("No entries match the current filters.")
+        return 0
+
+    for entry in cves:
+        cve_id = entry.get("cve_id", "?")
+        rank = entry.get("mention_rank", "?")
+        severity = entry.get("severity") or "—"
+        products = entry.get("products") or "—"
+        desc = entry.get("description") or "—"
+        poc_urls = entry.get("poc_urls", [])
+        is_new = entry.get("is_new", False)
+
+        new_badge = " 🆕" if is_new else ""
+        print(f"  #{rank}  {cve_id}{new_badge}")
+        print(f"       Severity : {severity}")
+        print(f"       Products : {products}")
+        print(f"       Description: {desc[:120]}")
+        if poc_urls:
+            print(f"       PoC URLs : {poc_urls[0]}")
+            for u in poc_urls[1:]:
+                print(f"                  {u}")
+        print()
 
     return 0
 
@@ -2260,6 +2384,10 @@ def main() -> None:
     if first_positional == "poc-search":
         idx = argv.index("poc-search")
         sys.exit(_run_poc_search(argv[idx + 1 :]))
+
+    if first_positional == "poc-week":
+        idx = argv.index("poc-week")
+        sys.exit(_run_poc_week(argv[idx + 1 :]))
 
     if first_positional == "changelog":
         idx = argv.index("changelog")

--- a/tests/test_cli_poc_week.py
+++ b/tests/test_cli_poc_week.py
@@ -1,0 +1,308 @@
+"""Tests for the `manus-agent poc-week` CLI subcommand."""
+
+import json
+import sys
+from unittest import mock
+
+import pytest
+
+from manus_agent import cli
+
+# ---------------------------------------------------------------------------
+# Parser tests
+# ---------------------------------------------------------------------------
+
+
+class TestPocWeekParser:
+    """Tests for _build_poc_week_parser."""
+
+    def test_parser_exists(self):
+        assert callable(cli._build_poc_week_parser)
+
+    def test_parser_prog_name(self):
+        p = cli._build_poc_week_parser()
+        assert p.prog == "manus-agent poc-week"
+
+    def test_parser_date_positional_optional(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args([])
+        assert args.date is None
+
+    def test_parser_date_positional_provided(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args(["2026-07-13"])
+        assert args.date == "2026-07-13"
+
+    def test_parser_output_default_text(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args([])
+        assert args.output == "text"
+
+    def test_parser_output_json(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args(["--output", "json"])
+        assert args.output == "json"
+
+    def test_parser_limit_default_zero(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args([])
+        assert args.limit == 0
+
+    def test_parser_limit_flag(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args(["--limit", "5"])
+        assert args.limit == 5
+
+    def test_parser_new_only_default_false(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args([])
+        assert args.new_only is False
+
+    def test_parser_new_only_flag(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args(["--new-only"])
+        assert args.new_only is True
+
+    def test_parser_all_flags_combined(self):
+        p = cli._build_poc_week_parser()
+        args = p.parse_args(["2026-06-01", "--output", "json", "--limit", "3", "--new-only"])
+        assert args.date == "2026-06-01"
+        assert args.output == "json"
+        assert args.limit == 3
+        assert args.new_only is True
+
+    def test_parser_help_exits_zero(self):
+        p = cli._build_poc_week_parser()
+        with pytest.raises(SystemExit) as exc_info:
+            p.parse_args(["--help"])
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Routing tests
+# ---------------------------------------------------------------------------
+
+
+class TestPocWeekRouting:
+    """Test that poc-week is registered and dispatched."""
+
+    def test_poc_week_in_subcommands(self):
+        assert "poc-week" in cli._SUBCOMMANDS
+
+    def test_poc_week_dispatch_in_main(self):
+        """main() routes 'poc-week' to _run_poc_week."""
+        with mock.patch.object(cli, "_run_poc_week", return_value=0) as mocked:
+            with mock.patch.object(sys, "argv", ["manus-agent", "poc-week", "2026-07-13"]):
+                with pytest.raises(SystemExit) as exc_info:
+                    cli.main()
+                assert exc_info.value.code == 0
+            mocked.assert_called_once_with(["2026-07-13"])
+
+
+# ---------------------------------------------------------------------------
+# Execution tests — _run_poc_week
+# ---------------------------------------------------------------------------
+
+
+_SAMPLE_RESULT = {
+    "week_date": "2026-07-12",
+    "url": "https://tonyharris.io/poc-week/poc-week-20260712/",
+    "total": 3,
+    "cves": [
+        {
+            "cve_id": "CVE-2026-1111",
+            "mention_rank": 1,
+            "severity": "CRITICAL",
+            "products": "Apache HTTP Server",
+            "description": "Remote code execution via crafted request",
+            "poc_urls": ["https://github.com/example/poc-1111"],
+            "is_new": True,
+        },
+        {
+            "cve_id": "CVE-2026-2222",
+            "mention_rank": 2,
+            "severity": "HIGH",
+            "products": "OpenSSL",
+            "description": "Buffer overflow in TLS handshake",
+            "poc_urls": ["https://github.com/example/poc-2222", "https://exploit-db.com/exploits/99999"],
+            "is_new": False,
+        },
+        {
+            "cve_id": "CVE-2026-3333",
+            "mention_rank": 3,
+            "severity": None,
+            "products": None,
+            "description": None,
+            "poc_urls": [],
+            "is_new": True,
+        },
+    ],
+}
+
+
+class TestRunPocWeek:
+    """Tests for _run_poc_week execution logic."""
+
+    def test_text_output_default(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "PoC Week Digest" in out
+        assert "2026-07-12" in out
+        assert "CVE-2026-1111" in out
+        assert "CVE-2026-2222" in out
+        assert "CVE-2026-3333" in out
+
+    def test_text_output_with_date(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT) as mocked:
+            rc = cli._run_poc_week(["2026-07-10"])
+        assert rc == 0
+        mocked.assert_called_once_with("2026-07-10")
+
+    def test_json_output(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["week_date"] == "2026-07-12"
+        assert data["total"] == 3
+        assert data["shown"] == 3
+        assert len(data["cves"]) == 3
+
+    def test_json_output_with_limit(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--output", "json", "--limit", "2"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["shown"] == 2
+        assert len(data["cves"]) == 2
+        assert data["total"] == 3  # original total preserved
+
+    def test_limit_flag_truncates(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--limit", "1"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CVE-2026-1111" in out
+        assert "CVE-2026-2222" not in out
+
+    def test_new_only_filter(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--new-only"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CVE-2026-1111" in out
+        assert "CVE-2026-3333" in out
+        assert "CVE-2026-2222" not in out  # not new
+
+    def test_new_only_with_limit(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--new-only", "--limit", "1"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CVE-2026-1111" in out
+        assert "CVE-2026-3333" not in out  # limited to 1
+
+    def test_error_from_tool(self, capsys):
+        error_result = {"error": "No PoC Week issue found within 3 weeks of 2026-07-12."}
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=error_result):
+            rc = cli._run_poc_week(["2020-01-01"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "No PoC Week issue found" in err
+
+    def test_empty_cves_list(self, capsys):
+        empty_result = {
+            "week_date": "2026-07-12",
+            "url": "https://tonyharris.io/poc-week/poc-week-20260712/",
+            "total": 0,
+            "cves": [],
+        }
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=empty_result):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No entries match" in out
+
+    def test_new_only_with_no_new_entries(self, capsys):
+        no_new_result = {
+            "week_date": "2026-07-12",
+            "url": "https://tonyharris.io/poc-week/poc-week-20260712/",
+            "total": 1,
+            "cves": [
+                {
+                    "cve_id": "CVE-2026-9999",
+                    "mention_rank": 1,
+                    "severity": "HIGH",
+                    "products": "nginx",
+                    "description": "Some vuln",
+                    "poc_urls": [],
+                    "is_new": False,
+                },
+            ],
+        }
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=no_new_result):
+            rc = cli._run_poc_week(["--new-only"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No entries match" in out
+
+    def test_text_displays_poc_urls(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "https://github.com/example/poc-1111" in out
+        assert "https://github.com/example/poc-2222" in out
+        assert "https://exploit-db.com/exploits/99999" in out
+
+    def test_text_displays_new_badge(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "\U0001f195" in out  # 🆕 emoji
+
+    def test_text_handles_none_fields(self, capsys):
+        """Entries with None severity/products/description display gracefully."""
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # CVE-2026-3333 has None fields — should show "—" placeholders
+        assert "CVE-2026-3333" in out
+
+    def test_no_date_passes_none(self):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT) as mocked:
+            cli._run_poc_week([])
+        mocked.assert_called_once_with(None)
+
+    def test_json_output_includes_url(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--output", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["url"] == "https://tonyharris.io/poc-week/poc-week-20260712/"
+
+    def test_text_shows_source_url(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "tonyharris.io" in out
+
+    def test_text_showing_count_with_limit(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--limit", "2"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "top 2 of 3" in out
+
+    def test_text_showing_new_only_count(self, capsys):
+        with mock.patch("manus_agent.tools.get_poc_week.get_poc_week", return_value=_SAMPLE_RESULT):
+            rc = cli._run_poc_week(["--new-only"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "NEW entries only" in out


### PR DESCRIPTION
## Summary

Adds a new `poc-week` CLI subcommand that fetches the [PoC Week](https://tonyharris.io/poc-week/) digest — a curated weekly list of trending CVEs with public Proof-of-Concept exploits, ranked by community mention count across security newsletters.

### What it does

```bash
manus-agent poc-week                          # latest available digest
manus-agent poc-week 2026-07-01              # specific week (rounds to Sunday)
manus-agent poc-week --output json           # JSON output for scripting
manus-agent poc-week --limit 5               # top 5 only
manus-agent poc-week --new-only              # only NEW entries this week
manus-agent poc-week --new-only --limit 3    # combine filters
```

- Fetches the weekly PoC Week digest via the existing `get_poc_week` library function (merged in PR #56)
- `--limit N` shows only the top N entries by mention rank
- `--new-only` filters to entries marked NEW this week
- Text output: formatted with rank, severity, products, description, PoC URLs, and 🆕 badge
- JSON output: structured data including `week_date`, `url`, `total`, `shown`, and `cves` array
- Graceful error handling: reports the tool's error message to stderr and exits 1

### Why this contribution

The `get_poc_week` tool was merged (#56) but had **no CLI access** — users had to invoke the full agent to get trending CVE data. This subcommand gives terminal users immediate access to the "what's trending in exploit-land this week" signal without the agent overhead.

### Existing PRs checked (no overlap)

Reviewed all 50 open PRs: #54, #58, #60, #64, #65, #67, #74–90, #96, #98, #100, #103–130. None cover a `poc-week` CLI subcommand. PR #60 covers `poc-freshness` (different tool — checks PoC age/staleness). PR #127 covers `exploit-search` (queries Exploit-DB/PacketStorm). Neither overlaps with the weekly trending digest.

### Tests

32 new tests in `tests/test_cli_poc_week.py`:
- `TestPocWeekParser` (12 tests): argument parsing, defaults, flag combinations
- `TestPocWeekRouting` (2 tests): `_SUBCOMMANDS` registration + main() dispatch
- `TestRunPocWeek` (18 tests): text/JSON output, `--limit`, `--new-only`, error handling, None fields, URL display, combined filters

All tests are 100% mocked (no real HTTP calls). Full suite: **1190 passed**, 0 failures.

### Files changed

- `src/manus_agent/cli.py` — +120 lines: `_build_poc_week_parser`, `_run_poc_week`, `_SUBCOMMANDS` entry, main() dispatch
- `tests/test_cli_poc_week.py` — new file, 32 tests
