### PR TITLE
feat(cli): add manus-agent poc-freshness subcommand for PoC activity recency scoring

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1055,6 +1055,7 @@ _SUBCOMMANDS = {
     "compare",
     "exploit-complexity",
     "poc-search",
+    "poc-freshness",
     "changelog",
     "blast-radius",
 }
@@ -1525,6 +1526,107 @@ def _run_poc_search(argv: list[str]) -> int:  # noqa: C901
         url = (r.get("url") or "")[:col_url]
         print(f"{src:<{col_src}}  {eaw_flag:<{col_eaw}}  {title:<{col_title}}  {date:<{col_date}}  {url}")
 
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# poc-freshness subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_poc_freshness_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent poc-freshness",
+        description=(
+            "Measure how recently PoC (proof-of-concept) activity occurred for a CVE.\n"
+            "Produces a 0-100 freshness score indicating ongoing attacker interest."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_poc_freshness(argv: list[str]) -> int:
+    parser = _build_poc_freshness_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip().upper()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.poc_freshness import (
+            _check_trickest,
+            _compute_freshness,
+            _count_nvd_exploit_refs,
+            _search_exploitdb,
+            _search_github_pocs,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import re as _re
+
+    if not _re.match(r"^CVE-\d{4}-\d+$", cve_id, _re.IGNORECASE):
+        print(f"[error] Invalid CVE ID format: {cve_id!r}", file=sys.stderr)
+        return 1
+
+    # Gather signals
+    try:
+        github_repos = _search_github_pocs(cve_id)
+    except Exception:
+        github_repos = []
+
+    try:
+        trickest = _check_trickest(cve_id)
+    except Exception:
+        trickest = {"found": False, "poc_count": 0}
+
+    try:
+        exploitdb_entries = _search_exploitdb(cve_id)
+    except Exception:
+        exploitdb_entries = []
+
+    try:
+        nvd_refs = _count_nvd_exploit_refs(cve_id)
+    except Exception:
+        nvd_refs = 0
+
+    result = _compute_freshness(github_repos, trickest, exploitdb_entries, nvd_refs)
+    result["cve_id"] = cve_id
+
+    if args.output == "json":
+        print(json.dumps(result, indent=2, default=str))
+        return 0
+
+    # Text output
+    score = result["freshness_score"]
+    classification = result["classification"]
+    print(f"PoC Freshness for {cve_id}")
+    print(f"  Freshness Score : {score}/100")
+    print(f"  Classification  : {classification}")
+    print()
+    print("Signal Breakdown:")
+    for sig in result["signals"]:
+        print(f"  [{sig['source']}] score={sig['score']:.1f} -- {sig['detail']}")
+    if not result["signals"]:
+        print("  (no PoC activity signals detected)")
+    print()
+    print("Summary:")
+    print(f"  GitHub PoC repos     : {result['github_repos_found']}")
+    print(f"  Exploit-DB entries   : {result['exploitdb_entries_found']}")
+    trickest_str = "Yes" if result["trickest_indexed"] else "No"
+    if result["trickest_indexed"]:
+        trickest_str += f" ({result['trickest_poc_count']} URLs)"
+    print(f"  trickest/cve indexed : {trickest_str}")
+    print(f"  NVD exploit refs     : {result['nvd_exploit_refs']}")
     return 0
 
 
@@ -2260,6 +2362,10 @@ def main() -> None:
     if first_positional == "poc-search":
         idx = argv.index("poc-search")
         sys.exit(_run_poc_search(argv[idx + 1 :]))
+
+    if first_positional == "poc-freshness":
+        idx = argv.index("poc-freshness")
+        sys.exit(_run_poc_freshness(argv[idx + 1 :]))
 
     if first_positional == "changelog":
         idx = argv.index("changelog")

--- a/src/manus_agent/tools/poc_freshness.py
+++ b/src/manus_agent/tools/poc_freshness.py
@@ -1,0 +1,437 @@
+"""
+Tool: poc_freshness
+
+Measures how recently proof-of-concept (PoC) activity occurred for a given
+CVE, producing a 0-100 freshness score. A high score means attacker interest
+is ongoing or very recent.
+
+Signals examined (all public, no authentication required by default):
+
+  1. GitHub PoC repos - last commit date, push recency, star recency
+  2. trickest/cve index - presence and number of known PoC links
+  3. Exploit-DB - publication date of matching entries (via CSV index)
+  4. NVD references - count of exploit-tagged references
+
+The score is an exponential decay function: activity today scores 100, activity
+one year ago scores near 0.  Multiple recent signals amplify the score.
+
+CLI: ``manus-agent poc-freshness CVE-XXXX-YYYY``
+"""
+
+from __future__ import annotations
+
+import csv
+import logging
+import math
+import os
+import re
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timezone
+from typing import Any
+
+from strands import tool
+
+__all__ = ["poc_freshness"]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-(\d{4})-\d+$", re.IGNORECASE)
+_GITHUB_API = "https://api.github.com"
+_TRICKEST_RAW = "https://raw.githubusercontent.com/trickest/cve/main/{year}/{cve_id}.md"
+_EXPLOITDB_CACHE = "/tmp/exploitdb_cache.csv"
+_EXPLOITDB_CSV_URL = "https://gitlab.com/exploit-database/exploitdb/-/raw/main/files_exploits.csv"
+_EXPLOITDB_CACHE_TTL = 86_400  # 24h
+_NVD_API = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_REQUEST_TIMEOUT = 15
+_HALF_LIFE_DAYS = 60  # activity half-life for decay scoring
+_URL_RE = re.compile(r"https?://\S+")
+
+# ---------------------------------------------------------------------------
+# HTTP helper
+# ---------------------------------------------------------------------------
+
+
+def _http_get_json(url: str, headers: dict[str, str] | None = None) -> Any:
+    """Minimal HTTP GET returning parsed JSON."""
+    import json as _json
+
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+        return _json.loads(resp.read().decode())
+
+
+def _http_get_text(url: str, headers: dict[str, str] | None = None) -> str:
+    """HTTP GET returning text."""
+    req = urllib.request.Request(url, headers=headers or {})
+    with urllib.request.urlopen(req, timeout=_REQUEST_TIMEOUT) as resp:
+        return resp.read().decode()
+
+
+# ---------------------------------------------------------------------------
+# Decay scoring
+# ---------------------------------------------------------------------------
+
+
+def _days_ago(date_str: str) -> float:
+    """Parse an ISO-ish date string and return days from now."""
+    date_str = date_str.replace("Z", "+00:00")
+    try:
+        dt = datetime.fromisoformat(date_str)
+    except ValueError:
+        # Try date-only
+        dt = datetime.strptime(date_str[:10], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    delta = (now - dt).total_seconds() / 86400
+    return max(delta, 0)
+
+
+def _decay_score(days: float) -> float:
+    """Exponential decay: 100 for today, ~50 at half-life, asymptotic to 0."""
+    return 100.0 * math.exp(-0.693 * days / _HALF_LIFE_DAYS)
+
+
+# ---------------------------------------------------------------------------
+# Signal 1: GitHub PoC repos
+# ---------------------------------------------------------------------------
+
+
+def _search_github_pocs(cve_id: str) -> list[dict]:
+    """Search GitHub for repos matching the CVE ID; return freshness signals."""
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    token = os.environ.get("GITHUB_TOKEN", "")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    query = urllib.parse.quote(f"{cve_id} poc OR exploit OR proof-of-concept")
+    url = f"{_GITHUB_API}/search/repositories?q={query}&sort=updated&per_page=10"
+
+    try:
+        data = _http_get_json(url, headers)
+    except Exception as exc:
+        logger.debug("GitHub search failed: %s", exc)
+        return []
+
+    results = []
+    for repo in data.get("items", [])[:10]:
+        pushed_at = repo.get("pushed_at", "")
+        created_at = repo.get("created_at", "")
+        stars = repo.get("stargazers_count", 0)
+        results.append(
+            {
+                "name": repo.get("full_name", ""),
+                "url": repo.get("html_url", ""),
+                "pushed_at": pushed_at,
+                "created_at": created_at,
+                "stars": stars,
+                "days_since_push": _days_ago(pushed_at) if pushed_at else 9999,
+                "days_since_create": _days_ago(created_at) if created_at else 9999,
+            }
+        )
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Signal 2: trickest/cve
+# ---------------------------------------------------------------------------
+
+
+def _check_trickest(cve_id: str) -> dict:
+    """Check trickest/cve for PoC links count."""
+    match = _CVE_RE.match(cve_id)
+    if not match:
+        return {"found": False, "poc_count": 0}
+    year = match.group(1)
+    url = _TRICKEST_RAW.format(year=year, cve_id=cve_id.upper())
+    try:
+        md = _http_get_text(url)
+    except Exception:
+        return {"found": False, "poc_count": 0}
+
+    urls = _URL_RE.findall(md)
+    return {"found": True, "poc_count": len(set(urls))}
+
+
+# ---------------------------------------------------------------------------
+# Signal 3: Exploit-DB CSV
+# ---------------------------------------------------------------------------
+
+
+def _ensure_exploitdb_csv() -> str | None:
+    """Download/cache Exploit-DB CSV; return path or None on failure."""
+    if os.path.isfile(_EXPLOITDB_CACHE):
+        age = time.time() - os.path.getmtime(_EXPLOITDB_CACHE)
+        if age < _EXPLOITDB_CACHE_TTL:
+            return _EXPLOITDB_CACHE
+    try:
+        req = urllib.request.Request(
+            _EXPLOITDB_CSV_URL,
+            headers={"User-Agent": "manus-agent/poc-freshness"},
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read()
+        with open(_EXPLOITDB_CACHE, "wb") as f:
+            f.write(data)
+        return _EXPLOITDB_CACHE
+    except Exception as exc:
+        logger.debug("Exploit-DB CSV fetch failed: %s", exc)
+        return None
+
+
+def _search_exploitdb(cve_id: str) -> list[dict]:
+    """Search cached Exploit-DB CSV for CVE matches."""
+    csv_path = _ensure_exploitdb_csv()
+    if not csv_path:
+        return []
+
+    results = []
+    cve_upper = cve_id.upper()
+    try:
+        with open(csv_path, encoding="utf-8", errors="replace") as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                codes = row.get("codes", "")
+                if cve_upper in codes.upper():
+                    date_published = row.get("date_published", "")
+                    results.append(
+                        {
+                            "edb_id": row.get("id", ""),
+                            "description": row.get("description", "")[:120],
+                            "date_published": date_published,
+                            "days_since_publish": (_days_ago(date_published) if date_published else 9999),
+                        }
+                    )
+    except Exception as exc:
+        logger.debug("Exploit-DB CSV parse failed: %s", exc)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Signal 4: NVD exploit references
+# ---------------------------------------------------------------------------
+
+
+def _count_nvd_exploit_refs(cve_id: str) -> int:
+    """Count NVD references tagged as exploit/third-party-advisory."""
+    url = f"{_NVD_API}?cveId={cve_id.upper()}"
+    headers = {"User-Agent": "manus-agent/poc-freshness"}
+    api_key = os.environ.get("NVD_API_KEY", "")
+    if api_key:
+        headers["apiKey"] = api_key
+    try:
+        data = _http_get_json(url, headers)
+    except Exception as exc:
+        logger.debug("NVD API failed: %s", exc)
+        return 0
+
+    count = 0
+    for vuln in data.get("vulnerabilities", []):
+        cve_obj = vuln.get("cve", {})
+        for ref in cve_obj.get("references", []):
+            tags = ref.get("tags", [])
+            if any(t.lower() in ("exploit", "third party advisory") for t in tags):
+                count += 1
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Composite scoring
+# ---------------------------------------------------------------------------
+
+
+def _compute_freshness(
+    github_repos: list[dict],
+    trickest: dict,
+    exploitdb_entries: list[dict],
+    nvd_exploit_refs: int,
+) -> dict:
+    """Compute composite freshness score and breakdown."""
+    signals: list[dict] = []
+
+    # GitHub: score from most recently pushed repo
+    if github_repos:
+        best = min(github_repos, key=lambda r: r["days_since_push"])
+        gh_score = _decay_score(best["days_since_push"])
+        signals.append(
+            {
+                "source": "github_poc_repos",
+                "score": gh_score,
+                "detail": (
+                    f"{len(github_repos)} repos found; "
+                    f"most recent push {best['days_since_push']:.0f}d ago "
+                    f"({best['name']})"
+                ),
+            }
+        )
+
+        # Bonus for newly-created repos (last 30 days)
+        new_repos = [r for r in github_repos if r["days_since_create"] < 30]
+        if new_repos:
+            newest = min(new_repos, key=lambda r: r["days_since_create"])
+            bonus = _decay_score(newest["days_since_create"]) * 0.5
+            signals.append(
+                {
+                    "source": "github_new_repo",
+                    "score": bonus,
+                    "detail": (
+                        f"{len(new_repos)} repo(s) created in last 30d; "
+                        f"newest {newest['days_since_create']:.0f}d ago "
+                        f"({newest['name']})"
+                    ),
+                }
+            )
+
+        # Star signal: high stars = ongoing community interest
+        max_stars = max(r["stars"] for r in github_repos)
+        if max_stars >= 50:
+            star_bonus = min(30.0, max_stars / 10.0)
+            signals.append(
+                {
+                    "source": "github_stars",
+                    "score": star_bonus,
+                    "detail": f"Top repo has {max_stars} stars (ongoing interest)",
+                }
+            )
+
+    # trickest: presence + density bonus
+    if trickest["found"]:
+        poc_count = trickest["poc_count"]
+        trickest_score = min(40.0, 15.0 + poc_count * 3)
+        signals.append(
+            {
+                "source": "trickest_cve_index",
+                "score": trickest_score,
+                "detail": f"{poc_count} PoC URLs indexed in trickest/cve",
+            }
+        )
+
+    # Exploit-DB: most recent publication
+    if exploitdb_entries:
+        best_edb = min(exploitdb_entries, key=lambda e: e["days_since_publish"])
+        edb_score = _decay_score(best_edb["days_since_publish"])
+        signals.append(
+            {
+                "source": "exploit_db",
+                "score": edb_score,
+                "detail": (
+                    f"{len(exploitdb_entries)} entries; "
+                    f"newest {best_edb['days_since_publish']:.0f}d ago "
+                    f"(EDB-{best_edb['edb_id']})"
+                ),
+            }
+        )
+
+    # NVD exploit references: presence signal
+    if nvd_exploit_refs > 0:
+        nvd_score = min(25.0, 10.0 + nvd_exploit_refs * 3)
+        signals.append(
+            {
+                "source": "nvd_exploit_refs",
+                "score": nvd_score,
+                "detail": f"{nvd_exploit_refs} exploit-tagged NVD references",
+            }
+        )
+
+    # Composite: weighted geometric-ish blend capped at 100
+    if not signals:
+        freshness_score = 0.0
+    else:
+        # Take the max signal as base, add diminishing returns from others
+        sorted_scores = sorted((s["score"] for s in signals), reverse=True)
+        composite = sorted_scores[0]
+        for i, s in enumerate(sorted_scores[1:], start=1):
+            composite += s * (0.5**i)
+        freshness_score = min(100.0, composite)
+
+    # Classification
+    if freshness_score >= 80:
+        classification = "CRITICAL - Active, very recent PoC activity"
+    elif freshness_score >= 60:
+        classification = "HIGH - Recent PoC activity (last few weeks)"
+    elif freshness_score >= 40:
+        classification = "MODERATE - PoC activity within last few months"
+    elif freshness_score >= 20:
+        classification = "LOW - Stale PoC activity (several months old)"
+    else:
+        classification = "MINIMAL - No recent PoC activity detected"
+
+    return {
+        "freshness_score": round(freshness_score, 1),
+        "classification": classification,
+        "signals": signals,
+        "github_repos_found": len(github_repos),
+        "exploitdb_entries_found": len(exploitdb_entries),
+        "trickest_indexed": trickest["found"],
+        "trickest_poc_count": trickest.get("poc_count", 0),
+        "nvd_exploit_refs": nvd_exploit_refs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Main tool
+# ---------------------------------------------------------------------------
+
+
+@tool
+def poc_freshness(cve_id: str) -> str:
+    """Measure how recently PoC (proof-of-concept) activity occurred for a CVE.
+
+    Produces a 0-100 freshness score based on: last commit recency in known PoC
+    repos, recently-starred/created repositories, new Exploit-DB entries, and
+    trickest/cve index presence.  A high freshness score means attacker interest
+    is ongoing.
+
+    Args:
+        cve_id: CVE identifier, e.g. "CVE-2024-3094".
+
+    Returns:
+        Formatted freshness report with score, classification, and signal breakdown.
+    """
+
+    cve_id = cve_id.strip().upper()
+    if not _CVE_RE.match(cve_id):
+        return f"Invalid CVE ID format: {cve_id!r}. Expected CVE-YYYY-NNNNN."
+
+    # Gather signals (best-effort, never fatal)
+    github_repos = _search_github_pocs(cve_id)
+    trickest = _check_trickest(cve_id)
+    exploitdb_entries = _search_exploitdb(cve_id)
+    nvd_refs = _count_nvd_exploit_refs(cve_id)
+
+    result = _compute_freshness(github_repos, trickest, exploitdb_entries, nvd_refs)
+    result["cve_id"] = cve_id
+
+    # Format as readable report
+    lines = [
+        f"## PoC Freshness Report: {cve_id}",
+        "",
+        f"**Freshness Score:** {result['freshness_score']}/100",
+        f"**Classification:** {result['classification']}",
+        "",
+        "### Signal Breakdown",
+    ]
+    for sig in result["signals"]:
+        lines.append(f"  - [{sig['source']}] score={sig['score']:.1f} -- {sig['detail']}")
+
+    if not result["signals"]:
+        lines.append("  (no PoC activity signals detected)")
+
+    lines += [
+        "",
+        "### Summary",
+        f"  GitHub PoC repos: {result['github_repos_found']}",
+        f"  Exploit-DB entries: {result['exploitdb_entries_found']}",
+        f"  trickest/cve indexed: {'Yes' if result['trickest_indexed'] else 'No'}"
+        + (f" ({result['trickest_poc_count']} URLs)" if result["trickest_indexed"] else ""),
+        f"  NVD exploit refs: {result['nvd_exploit_refs']}",
+    ]
+
+    return "\n".join(lines)

--- a/tests/test_cli_poc_freshness.py
+++ b/tests/test_cli_poc_freshness.py
@@ -1,0 +1,601 @@
+"""Comprehensive tests for poc-freshness CLI subcommand and poc_freshness tool."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+from manus_agent.tools.poc_freshness import (
+    _check_trickest,
+    _compute_freshness,
+    _count_nvd_exploit_refs,
+    _days_ago,
+    _decay_score,
+    _search_exploitdb,
+    _search_github_pocs,
+)
+
+# ---------------------------------------------------------------------------
+# Unit tests for decay scoring
+# ---------------------------------------------------------------------------
+
+
+class TestDecayScore:
+    """Tests for the exponential decay scoring function."""
+
+    def test_today_scores_100(self):
+        assert _decay_score(0) == pytest.approx(100.0)
+
+    def test_half_life_scores_50(self):
+        score = _decay_score(60)  # _HALF_LIFE_DAYS = 60
+        assert score == pytest.approx(50.0, rel=0.01)
+
+    def test_very_old_approaches_zero(self):
+        score = _decay_score(365)
+        assert score < 2.0
+
+    def test_one_week_still_high(self):
+        score = _decay_score(7)
+        assert score > 90.0
+
+    def test_one_month_moderate(self):
+        score = _decay_score(30)
+        assert 60.0 < score < 80.0
+
+
+class TestDaysAgo:
+    """Tests for date parsing and days-ago calculation."""
+
+    def test_iso_with_z(self):
+        # A date in the past should return positive days
+        days = _days_ago("2020-01-01T00:00:00Z")
+        assert days > 365
+
+    def test_iso_with_offset(self):
+        days = _days_ago("2020-06-15T12:00:00+00:00")
+        assert days > 365
+
+    def test_date_only(self):
+        days = _days_ago("2020-01-01")
+        assert days > 365
+
+    def test_future_returns_zero(self):
+        # If somehow a date is in the future, clamp to 0
+        days = _days_ago("2099-01-01T00:00:00Z")
+        assert days == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for individual signal gatherers (mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestSearchGithubPocs:
+    """Tests for GitHub PoC repo search."""
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_returns_repos(self, mock_get):
+        mock_get.return_value = {
+            "items": [
+                {
+                    "full_name": "attacker/CVE-2024-3094-poc",
+                    "html_url": "https://github.com/attacker/CVE-2024-3094-poc",
+                    "pushed_at": "2026-07-18T10:00:00Z",
+                    "created_at": "2026-07-15T10:00:00Z",
+                    "stargazers_count": 42,
+                }
+            ]
+        }
+        result = _search_github_pocs("CVE-2024-3094")
+        assert len(result) == 1
+        assert result[0]["name"] == "attacker/CVE-2024-3094-poc"
+        assert result[0]["stars"] == 42
+        assert result[0]["days_since_push"] >= 0
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_empty_results(self, mock_get):
+        mock_get.return_value = {"items": []}
+        result = _search_github_pocs("CVE-2099-9999")
+        assert result == []
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("rate limited")
+        result = _search_github_pocs("CVE-2024-3094")
+        assert result == []
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_missing_fields_handled(self, mock_get):
+        mock_get.return_value = {
+            "items": [
+                {
+                    "full_name": "test/repo",
+                    "html_url": "https://github.com/test/repo",
+                    "pushed_at": "",
+                    "created_at": "",
+                    "stargazers_count": 0,
+                }
+            ]
+        }
+        result = _search_github_pocs("CVE-2024-1234")
+        assert len(result) == 1
+        assert result[0]["days_since_push"] == 9999
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_respects_per_page_limit(self, mock_get):
+        items = [
+            {
+                "full_name": f"user/repo-{i}",
+                "html_url": f"https://github.com/user/repo-{i}",
+                "pushed_at": "2026-07-01T00:00:00Z",
+                "created_at": "2026-06-01T00:00:00Z",
+                "stargazers_count": i,
+            }
+            for i in range(15)
+        ]
+        mock_get.return_value = {"items": items}
+        result = _search_github_pocs("CVE-2024-3094")
+        assert len(result) == 10  # capped at 10
+
+
+class TestCheckTrickest:
+    """Tests for trickest/cve index check."""
+
+    @patch("manus_agent.tools.poc_freshness._http_get_text")
+    def test_found_with_pocs(self, mock_get):
+        mock_get.return_value = "### POC\n#### Github\n- https://github.com/user/poc1\n- https://github.com/user/poc2\n"
+        result = _check_trickest("CVE-2024-3094")
+        assert result["found"] is True
+        assert result["poc_count"] == 2
+
+    @patch("manus_agent.tools.poc_freshness._http_get_text")
+    def test_not_found(self, mock_get):
+        mock_get.side_effect = Exception("404")
+        result = _check_trickest("CVE-2099-9999")
+        assert result["found"] is False
+        assert result["poc_count"] == 0
+
+    def test_invalid_cve_format(self):
+        result = _check_trickest("not-a-cve")
+        assert result["found"] is False
+
+
+class TestSearchExploitdb:
+    """Tests for Exploit-DB CSV search."""
+
+    @patch("manus_agent.tools.poc_freshness._ensure_exploitdb_csv")
+    def test_csv_unavailable(self, mock_ensure):
+        mock_ensure.return_value = None
+        result = _search_exploitdb("CVE-2024-3094")
+        assert result == []
+
+    @patch("manus_agent.tools.poc_freshness._ensure_exploitdb_csv")
+    def test_finds_matching_entries(self, mock_ensure, tmp_path):
+        csv_file = tmp_path / "exploits.csv"
+        csv_file.write_text(
+            "id,description,date_published,codes\n"
+            "51234,XSS in Foo,2026-07-10,CVE-2024-3094;OSVDB-12345\n"
+            "51235,SQLi in Bar,2026-06-01,CVE-2024-9999\n"
+        )
+        mock_ensure.return_value = str(csv_file)
+        result = _search_exploitdb("CVE-2024-3094")
+        assert len(result) == 1
+        assert result[0]["edb_id"] == "51234"
+
+    @patch("manus_agent.tools.poc_freshness._ensure_exploitdb_csv")
+    def test_no_match(self, mock_ensure, tmp_path):
+        csv_file = tmp_path / "exploits.csv"
+        csv_file.write_text("id,description,date_published,codes\n51235,SQLi in Bar,2026-06-01,CVE-2024-9999\n")
+        mock_ensure.return_value = str(csv_file)
+        result = _search_exploitdb("CVE-2024-3094")
+        assert result == []
+
+
+class TestCountNvdExploitRefs:
+    """Tests for NVD exploit reference counting."""
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_counts_exploit_tags(self, mock_get):
+        mock_get.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "references": [
+                            {"url": "https://example.com/poc", "tags": ["Exploit"]},
+                            {"url": "https://nvd.nist.gov", "tags": ["Vendor Advisory"]},
+                            {"url": "https://exploit-db.com/1234", "tags": ["Third Party Advisory", "Exploit"]},
+                        ]
+                    }
+                }
+            ]
+        }
+        count = _count_nvd_exploit_refs("CVE-2024-3094")
+        assert count == 2
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_no_exploit_refs(self, mock_get):
+        mock_get.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "references": [
+                            {"url": "https://nvd.nist.gov", "tags": ["Vendor Advisory"]},
+                        ]
+                    }
+                }
+            ]
+        }
+        count = _count_nvd_exploit_refs("CVE-2024-3094")
+        assert count == 0
+
+    @patch("manus_agent.tools.poc_freshness._http_get_json")
+    def test_api_failure(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        count = _count_nvd_exploit_refs("CVE-2024-3094")
+        assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for composite scoring
+# ---------------------------------------------------------------------------
+
+
+class TestComputeFreshness:
+    """Tests for the composite freshness scoring algorithm."""
+
+    def test_no_signals_scores_zero(self):
+        result = _compute_freshness([], {"found": False, "poc_count": 0}, [], 0)
+        assert result["freshness_score"] == 0.0
+        assert result["classification"] == "MINIMAL - No recent PoC activity detected"
+
+    def test_recent_github_activity_scores_high(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "https://github.com/test/poc",
+                "pushed_at": "2026-07-19T00:00:00Z",
+                "created_at": "2026-07-19T00:00:00Z",
+                "stars": 10,
+                "days_since_push": 1,
+                "days_since_create": 1,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert result["freshness_score"] > 80
+
+    def test_old_activity_scores_low(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "https://github.com/test/poc",
+                "pushed_at": "2025-01-01T00:00:00Z",
+                "created_at": "2024-06-01T00:00:00Z",
+                "stars": 5,
+                "days_since_push": 500,
+                "days_since_create": 700,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert result["freshness_score"] < 20
+
+    def test_multiple_signals_amplify(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "https://github.com/test/poc",
+                "pushed_at": "2026-07-15T00:00:00Z",
+                "created_at": "2026-07-10T00:00:00Z",
+                "stars": 100,
+                "days_since_push": 5,
+                "days_since_create": 10,
+            }
+        ]
+        trickest = {"found": True, "poc_count": 8}
+        edb = [{"edb_id": "123", "description": "test", "date_published": "2026-07-10", "days_since_publish": 10}]
+        result = _compute_freshness(repos, trickest, edb, 5)
+        assert result["freshness_score"] > 90
+
+    def test_trickest_only(self):
+        result = _compute_freshness([], {"found": True, "poc_count": 3}, [], 0)
+        assert result["freshness_score"] > 0
+        assert any(s["source"] == "trickest_cve_index" for s in result["signals"])
+
+    def test_exploitdb_only(self):
+        edb = [{"edb_id": "999", "description": "test", "date_published": "2026-07-01", "days_since_publish": 19}]
+        result = _compute_freshness([], {"found": False, "poc_count": 0}, edb, 0)
+        assert result["freshness_score"] > 0
+        assert any(s["source"] == "exploit_db" for s in result["signals"])
+
+    def test_nvd_only(self):
+        result = _compute_freshness([], {"found": False, "poc_count": 0}, [], 5)
+        assert result["freshness_score"] > 0
+        assert any(s["source"] == "nvd_exploit_refs" for s in result["signals"])
+
+    def test_score_capped_at_100(self):
+        # Extreme signals should not exceed 100
+        repos = [
+            {
+                "name": f"test/poc-{i}",
+                "url": f"https://github.com/test/poc-{i}",
+                "pushed_at": "2026-07-20T00:00:00Z",
+                "created_at": "2026-07-20T00:00:00Z",
+                "stars": 500,
+                "days_since_push": 0,
+                "days_since_create": 0,
+            }
+            for i in range(10)
+        ]
+        trickest = {"found": True, "poc_count": 20}
+        edb = [{"edb_id": "1", "description": "x", "date_published": "2026-07-20", "days_since_publish": 0}]
+        result = _compute_freshness(repos, trickest, edb, 10)
+        assert result["freshness_score"] <= 100.0
+
+    def test_classification_critical(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "now",
+                "created_at": "now",
+                "stars": 200,
+                "days_since_push": 0,
+                "days_since_create": 0,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": True, "poc_count": 10}, [], 5)
+        assert "CRITICAL" in result["classification"]
+
+    def test_classification_high(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "x",
+                "created_at": "x",
+                "stars": 10,
+                "days_since_push": 14,
+                "days_since_create": 60,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": True, "poc_count": 3}, [], 0)
+        assert "HIGH" in result["classification"] or "CRITICAL" in result["classification"]
+
+    def test_star_bonus_threshold(self):
+        # Stars < 50 should not produce github_stars signal
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "x",
+                "created_at": "x",
+                "stars": 49,
+                "days_since_push": 5,
+                "days_since_create": 100,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert not any(s["source"] == "github_stars" for s in result["signals"])
+
+    def test_star_bonus_above_threshold(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "x",
+                "created_at": "x",
+                "stars": 100,
+                "days_since_push": 5,
+                "days_since_create": 100,
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert any(s["source"] == "github_stars" for s in result["signals"])
+
+    def test_new_repo_bonus(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "x",
+                "created_at": "x",
+                "stars": 5,
+                "days_since_push": 2,
+                "days_since_create": 2,  # < 30 days
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert any(s["source"] == "github_new_repo" for s in result["signals"])
+
+    def test_no_new_repo_bonus_when_old(self):
+        repos = [
+            {
+                "name": "test/poc",
+                "url": "u",
+                "pushed_at": "x",
+                "created_at": "x",
+                "stars": 5,
+                "days_since_push": 5,
+                "days_since_create": 60,  # > 30 days
+            }
+        ]
+        result = _compute_freshness(repos, {"found": False, "poc_count": 0}, [], 0)
+        assert not any(s["source"] == "github_new_repo" for s in result["signals"])
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliPocFreshness:
+    """Tests for the manus-agent poc-freshness CLI subcommand."""
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_text_output(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        mock_gh.return_value = [
+            {
+                "name": "attacker/poc",
+                "url": "https://github.com/attacker/poc",
+                "pushed_at": "2026-07-18T00:00:00Z",
+                "created_at": "2026-07-15T00:00:00Z",
+                "stars": 25,
+                "days_since_push": 2,
+                "days_since_create": 5,
+            }
+        ]
+        mock_tr.return_value = {"found": True, "poc_count": 4}
+        mock_edb.return_value = []
+        mock_nvd.return_value = 2
+
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Freshness Score" in out
+        assert "CVE-2024-3094" in out
+        assert "Classification" in out
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_json_output(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        mock_gh.return_value = []
+        mock_tr.return_value = {"found": True, "poc_count": 2}
+        mock_edb.return_value = []
+        mock_nvd.return_value = 0
+
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert "freshness_score" in data
+        assert "classification" in data
+        assert "signals" in data
+        assert data["cve_id"] == "CVE-2024-3094"
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_invalid_cve_format(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["not-a-cve"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Invalid CVE ID" in err
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_all_signals_fail_gracefully(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        mock_gh.side_effect = Exception("network error")
+        mock_tr.side_effect = Exception("network error")
+        mock_edb.side_effect = Exception("network error")
+        mock_nvd.side_effect = Exception("network error")
+
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["CVE-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "0.0/100" in out or "0/100" in out
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_case_insensitive_cve(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        mock_gh.return_value = []
+        mock_tr.return_value = {"found": False, "poc_count": 0}
+        mock_edb.return_value = []
+        mock_nvd.return_value = 0
+
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["cve-2024-3094"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "CVE-2024-3094" in out
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_json_output_structure(self, mock_gh, mock_tr, mock_edb, mock_nvd, capsys):
+        mock_gh.return_value = [
+            {
+                "name": "user/exploit",
+                "url": "https://github.com/user/exploit",
+                "pushed_at": "2026-07-10T00:00:00Z",
+                "created_at": "2026-06-01T00:00:00Z",
+                "stars": 75,
+                "days_since_push": 10,
+                "days_since_create": 49,
+            }
+        ]
+        mock_tr.return_value = {"found": True, "poc_count": 5}
+        mock_edb.return_value = [
+            {"edb_id": "55555", "description": "PoC", "date_published": "2026-07-05", "days_since_publish": 15}
+        ]
+        mock_nvd.return_value = 3
+
+        from manus_agent.cli import _run_poc_freshness
+
+        rc = _run_poc_freshness(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert isinstance(data["freshness_score"], (int, float))
+        assert isinstance(data["signals"], list)
+        assert data["github_repos_found"] == 1
+        assert data["exploitdb_entries_found"] == 1
+        assert data["trickest_indexed"] is True
+        assert data["trickest_poc_count"] == 5
+        assert data["nvd_exploit_refs"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Tool function tests
+# ---------------------------------------------------------------------------
+
+
+class TestPocFreshnessTool:
+    """Tests for the @tool decorated poc_freshness function."""
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_invalid_cve(self, mock_gh, mock_tr, mock_edb, mock_nvd):
+        from manus_agent.tools.poc_freshness import poc_freshness
+
+        # Call the underlying function directly
+        result = poc_freshness._tool_func(cve_id="invalid")
+        assert "Invalid CVE ID" in result
+
+    @patch("manus_agent.tools.poc_freshness._count_nvd_exploit_refs")
+    @patch("manus_agent.tools.poc_freshness._search_exploitdb")
+    @patch("manus_agent.tools.poc_freshness._check_trickest")
+    @patch("manus_agent.tools.poc_freshness._search_github_pocs")
+    def test_valid_cve_returns_report(self, mock_gh, mock_tr, mock_edb, mock_nvd):
+        mock_gh.return_value = []
+        mock_tr.return_value = {"found": False, "poc_count": 0}
+        mock_edb.return_value = []
+        mock_nvd.return_value = 0
+
+        from manus_agent.tools.poc_freshness import poc_freshness
+
+        # Call the underlying function directly
+        result = poc_freshness._tool_func(cve_id="CVE-2024-3094")
+        assert "Freshness Score" in result
+        assert "CVE-2024-3094" in result


### PR DESCRIPTION
## Summary

Implements the `manus-agent poc-freshness` CLI subcommand, which was **documented in the README** (usage examples, flag table) but had **zero implementation** — no tool module, no CLI wiring.

## What it does

`poc-freshness` measures how recently proof-of-concept (PoC) activity occurred for a given CVE, producing a **0–100 freshness score**. A high score means attacker interest is ongoing or very recent.

```bash
manus-agent poc-freshness CVE-2024-3094
manus-agent poc-freshness CVE-2024-3094 --output json | jq .freshness_score
```

### Signals examined (all public, best-effort):

| Signal | What it measures |
|--------|-----------------|
| GitHub PoC repos | Last push recency, new repo creation, star count |
| trickest/cve index | Presence and density of indexed PoC URLs |
| Exploit-DB | Publication date of matching entries (via CSV index) |
| NVD references | Count of exploit-tagged references |

### Scoring algorithm

- Exponential decay function: activity today = 100, activity at half-life (60d) ≈ 50, asymptotic to 0
- Composite score: max signal as base + diminishing returns from additional signals
- Classification bands: CRITICAL (80+), HIGH (60+), MODERATE (40+), LOW (20+), MINIMAL (<20)

## Files changed

- `src/manus_agent/tools/poc_freshness.py` — new tool module (~350 lines)
- `src/manus_agent/cli.py` — parser, runner, `_SUBCOMMANDS`, dispatch wiring (+100 lines)
- `tests/test_cli_poc_freshness.py` — 45 fully-mocked tests covering:
  - Decay scoring math
  - Date parsing edge cases
  - Each signal gatherer (GitHub, trickest, Exploit-DB, NVD) with mocked HTTP
  - Composite scoring algorithm (all classification bands, cap at 100, bonus signals)
  - CLI text and JSON output formats
  - Graceful degradation when all signals fail
  - Case-insensitive CVE input
  - Tool function direct invocation

## Test results

```
1203 passed, 3 deselected, 3 warnings in 25.48s
```

(Baseline 1158 + 45 new = 1203, 0 failures)

## Duplicate check

Confirmed NO overlap with existing open or merged PRs:
- PR #127 (`exploit-search`) — different tool (searches exploit databases, not freshness scoring)
- PR #131 (`poc-week`) — different tool (weekly trending digest, not per-CVE freshness)
- PR #60 (merged, `poc-freshness` not in title — was `search_poc_sources` / `poc-search`)
- Scanned all 49 open PRs (#67–#133) and 30 most recent merged PRs — none implement `poc-freshness`
- The README documents `poc-freshness` as a distinct subcommand separate from `poc-search`
