### PR TITLE
feat(cli): add manus-agent sbom-scan subcommand for SBOM vulnerability scanning (+66 tests)

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "sbom-scan",
 }
 
 
@@ -2050,6 +2051,117 @@ def _build_run_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# ---------------------------------------------------------------------------
+# sbom-scan subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_sbom_scan_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent sbom-scan",
+        description=(
+            "Scan a CycloneDX or SPDX SBOM file for known vulnerabilities.\n"
+            "Queries OSV.dev in batch, enriches findings with EPSS and CISA KEV status,\n"
+            "and ranks results by KEV membership then EPSS score."
+        ),
+        add_help=True,
+    )
+    p.add_argument(
+        "bom_file",
+        metavar="BOM-FILE",
+        help="Path to SBOM file (CycloneDX JSON or SPDX JSON). Example: bom.json",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_sbom_scan(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_sbom_scan_parser()
+    args = parser.parse_args(argv)
+    bom_file = args.bom_file.strip()
+    if not bom_file:
+        parser.error("BOM-FILE is required")
+
+    try:
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+    except ImportError as exc:
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = scan_sbom_file(bom_file)
+    except FileNotFoundError as exc:
+        print(f"[error] {exc}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"[error] {exc}", file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"[error] SBOM scan failed: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2, ensure_ascii=False))
+        return 0
+
+    # Text output
+    from rich.table import Table
+
+    console.print(
+        Panel(
+            f"[bold cyan]SBOM Scan Results[/bold cyan]\n"
+            f"Format: [yellow]{result['format']}[/yellow]  "
+            f"Components: [green]{result['total_components']}[/green]  "
+            f"Vulnerable: [red]{result['vulnerable_components']}[/red]  "
+            f"Findings: [red]{result['total_vulnerabilities']}[/red]  "
+            f"Critical: [bold red]{result['critical_count']}[/bold red]",
+            border_style="blue",
+        )
+    )
+
+    findings = result.get("findings", [])
+    if not findings:
+        console.print("[green]No known vulnerabilities found.[/green]")
+        return 0
+
+    table = Table(
+        title=f"Vulnerabilities ({len(findings)} findings)",
+        show_header=True,
+        header_style="bold magenta",
+    )
+    table.add_column("ID", style="cyan", width=20)
+    table.add_column("Package", style="yellow", width=25)
+    table.add_column("Version", style="dim", width=12)
+    table.add_column("EPSS", style="blue", width=8)
+    table.add_column("KEV", width=5)
+    table.add_column("Summary", style="white", max_width=40)
+
+    for finding in findings[:50]:  # Cap display at 50
+        vuln_id = finding.get("cve_id") or finding.get("vuln_id", "")
+        pkg = finding.get("affected_package", "")
+        ver = finding.get("affected_version", "")
+        epss = f"{finding.get('epss', 0):.4f}"
+        kev = "[bold red]YES[/bold red]" if finding.get("in_kev") else "[dim]-[/dim]"
+        summary = (finding.get("summary", "") or "")[:60]
+        if len(finding.get("summary", "") or "") > 60:
+            summary += "…"
+        table.add_row(vuln_id, pkg, ver, epss, kev, summary)
+
+    console.print(table)
+
+    if len(findings) > 50:
+        console.print(f"[dim]... and {len(findings) - 50} more (use --output json for full list)[/dim]")
+
+    return 0
+
+
 def _build_init_parser() -> argparse.ArgumentParser:
     """Build the `init` subcommand parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2380,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "sbom-scan":
+        idx = argv.index("sbom-scan")
+        sys.exit(_run_sbom_scan(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/scan_sbom.py
+++ b/src/manus_agent/tools/scan_sbom.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""
+Tool for scanning SBOM (Software Bill of Materials) files against OSV.dev.
+
+Parses CycloneDX (JSON) or SPDX (JSON) SBOM files, extracts all component
+package identifiers (ecosystem + name + version), queries OSV.dev in batch
+for known vulnerabilities, enriches each finding with EPSS score and CISA KEV
+membership, and ranks results by KEV status then EPSS score descending.
+
+Public APIs used (no keys required):
+- OSV.dev batch query: POST https://api.osv.dev/v1/querybatch
+- FIRST.org EPSS: GET https://api.first.org/data/v1/epss?cve=<ids>
+- CISA KEV catalog: GET https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+_OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
+_EPSS_URL = "https://api.first.org/data/v1/epss"
+_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+_TIMEOUT = 20
+
+# Retry settings (overridable via env for tests)
+_MAX_RETRIES: int = int(os.environ.get("SBOM_SCAN_MAX_RETRIES", "3"))
+_RETRY_BASE_DELAY: float = float(os.environ.get("SBOM_SCAN_RETRY_BASE_DELAY", "1.0"))
+_RETRYABLE_STATUSES: frozenset[int] = frozenset({429, 500, 502, 503, 504})
+
+# OSV batch query limit per request
+_OSV_BATCH_SIZE = 1000
+
+# ---------------------------------------------------------------------------
+# PURL ecosystem mapping
+# ---------------------------------------------------------------------------
+
+# Maps purl type prefixes to OSV ecosystem names.
+_PURL_TO_ECOSYSTEM: dict[str, str] = {
+    "npm": "npm",
+    "pypi": "PyPI",
+    "maven": "Maven",
+    "golang": "Go",
+    "cargo": "crates.io",
+    "nuget": "NuGet",
+    "gem": "RubyGems",
+    "composer": "Packagist",
+    "pub": "Pub",
+    "hex": "Hex",
+    "hackage": "Hackage",
+    "cocoapods": "CocoaPods",
+    "swift": "SwiftURL",
+    "cran": "CRAN",
+    "deb": "Debian",
+    "apk": "Alpine",
+    "rpm": "Rocky Linux",
+}
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC (Strands tool interface)
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "scan_sbom",
+    "description": (
+        "Scans a CycloneDX or SPDX SBOM file for known vulnerabilities using "
+        "OSV.dev batch queries. Enriches each finding with EPSS score and CISA "
+        "KEV membership. Returns results ranked by KEV status then EPSS score. "
+        "Supports CycloneDX JSON and SPDX JSON formats."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "file_path": {
+                    "type": "string",
+                    "description": (
+                        "Path to the SBOM file (CycloneDX JSON or SPDX JSON). Example: 'bom.json' or 'sbom.spdx.json'."
+                    ),
+                }
+            },
+            "required": ["file_path"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper with retry/back-off
+# ---------------------------------------------------------------------------
+
+
+def _request_with_retry(
+    method: str,
+    url: str,
+    *,
+    json_body: Any | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: int = _TIMEOUT,
+) -> requests.Response:
+    """Make an HTTP request with exponential back-off on retryable errors."""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.request(method, url, json=json_body, params=params, timeout=timeout)
+            if resp.status_code not in _RETRYABLE_STATUSES:
+                return resp
+            last_exc = requests.HTTPError(f"HTTP {resp.status_code}", response=resp)
+        except requests.RequestException as exc:
+            last_exc = exc
+
+        if attempt < _MAX_RETRIES - 1:
+            delay = _RETRY_BASE_DELAY * (2**attempt)
+            time.sleep(delay)
+
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# SBOM Parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_purl(purl: str) -> tuple[str, str, str] | None:
+    """Parse a Package URL into (ecosystem, name, version) or None."""
+    # Format: pkg:<type>/<namespace>/<name>@<version>
+    # or:     pkg:<type>/<name>@<version>
+    if not purl.startswith("pkg:"):
+        return None
+
+    # Strip scheme
+    remainder = purl[4:]
+
+    # Split type from the rest
+    slash_idx = remainder.find("/")
+    if slash_idx < 0:
+        return None
+    purl_type = remainder[:slash_idx].lower()
+    rest = remainder[slash_idx + 1 :]
+
+    # Split version
+    at_idx = rest.rfind("@")
+    if at_idx < 0:
+        return None
+    name_part = rest[:at_idx]
+    version = rest[at_idx + 1 :]
+
+    # Strip qualifiers/subpath from version
+    for sep in ("?", "#"):
+        q_idx = version.find(sep)
+        if q_idx >= 0:
+            version = version[:q_idx]
+
+    # URL-decode common characters
+    name_part = name_part.replace("%2F", "/").replace("%40", "@")
+
+    ecosystem = _PURL_TO_ECOSYSTEM.get(purl_type)
+    if not ecosystem:
+        # Use the purl type as ecosystem (best effort)
+        ecosystem = purl_type
+
+    # For Maven, the namespace/name is the full group:artifact
+    if purl_type == "maven":
+        name_part = name_part.replace("/", ":")
+
+    return ecosystem, name_part, version
+
+
+def _parse_cyclonedx(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Extract components from a CycloneDX SBOM."""
+    components: list[dict[str, str]] = []
+    for comp in data.get("components", []):
+        purl = comp.get("purl", "")
+        if purl:
+            parsed = _parse_purl(purl)
+            if parsed:
+                ecosystem, name, version = parsed
+                components.append({"ecosystem": ecosystem, "name": name, "version": version, "purl": purl})
+        elif comp.get("name") and comp.get("version"):
+            # Fallback: without purl we cannot reliably determine ecosystem
+            name = comp["name"]
+            version = comp["version"]
+            # Without purl, we cannot reliably determine ecosystem
+            # Use generic package query
+            components.append({"ecosystem": "", "name": name, "version": version, "purl": ""})
+    return components
+
+
+def _parse_spdx(data: dict[str, Any]) -> list[dict[str, str]]:
+    """Extract packages from an SPDX SBOM."""
+    components: list[dict[str, str]] = []
+    for pkg in data.get("packages", []):
+        # SPDX uses externalRefs for purls
+        for ref in pkg.get("externalRefs", []):
+            if ref.get("referenceType") == "purl" or ref.get("referenceCategory") == "PACKAGE-MANAGER":
+                locator = ref.get("referenceLocator", "")
+                if locator.startswith("pkg:"):
+                    parsed = _parse_purl(locator)
+                    if parsed:
+                        ecosystem, name, version = parsed
+                        components.append({"ecosystem": ecosystem, "name": name, "version": version, "purl": locator})
+                    break
+        else:
+            # Fallback: use name + version if available
+            name = pkg.get("name", "")
+            version = pkg.get("versionInfo", "")
+            if name and version and name != "NOASSERTION" and version != "NOASSERTION":
+                components.append({"ecosystem": "", "name": name, "version": version, "purl": ""})
+    return components
+
+
+def parse_sbom(file_path: str) -> tuple[str, list[dict[str, str]]]:
+    """
+    Parse an SBOM file and return (format_name, components).
+
+    Raises ValueError on unrecognised format or parse errors.
+    """
+    path = Path(file_path)
+    if not path.exists():
+        raise FileNotFoundError(f"SBOM file not found: {file_path}")
+
+    text = path.read_text(encoding="utf-8")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON in SBOM file: {exc}") from exc
+
+    if not isinstance(data, dict):
+        raise ValueError("SBOM file must contain a JSON object at root level")
+
+    # Detect format
+    if "bomFormat" in data or "components" in data:
+        # CycloneDX
+        fmt = "CycloneDX"
+        components = _parse_cyclonedx(data)
+    elif "spdxVersion" in data or "packages" in data:
+        # SPDX
+        fmt = "SPDX"
+        components = _parse_spdx(data)
+    else:
+        raise ValueError("Unrecognised SBOM format. Supported: CycloneDX JSON, SPDX JSON.")
+
+    return fmt, components
+
+
+# ---------------------------------------------------------------------------
+# OSV.dev Batch Query
+# ---------------------------------------------------------------------------
+
+
+def _build_osv_queries(
+    components: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """Build OSV batch query payloads from parsed components."""
+    queries: list[dict[str, Any]] = []
+    for comp in components:
+        q: dict[str, Any] = {"version": comp["version"]}
+        if comp["ecosystem"]:
+            q["package"] = {"name": comp["name"], "ecosystem": comp["ecosystem"]}
+        else:
+            # Without ecosystem, query by package name only
+            q["package"] = {"name": comp["name"]}
+        queries.append(q)
+    return queries
+
+
+def query_osv_batch(
+    components: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    """
+    Query OSV.dev for vulnerabilities affecting the given components.
+
+    Returns a list of finding dicts with keys:
+      component, ecosystem, name, version, purl, vulns (list of osv records)
+    """
+    if not components:
+        return []
+
+    queries = _build_osv_queries(components)
+    all_results: list[dict[str, Any]] = []
+
+    # Process in batches
+    for i in range(0, len(queries), _OSV_BATCH_SIZE):
+        batch = queries[i : i + _OSV_BATCH_SIZE]
+        batch_components = components[i : i + _OSV_BATCH_SIZE]
+
+        resp = _request_with_retry("POST", _OSV_BATCH_URL, json_body={"queries": batch})
+        resp.raise_for_status()
+        data = resp.json()
+
+        results_list = data.get("results", [])
+        for idx, result in enumerate(results_list):
+            vulns = result.get("vulns", [])
+            if vulns and idx < len(batch_components):
+                comp = batch_components[idx]
+                all_results.append(
+                    {
+                        "ecosystem": comp["ecosystem"],
+                        "name": comp["name"],
+                        "version": comp["version"],
+                        "purl": comp["purl"],
+                        "vulns": vulns,
+                    }
+                )
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# EPSS Enrichment
+# ---------------------------------------------------------------------------
+
+
+def _fetch_epss_scores(cve_ids: list[str]) -> dict[str, float]:
+    """Fetch EPSS scores for a list of CVE IDs. Returns {cve_id: score}."""
+    if not cve_ids:
+        return {}
+
+    scores: dict[str, float] = {}
+
+    # EPSS API accepts comma-separated CVEs (limit batches to avoid URL length issues)
+    batch_size = 100
+    for i in range(0, len(cve_ids), batch_size):
+        batch = cve_ids[i : i + batch_size]
+        try:
+            resp = _request_with_retry("GET", _EPSS_URL, params={"cve": ",".join(batch)})
+            if resp.status_code == 200:
+                data = resp.json()
+                for item in data.get("data", []):
+                    cve = item.get("cve", "")
+                    score = float(item.get("epss", 0))
+                    scores[cve] = score
+        except Exception:
+            # Graceful degradation — EPSS enrichment is optional
+            pass
+
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# CISA KEV Enrichment
+# ---------------------------------------------------------------------------
+
+
+def _fetch_kev_cve_set() -> set[str]:
+    """Fetch the set of CVE IDs in the CISA KEV catalog."""
+    try:
+        resp = _request_with_retry("GET", _KEV_URL)
+        if resp.status_code == 200:
+            data = resp.json()
+            return {v.get("cveID", "") for v in data.get("vulnerabilities", []) if v.get("cveID")}
+    except Exception:
+        pass
+    return set()
+
+
+# ---------------------------------------------------------------------------
+# Core scan logic
+# ---------------------------------------------------------------------------
+
+
+def scan_sbom_file(file_path: str) -> dict[str, Any]:
+    """
+    Scan an SBOM file for vulnerabilities.
+
+    Returns a dict with:
+      - format: SBOM format detected
+      - total_components: number of components parsed
+      - vulnerable_components: number with at least one vulnerability
+      - total_vulnerabilities: unique CVE/advisory count
+      - critical_count: findings with EPSS >= 0.5 or in KEV
+      - findings: list of enriched findings sorted by severity
+    """
+    fmt, components = parse_sbom(file_path)
+
+    if not components:
+        return {
+            "format": fmt,
+            "total_components": 0,
+            "vulnerable_components": 0,
+            "total_vulnerabilities": 0,
+            "critical_count": 0,
+            "findings": [],
+        }
+
+    # Query OSV
+    osv_results = query_osv_batch(components)
+
+    if not osv_results:
+        return {
+            "format": fmt,
+            "total_components": len(components),
+            "vulnerable_components": 0,
+            "total_vulnerabilities": 0,
+            "critical_count": 0,
+            "findings": [],
+        }
+
+    # Collect all unique CVE IDs for enrichment
+    all_cve_ids: set[str] = set()
+    for result in osv_results:
+        for vuln in result["vulns"]:
+            vuln_id = vuln.get("id", "")
+            if vuln_id.startswith("CVE-"):
+                all_cve_ids.add(vuln_id)
+            # Also check aliases
+            for alias in vuln.get("aliases", []):
+                if alias.startswith("CVE-"):
+                    all_cve_ids.add(alias)
+
+    # Enrich with EPSS + KEV
+    epss_scores = _fetch_epss_scores(sorted(all_cve_ids))
+    kev_set = _fetch_kev_cve_set()
+
+    # Build findings
+    findings: list[dict[str, Any]] = []
+    seen_vuln_ids: set[str] = set()
+
+    for result in osv_results:
+        for vuln in result["vulns"]:
+            vuln_id = vuln.get("id", "")
+            if vuln_id in seen_vuln_ids:
+                continue
+            seen_vuln_ids.add(vuln_id)
+
+            # Determine CVE ID (may be the id itself or in aliases)
+            cve_id = vuln_id if vuln_id.startswith("CVE-") else ""
+            aliases = vuln.get("aliases", [])
+            if not cve_id:
+                for alias in aliases:
+                    if alias.startswith("CVE-"):
+                        cve_id = alias
+                        break
+
+            epss = epss_scores.get(cve_id, 0.0) if cve_id else 0.0
+            in_kev = cve_id in kev_set if cve_id else False
+
+            severity_list = vuln.get("severity", [])
+            cvss_score = None
+            for sev in severity_list:
+                if sev.get("type") == "CVSS_V3":
+                    # Try to extract base score from vector
+                    vector = sev.get("score", "")
+                    if vector:
+                        cvss_score = vector
+
+            finding: dict[str, Any] = {
+                "vuln_id": vuln_id,
+                "cve_id": cve_id,
+                "aliases": aliases,
+                "summary": vuln.get("summary", vuln.get("details", ""))[:200],
+                "affected_package": result["name"],
+                "affected_ecosystem": result["ecosystem"],
+                "affected_version": result["version"],
+                "epss": epss,
+                "in_kev": in_kev,
+                "cvss_vector": cvss_score,
+            }
+            findings.append(finding)
+
+    # Sort: KEV first, then by EPSS descending
+    findings.sort(key=lambda f: (not f["in_kev"], -f["epss"]))
+
+    critical_count = sum(1 for f in findings if f["in_kev"] or f["epss"] >= 0.5)
+
+    return {
+        "format": fmt,
+        "total_components": len(components),
+        "vulnerable_components": len(osv_results),
+        "total_vulnerabilities": len(findings),
+        "critical_count": critical_count,
+        "findings": findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
+def scan_sbom(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands tool entry point for SBOM scanning."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+    file_path = tool_input.get("file_path", "")
+
+    if not file_path:
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "The 'file_path' input is required."}],
+        }
+        log_tool_output_size("scan_sbom", result)
+        return result
+
+    try:
+        scan_result = scan_sbom_file(file_path)
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "success",
+            "content": [{"json": scan_result}],
+        }
+        log_tool_output_size("scan_sbom", result)
+        return result
+    except FileNotFoundError as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": str(exc)}],
+        }
+        log_tool_output_size("scan_sbom", result)
+        return result
+    except ValueError as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": str(exc)}],
+        }
+        log_tool_output_size("scan_sbom", result)
+        return result
+    except requests.RequestException as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Network error during SBOM scan: {exc}"}],
+        }
+        log_tool_output_size("scan_sbom", result)
+        return result

--- a/tests/test_scan_sbom.py
+++ b/tests/test_scan_sbom.py
@@ -1,0 +1,1086 @@
+#!/usr/bin/env python3
+"""Comprehensive test suite for scan_sbom tool and sbom-scan CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the package is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_CYCLONEDX = {
+    "bomFormat": "CycloneDX",
+    "specVersion": "1.4",
+    "components": [
+        {
+            "type": "library",
+            "name": "requests",
+            "version": "2.28.0",
+            "purl": "pkg:pypi/requests@2.28.0",
+        },
+        {
+            "type": "library",
+            "name": "lodash",
+            "version": "4.17.20",
+            "purl": "pkg:npm/lodash@4.17.20",
+        },
+        {
+            "type": "library",
+            "name": "spring-core",
+            "version": "5.3.20",
+            "purl": "pkg:maven/org.springframework/spring-core@5.3.20",
+        },
+    ],
+}
+
+SAMPLE_SPDX = {
+    "spdxVersion": "SPDX-2.3",
+    "packages": [
+        {
+            "name": "axios",
+            "versionInfo": "1.6.0",
+            "externalRefs": [
+                {
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceLocator": "pkg:npm/axios@1.6.0",
+                }
+            ],
+        },
+        {
+            "name": "flask",
+            "versionInfo": "2.3.0",
+            "externalRefs": [
+                {
+                    "referenceType": "purl",
+                    "referenceCategory": "PACKAGE-MANAGER",
+                    "referenceLocator": "pkg:pypi/flask@2.3.0",
+                }
+            ],
+        },
+    ],
+}
+
+SAMPLE_OSV_BATCH_RESPONSE = {
+    "results": [
+        {
+            "vulns": [
+                {
+                    "id": "GHSA-j8r2-6x86-q33q",
+                    "aliases": ["CVE-2023-32681"],
+                    "summary": "Unintended leak of Proxy-Authorization header in requests",
+                    "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:N/A:N"}],
+                }
+            ]
+        },
+        {
+            "vulns": [
+                {
+                    "id": "CVE-2021-23337",
+                    "aliases": [],
+                    "summary": "Lodash Command Injection",
+                    "severity": [],
+                }
+            ]
+        },
+        {"vulns": []},  # spring-core - no vulns
+    ]
+}
+
+SAMPLE_EPSS_RESPONSE = {
+    "status": "OK",
+    "data": [
+        {"cve": "CVE-2023-32681", "epss": "0.00234", "percentile": "0.612"},
+        {"cve": "CVE-2021-23337", "epss": "0.87654", "percentile": "0.991"},
+    ],
+}
+
+SAMPLE_KEV_RESPONSE = {
+    "vulnerabilities": [
+        {"cveID": "CVE-2021-23337"},
+        {"cveID": "CVE-2021-44228"},
+    ]
+}
+
+
+@pytest.fixture
+def cyclonedx_file(tmp_path: Path) -> Path:
+    """Create a temp CycloneDX SBOM file."""
+    f = tmp_path / "bom.json"
+    f.write_text(json.dumps(SAMPLE_CYCLONEDX))
+    return f
+
+
+@pytest.fixture
+def spdx_file(tmp_path: Path) -> Path:
+    """Create a temp SPDX SBOM file."""
+    f = tmp_path / "sbom.spdx.json"
+    f.write_text(json.dumps(SAMPLE_SPDX))
+    return f
+
+
+@pytest.fixture
+def empty_cyclonedx_file(tmp_path: Path) -> Path:
+    """CycloneDX with no components."""
+    f = tmp_path / "empty.json"
+    f.write_text(json.dumps({"bomFormat": "CycloneDX", "components": []}))
+    return f
+
+
+@pytest.fixture
+def invalid_json_file(tmp_path: Path) -> Path:
+    """Invalid JSON file."""
+    f = tmp_path / "bad.json"
+    f.write_text("not valid json {{{")
+    return f
+
+
+@pytest.fixture
+def unknown_format_file(tmp_path: Path) -> Path:
+    """Valid JSON but unrecognised SBOM format."""
+    f = tmp_path / "unknown.json"
+    f.write_text(json.dumps({"foo": "bar", "items": []}))
+    return f
+
+
+def _mock_tool_use(file_path: str) -> dict[str, Any]:
+    """Build a mock ToolUse dict."""
+    return {"toolUseId": "test-123", "input": {"file_path": file_path}}
+
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Verify TOOL_SPEC follows project conventions."""
+
+    def test_tool_spec_exists(self):
+        from manus_agent.tools.scan_sbom import TOOL_SPEC
+
+        assert TOOL_SPEC is not None
+
+    def test_tool_spec_has_name(self):
+        from manus_agent.tools.scan_sbom import TOOL_SPEC
+
+        assert TOOL_SPEC["name"] == "scan_sbom"
+
+    def test_tool_spec_has_description(self):
+        from manus_agent.tools.scan_sbom import TOOL_SPEC
+
+        assert len(TOOL_SPEC["description"]) > 20
+
+    def test_tool_spec_has_input_schema(self):
+        from manus_agent.tools.scan_sbom import TOOL_SPEC
+
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["type"] == "object"
+        assert "file_path" in schema["properties"]
+        assert "file_path" in schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# PURL parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestPurlParsing:
+    """Test Package URL parsing logic."""
+
+    def test_parse_pypi_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:pypi/requests@2.28.0")
+        assert result == ("PyPI", "requests", "2.28.0")
+
+    def test_parse_npm_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:npm/lodash@4.17.20")
+        assert result == ("npm", "lodash", "4.17.20")
+
+    def test_parse_maven_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:maven/org.springframework/spring-core@5.3.20")
+        assert result == ("Maven", "org.springframework:spring-core", "5.3.20")
+
+    def test_parse_cargo_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:cargo/serde@1.0.188")
+        assert result == ("crates.io", "serde", "1.0.188")
+
+    def test_parse_golang_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:golang/github.com/gin-gonic/gin@1.9.1")
+        assert result == ("Go", "github.com/gin-gonic/gin", "1.9.1")
+
+    def test_parse_nuget_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:nuget/Newtonsoft.Json@13.0.3")
+        assert result == ("NuGet", "Newtonsoft.Json", "13.0.3")
+
+    def test_parse_gem_purl(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:gem/rails@7.0.0")
+        assert result == ("RubyGems", "rails", "7.0.0")
+
+    def test_parse_purl_with_qualifiers(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:npm/lodash@4.17.20?type=module")
+        assert result == ("npm", "lodash", "4.17.20")
+
+    def test_parse_purl_with_subpath(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:npm/lodash@4.17.20#sub/path")
+        assert result == ("npm", "lodash", "4.17.20")
+
+    def test_parse_purl_unknown_type(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:conan/openssl@3.0.0")
+        # Unknown purl type maps to the type itself
+        assert result == ("conan", "openssl", "3.0.0")
+
+    def test_parse_purl_no_version_returns_none(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:npm/lodash")
+        assert result is None
+
+    def test_parse_purl_invalid_no_pkg_prefix(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("npm/lodash@1.0.0")
+        assert result is None
+
+    def test_parse_purl_no_slash_returns_none(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:invalid")
+        assert result is None
+
+    def test_parse_purl_encoded_chars(self):
+        from manus_agent.tools.scan_sbom import _parse_purl
+
+        result = _parse_purl("pkg:npm/%40scope/pkg@1.0.0")
+        assert result == ("npm", "@scope/pkg", "1.0.0")
+
+
+# ---------------------------------------------------------------------------
+# SBOM Parsing tests
+# ---------------------------------------------------------------------------
+
+
+class TestSbomParsing:
+    """Test CycloneDX and SPDX parsing."""
+
+    def test_parse_cyclonedx_components(self, cyclonedx_file: Path):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        fmt, components = parse_sbom(str(cyclonedx_file))
+        assert fmt == "CycloneDX"
+        assert len(components) == 3
+        assert components[0]["name"] == "requests"
+        assert components[0]["ecosystem"] == "PyPI"
+        assert components[0]["version"] == "2.28.0"
+
+    def test_parse_spdx_packages(self, spdx_file: Path):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        fmt, components = parse_sbom(str(spdx_file))
+        assert fmt == "SPDX"
+        assert len(components) == 2
+        assert components[0]["name"] == "axios"
+        assert components[0]["ecosystem"] == "npm"
+
+    def test_parse_empty_cyclonedx(self, empty_cyclonedx_file: Path):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        fmt, components = parse_sbom(str(empty_cyclonedx_file))
+        assert fmt == "CycloneDX"
+        assert components == []
+
+    def test_parse_file_not_found(self):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        with pytest.raises(FileNotFoundError):
+            parse_sbom("/nonexistent/file.json")
+
+    def test_parse_invalid_json(self, invalid_json_file: Path):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            parse_sbom(str(invalid_json_file))
+
+    def test_parse_unknown_format(self, unknown_format_file: Path):
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        with pytest.raises(ValueError, match="Unrecognised SBOM format"):
+            parse_sbom(str(unknown_format_file))
+
+    def test_cyclonedx_fallback_no_purl(self, tmp_path: Path):
+        """Components without purl use name/version fallback."""
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        data = {
+            "bomFormat": "CycloneDX",
+            "components": [
+                {"type": "library", "name": "mylib", "version": "1.0.0"},
+            ],
+        }
+        f = tmp_path / "nopurl.json"
+        f.write_text(json.dumps(data))
+        fmt, components = parse_sbom(str(f))
+        assert len(components) == 1
+        assert components[0]["name"] == "mylib"
+        assert components[0]["ecosystem"] == ""
+
+    def test_spdx_fallback_no_purl(self, tmp_path: Path):
+        """SPDX packages without externalRefs use name/version fallback."""
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        data = {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [
+                {"name": "mylib", "versionInfo": "2.0.0", "externalRefs": []},
+            ],
+        }
+        f = tmp_path / "nopurl-spdx.json"
+        f.write_text(json.dumps(data))
+        fmt, components = parse_sbom(str(f))
+        assert len(components) == 1
+        assert components[0]["name"] == "mylib"
+        assert components[0]["version"] == "2.0.0"
+
+    def test_spdx_skips_noassertion(self, tmp_path: Path):
+        """SPDX packages with NOASSERTION name or version are skipped."""
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        data = {
+            "spdxVersion": "SPDX-2.3",
+            "packages": [
+                {"name": "NOASSERTION", "versionInfo": "1.0.0", "externalRefs": []},
+                {"name": "pkg", "versionInfo": "NOASSERTION", "externalRefs": []},
+            ],
+        }
+        f = tmp_path / "noassert.json"
+        f.write_text(json.dumps(data))
+        fmt, components = parse_sbom(str(f))
+        assert components == []
+
+    def test_root_not_dict(self, tmp_path: Path):
+        """Root-level JSON array should raise ValueError."""
+        from manus_agent.tools.scan_sbom import parse_sbom
+
+        f = tmp_path / "array.json"
+        f.write_text(json.dumps([{"name": "x"}]))
+        with pytest.raises(ValueError, match="must contain a JSON object"):
+            parse_sbom(str(f))
+
+
+# ---------------------------------------------------------------------------
+# OSV Batch Query tests
+# ---------------------------------------------------------------------------
+
+
+class TestOsvBatchQuery:
+    """Test OSV.dev batch query logic."""
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_query_empty_components(self, mock_req):
+        from manus_agent.tools.scan_sbom import query_osv_batch
+
+        result = query_osv_batch([])
+        assert result == []
+        mock_req.assert_not_called()
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_query_returns_vulnerable(self, mock_req):
+        from manus_agent.tools.scan_sbom import query_osv_batch
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_OSV_BATCH_RESPONSE
+        mock_resp.raise_for_status = MagicMock()
+        mock_req.return_value = mock_resp
+
+        components = [
+            {"ecosystem": "PyPI", "name": "requests", "version": "2.28.0", "purl": "pkg:pypi/requests@2.28.0"},
+            {"ecosystem": "npm", "name": "lodash", "version": "4.17.20", "purl": "pkg:npm/lodash@4.17.20"},
+            {
+                "ecosystem": "Maven",
+                "name": "spring-core",
+                "version": "5.3.20",
+                "purl": "pkg:maven/org.springframework/spring-core@5.3.20",
+            },
+        ]
+        result = query_osv_batch(components)
+        # spring-core has no vulns, so only 2 results
+        assert len(result) == 2
+        assert result[0]["name"] == "requests"
+        assert result[1]["name"] == "lodash"
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_query_builds_correct_payload(self, mock_req):
+        from manus_agent.tools.scan_sbom import query_osv_batch
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": [{"vulns": []}]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_req.return_value = mock_resp
+
+        components = [
+            {"ecosystem": "npm", "name": "express", "version": "4.18.0", "purl": "pkg:npm/express@4.18.0"},
+        ]
+        query_osv_batch(components)
+
+        call_kwargs = mock_req.call_args
+        payload = call_kwargs.kwargs.get("json_body") or call_kwargs[1].get("json_body")
+        assert payload["queries"][0]["version"] == "4.18.0"
+        assert payload["queries"][0]["package"]["name"] == "express"
+        assert payload["queries"][0]["package"]["ecosystem"] == "npm"
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_query_no_ecosystem_omits_ecosystem_key(self, mock_req):
+        from manus_agent.tools.scan_sbom import query_osv_batch
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"results": [{"vulns": []}]}
+        mock_resp.raise_for_status = MagicMock()
+        mock_req.return_value = mock_resp
+
+        components = [
+            {"ecosystem": "", "name": "mylib", "version": "1.0.0", "purl": ""},
+        ]
+        query_osv_batch(components)
+
+        call_kwargs = mock_req.call_args
+        payload = call_kwargs.kwargs.get("json_body") or call_kwargs[1].get("json_body")
+        assert "ecosystem" not in payload["queries"][0]["package"]
+
+
+# ---------------------------------------------------------------------------
+# EPSS Enrichment tests
+# ---------------------------------------------------------------------------
+
+
+class TestEpssEnrichment:
+    """Test EPSS score fetching."""
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_epss_scores(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_epss_scores
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_EPSS_RESPONSE
+        mock_req.return_value = mock_resp
+
+        scores = _fetch_epss_scores(["CVE-2023-32681", "CVE-2021-23337"])
+        assert scores["CVE-2023-32681"] == pytest.approx(0.00234)
+        assert scores["CVE-2021-23337"] == pytest.approx(0.87654)
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_epss_empty_list(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_epss_scores
+
+        scores = _fetch_epss_scores([])
+        assert scores == {}
+        mock_req.assert_not_called()
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_epss_graceful_failure(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_epss_scores
+
+        mock_req.side_effect = Exception("network error")
+        scores = _fetch_epss_scores(["CVE-2023-32681"])
+        assert scores == {}
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_epss_non_200_graceful(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_epss_scores
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_req.return_value = mock_resp
+        scores = _fetch_epss_scores(["CVE-2023-32681"])
+        assert scores == {}
+
+
+# ---------------------------------------------------------------------------
+# KEV Enrichment tests
+# ---------------------------------------------------------------------------
+
+
+class TestKevEnrichment:
+    """Test CISA KEV catalog fetching."""
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_kev_cve_set(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_kev_cve_set
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = SAMPLE_KEV_RESPONSE
+        mock_req.return_value = mock_resp
+
+        kev_set = _fetch_kev_cve_set()
+        assert "CVE-2021-23337" in kev_set
+        assert "CVE-2021-44228" in kev_set
+
+    @patch("manus_agent.tools.scan_sbom._request_with_retry")
+    def test_fetch_kev_graceful_failure(self, mock_req):
+        from manus_agent.tools.scan_sbom import _fetch_kev_cve_set
+
+        mock_req.side_effect = Exception("timeout")
+        kev_set = _fetch_kev_cve_set()
+        assert kev_set == set()
+
+
+# ---------------------------------------------------------------------------
+# Retry logic tests
+# ---------------------------------------------------------------------------
+
+
+class TestRetryLogic:
+    """Test HTTP retry/back-off."""
+
+    @patch("manus_agent.tools.scan_sbom.time.sleep")
+    @patch("manus_agent.tools.scan_sbom.requests.request")
+    def test_retry_on_429(self, mock_request, mock_sleep):
+        from manus_agent.tools.scan_sbom import _request_with_retry
+
+        # First call returns 429, second returns 200
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        mock_request.side_effect = [resp_429, resp_200]
+
+        result = _request_with_retry("GET", "http://example.com")
+        assert result.status_code == 200
+        assert mock_request.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("manus_agent.tools.scan_sbom.time.sleep")
+    @patch("manus_agent.tools.scan_sbom.requests.request")
+    def test_retry_on_network_error(self, mock_request, mock_sleep):
+        import requests as req
+
+        from manus_agent.tools.scan_sbom import _request_with_retry
+
+        # All retries fail with connection error
+        mock_request.side_effect = req.ConnectionError("refused")
+
+        with pytest.raises(req.ConnectionError):
+            _request_with_retry("GET", "http://example.com")
+
+    @patch("manus_agent.tools.scan_sbom.time.sleep")
+    @patch("manus_agent.tools.scan_sbom.requests.request")
+    def test_no_retry_on_400(self, mock_request, mock_sleep):
+        from manus_agent.tools.scan_sbom import _request_with_retry
+
+        resp_400 = MagicMock()
+        resp_400.status_code = 400
+        mock_request.return_value = resp_400
+
+        result = _request_with_retry("GET", "http://example.com")
+        assert result.status_code == 400
+        assert mock_request.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Full scan integration tests (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestScanSbomFile:
+    """Test the scan_sbom_file orchestration function."""
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_scan_cyclonedx_full(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "pkg:pypi/requests@2.28.0",
+                "vulns": [
+                    {
+                        "id": "GHSA-j8r2-6x86-q33q",
+                        "aliases": ["CVE-2023-32681"],
+                        "summary": "Proxy leak",
+                        "severity": [],
+                    },
+                ],
+            }
+        ]
+        mock_epss.return_value = {"CVE-2023-32681": 0.05}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["format"] == "CycloneDX"
+        assert result["total_components"] == 3
+        assert result["vulnerable_components"] == 1
+        assert result["total_vulnerabilities"] == 1
+        assert result["findings"][0]["cve_id"] == "CVE-2023-32681"
+        assert result["findings"][0]["epss"] == 0.05
+        assert result["findings"][0]["in_kev"] is False
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_scan_kev_finding_ranked_first(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [
+                    {"id": "CVE-2023-32681", "aliases": [], "summary": "Proxy leak", "severity": []},
+                    {"id": "CVE-2021-23337", "aliases": [], "summary": "Command injection", "severity": []},
+                ],
+            }
+        ]
+        mock_epss.return_value = {"CVE-2023-32681": 0.9, "CVE-2021-23337": 0.1}
+        mock_kev.return_value = {"CVE-2021-23337"}
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        # KEV finding should come first despite lower EPSS
+        assert result["findings"][0]["cve_id"] == "CVE-2021-23337"
+        assert result["findings"][0]["in_kev"] is True
+        assert result["findings"][1]["cve_id"] == "CVE-2023-32681"
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_scan_no_vulnerabilities(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = []
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["vulnerable_components"] == 0
+        assert result["total_vulnerabilities"] == 0
+        assert result["findings"] == []
+
+    def test_scan_empty_sbom(self, empty_cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        result = scan_sbom_file(str(empty_cyclonedx_file))
+        assert result["total_components"] == 0
+        assert result["findings"] == []
+
+    def test_scan_file_not_found(self):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        with pytest.raises(FileNotFoundError):
+            scan_sbom_file("/nonexistent/bom.json")
+
+    def test_scan_invalid_json(self, invalid_json_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            scan_sbom_file(str(invalid_json_file))
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_scan_critical_count(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [
+                    {"id": "CVE-2023-0001", "aliases": [], "summary": "A", "severity": []},
+                    {"id": "CVE-2023-0002", "aliases": [], "summary": "B", "severity": []},
+                    {"id": "CVE-2023-0003", "aliases": [], "summary": "C", "severity": []},
+                ],
+            }
+        ]
+        # Only CVE-2023-0001 has high EPSS, CVE-2023-0002 is in KEV
+        mock_epss.return_value = {"CVE-2023-0001": 0.6, "CVE-2023-0002": 0.01, "CVE-2023-0003": 0.01}
+        mock_kev.return_value = {"CVE-2023-0002"}
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        # Critical: CVE-2023-0001 (EPSS >= 0.5) + CVE-2023-0002 (in KEV)
+        assert result["critical_count"] == 2
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_scan_deduplicates_vulns(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        # Same vuln reported by two different packages
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [{"id": "CVE-2023-0001", "aliases": [], "summary": "X", "severity": []}],
+            },
+            {
+                "ecosystem": "npm",
+                "name": "lodash",
+                "version": "4.17.20",
+                "purl": "",
+                "vulns": [{"id": "CVE-2023-0001", "aliases": [], "summary": "X", "severity": []}],
+            },
+        ]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["total_vulnerabilities"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolEntryPoint:
+    """Test the scan_sbom Strands tool function."""
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_success(self, mock_scan, cyclonedx_file):
+        from manus_agent.tools.scan_sbom import scan_sbom
+
+        mock_scan.return_value = {
+            "format": "CycloneDX",
+            "findings": [],
+            "total_components": 3,
+            "vulnerable_components": 0,
+            "total_vulnerabilities": 0,
+            "critical_count": 0,
+        }
+        tool_use = _mock_tool_use(str(cyclonedx_file))
+        result = scan_sbom(tool_use)
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-123"
+
+    def test_missing_file_path(self):
+        from manus_agent.tools.scan_sbom import scan_sbom
+
+        tool_use = {"toolUseId": "test-456", "input": {"file_path": ""}}
+        result = scan_sbom(tool_use)
+        assert result["status"] == "error"
+        assert "required" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_file_not_found_error(self, mock_scan):
+        from manus_agent.tools.scan_sbom import scan_sbom
+
+        mock_scan.side_effect = FileNotFoundError("SBOM file not found: /x.json")
+        tool_use = _mock_tool_use("/x.json")
+        result = scan_sbom(tool_use)
+        assert result["status"] == "error"
+        assert "not found" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_value_error(self, mock_scan):
+        from manus_agent.tools.scan_sbom import scan_sbom
+
+        mock_scan.side_effect = ValueError("Invalid JSON")
+        tool_use = _mock_tool_use("/bad.json")
+        result = scan_sbom(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid JSON" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_network_error(self, mock_scan):
+        import requests as req
+
+        from manus_agent.tools.scan_sbom import scan_sbom
+
+        mock_scan.side_effect = req.ConnectionError("timeout")
+        tool_use = _mock_tool_use("/bom.json")
+        result = scan_sbom(tool_use)
+        assert result["status"] == "error"
+        assert "Network error" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliSbomScan:
+    """Test manus-agent sbom-scan CLI subcommand."""
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_cli_json_output(self, mock_scan, cyclonedx_file, capsys):
+        from manus_agent.cli import _run_sbom_scan
+
+        mock_scan.return_value = {
+            "format": "CycloneDX",
+            "total_components": 3,
+            "vulnerable_components": 1,
+            "total_vulnerabilities": 2,
+            "critical_count": 1,
+            "findings": [
+                {
+                    "vuln_id": "CVE-2023-0001",
+                    "cve_id": "CVE-2023-0001",
+                    "aliases": [],
+                    "summary": "Test",
+                    "affected_package": "req",
+                    "affected_ecosystem": "PyPI",
+                    "affected_version": "2.28.0",
+                    "epss": 0.5,
+                    "in_kev": True,
+                    "cvss_vector": None,
+                },
+            ],
+        }
+        exit_code = _run_sbom_scan([str(cyclonedx_file), "--output", "json"])
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["critical_count"] == 1
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_cli_text_output_no_findings(self, mock_scan, cyclonedx_file):
+        from manus_agent.cli import _run_sbom_scan
+
+        mock_scan.return_value = {
+            "format": "CycloneDX",
+            "total_components": 3,
+            "vulnerable_components": 0,
+            "total_vulnerabilities": 0,
+            "critical_count": 0,
+            "findings": [],
+        }
+        exit_code = _run_sbom_scan([str(cyclonedx_file)])
+        assert exit_code == 0
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_cli_text_output_with_findings(self, mock_scan, cyclonedx_file):
+        from manus_agent.cli import _run_sbom_scan
+
+        mock_scan.return_value = {
+            "format": "CycloneDX",
+            "total_components": 3,
+            "vulnerable_components": 1,
+            "total_vulnerabilities": 1,
+            "critical_count": 0,
+            "findings": [
+                {
+                    "vuln_id": "GHSA-abc",
+                    "cve_id": "CVE-2023-0001",
+                    "aliases": [],
+                    "summary": "Short summary",
+                    "affected_package": "pkg",
+                    "affected_ecosystem": "npm",
+                    "affected_version": "1.0.0",
+                    "epss": 0.01,
+                    "in_kev": False,
+                    "cvss_vector": None,
+                },
+            ],
+        }
+        exit_code = _run_sbom_scan([str(cyclonedx_file)])
+        assert exit_code == 0
+
+    def test_cli_file_not_found(self, capsys):
+        from manus_agent.cli import _run_sbom_scan
+
+        exit_code = _run_sbom_scan(["/nonexistent/bom.json"])
+        assert exit_code == 1
+
+    def test_cli_no_args(self):
+        from manus_agent.cli import _run_sbom_scan
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_sbom_scan([])
+        assert exc_info.value.code == 2  # argparse error
+
+    @patch("manus_agent.tools.scan_sbom.scan_sbom_file")
+    def test_cli_invalid_json_file(self, mock_scan, invalid_json_file):
+        from manus_agent.cli import _run_sbom_scan
+
+        mock_scan.side_effect = ValueError("Invalid JSON in SBOM file")
+        exit_code = _run_sbom_scan([str(invalid_json_file)])
+        assert exit_code == 1
+
+    def test_cli_sbom_scan_in_subcommands(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "sbom-scan" in _SUBCOMMANDS
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_ghsa_alias_resolution(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        """GHSA IDs should resolve CVE from aliases for EPSS/KEV lookup."""
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [
+                    {"id": "GHSA-j8r2-6x86-q33q", "aliases": ["CVE-2023-32681"], "summary": "Leak", "severity": []},
+                ],
+            }
+        ]
+        mock_epss.return_value = {"CVE-2023-32681": 0.8}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["findings"][0]["cve_id"] == "CVE-2023-32681"
+        assert result["findings"][0]["epss"] == 0.8
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_vuln_without_cve_alias(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        """Vulns without any CVE alias should have empty cve_id and 0 EPSS."""
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "npm",
+                "name": "lodash",
+                "version": "4.17.20",
+                "purl": "",
+                "vulns": [
+                    {"id": "GHSA-xxxx-yyyy-zzzz", "aliases": ["GHSA-another"], "summary": "No CVE", "severity": []},
+                ],
+            }
+        ]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["findings"][0]["cve_id"] == ""
+        assert result["findings"][0]["epss"] == 0.0
+        assert result["findings"][0]["in_kev"] is False
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_cvss_vector_extraction(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        """CVSS vectors should be extracted from severity list."""
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [
+                    {
+                        "id": "CVE-2023-32681",
+                        "aliases": [],
+                        "summary": "Test",
+                        "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+                    },
+                ],
+            }
+        ]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert result["findings"][0]["cvss_vector"] == "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_summary_truncation(self, mock_osv, mock_epss, mock_kev, cyclonedx_file):
+        """Long summaries should be truncated to 200 chars."""
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        long_summary = "x" * 300
+        mock_osv.return_value = [
+            {
+                "ecosystem": "PyPI",
+                "name": "requests",
+                "version": "2.28.0",
+                "purl": "",
+                "vulns": [
+                    {"id": "CVE-2023-0001", "aliases": [], "summary": long_summary, "severity": []},
+                ],
+            }
+        ]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(cyclonedx_file))
+        assert len(result["findings"][0]["summary"]) == 200
+
+    @patch("manus_agent.tools.scan_sbom._fetch_kev_cve_set")
+    @patch("manus_agent.tools.scan_sbom._fetch_epss_scores")
+    @patch("manus_agent.tools.scan_sbom.query_osv_batch")
+    def test_spdx_scan(self, mock_osv, mock_epss, mock_kev, spdx_file):
+        """SPDX format should work end-to-end."""
+        from manus_agent.tools.scan_sbom import scan_sbom_file
+
+        mock_osv.return_value = [
+            {
+                "ecosystem": "npm",
+                "name": "axios",
+                "version": "1.6.0",
+                "purl": "pkg:npm/axios@1.6.0",
+                "vulns": [
+                    {"id": "CVE-2024-0001", "aliases": [], "summary": "SSRF", "severity": []},
+                ],
+            }
+        ]
+        mock_epss.return_value = {"CVE-2024-0001": 0.3}
+        mock_kev.return_value = set()
+
+        result = scan_sbom_file(str(spdx_file))
+        assert result["format"] == "SPDX"
+        assert result["total_components"] == 2
+        assert result["total_vulnerabilities"] == 1


### PR DESCRIPTION
## Summary

Implements the `manus-agent sbom-scan` CLI subcommand — documented in the README but previously unimplemented. This adds a complete SBOM vulnerability scanner that parses CycloneDX or SPDX JSON files, queries OSV.dev in batch for known vulnerabilities, enriches each finding with EPSS scores and CISA KEV membership, and ranks results by severity.

## What's included

### New tool: `src/manus_agent/tools/scan_sbom.py`
- **SBOM parsing**: CycloneDX JSON and SPDX JSON format detection and component extraction
- **PURL parsing**: Full Package URL support with 17 ecosystem mappings (npm, PyPI, Maven, Go, crates.io, NuGet, RubyGems, Packagist, etc.)
- **OSV.dev batch query**: Efficient batch vulnerability lookup (up to 1000 packages per request)
- **EPSS enrichment**: Fetches exploit prediction scores for all discovered CVEs
- **CISA KEV enrichment**: Checks all findings against the Known Exploited Vulnerabilities catalog
- **Ranking**: Results sorted by KEV membership first, then EPSS score descending
- **Retry/back-off**: Exponential back-off on all HTTP requests (429, 5xx), configurable via env vars
- **Graceful degradation**: EPSS and KEV enrichment failures don't break the scan
- **Strands TOOL_SPEC**: Full tool interface for agent use

### CLI subcommand: `manus-agent sbom-scan <bom-file>`
- `--output text` (default): Rich table with color-coded findings
- `--output json`: Machine-readable JSON with `critical_count`, all findings, and metadata
- Proper error handling for missing files, invalid JSON, unrecognised formats

### Test suite: `tests/test_scan_sbom.py` (+66 tests)
- TOOL_SPEC contract verification (4 tests)
- PURL parsing (14 tests) — all ecosystem types, qualifiers, edge cases
- SBOM parsing (10 tests) — CycloneDX, SPDX, fallbacks, error cases
- OSV batch query (4 tests) — payload construction, empty input, ecosystem handling
- EPSS enrichment (4 tests) — success, empty, graceful failure
- KEV enrichment (2 tests) — success, graceful failure
- Retry logic (3 tests) — 429 retry, network error, no-retry on 4xx
- Full scan integration (7 tests) — ranking, deduplication, critical count
- Strands tool entry point (4 tests) — success, missing input, errors
- CLI subcommand (7 tests) — JSON output, text output, argparse, error paths
- Edge cases (5 tests) — GHSA alias resolution, no-CVE vulns, CVSS extraction, truncation, SPDX end-to-end

All tests are 100% mocked — no real HTTP calls.

## Usage

```bash
# Text output with severity-ranked table
manus-agent sbom-scan bom.json

# JSON output for piping
manus-agent sbom-scan sbom.spdx.json --output json | jq .critical_count
```

## Open PRs checked (no overlap)

Reviewed all 50 open PRs (#135–#184). No existing open or merged PR implements `sbom-scan`:
- #183 (export_sarif) — SARIF export, not SBOM scanning
- #170 (cve-enrich) — single-CVE enrichment, not SBOM batch scanning
- #97 (merged, osv CLI) — single-CVE OSV lookup, not batch SBOM scanning
- #179 (watchlist) — CVE tracking, not SBOM scanning

## Test results

```
1224 passed, 3 deselected, 3 warnings in 25.66s
```

Zero new dependencies — uses only `requests` (already in project deps).
