### PR TITLE
feat(cli): add manus-agent silent-patches subcommand for silent patch detection

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "silent-patches",
 }
 
 
@@ -1802,6 +1803,106 @@ def _build_blast_radius_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _run_silent_patches(argv: list[str]) -> int:
+    import json as _json
+
+    parser = argparse.ArgumentParser(
+        prog="manus-agent silent-patches",
+        description="Detect silently patched security fixes in a GitHub repository.",
+    )
+    parser.add_argument("repo", help="GitHub repository in owner/repo format")
+    parser.add_argument(
+        "--since",
+        default=None,
+        help="Start date for commit scan (YYYY-MM-DD, default: 90 days ago)",
+    )
+    parser.add_argument(
+        "--until",
+        default=None,
+        help="End date for commit scan (YYYY-MM-DD, default: today)",
+    )
+    parser.add_argument(
+        "--max-commits",
+        type=int,
+        default=500,
+        help="Hard limit on commits fetched (default: 500)",
+    )
+    parser.add_argument(
+        "--fast",
+        action="store_true",
+        help="Skip diff scoring (message keywords only)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.detect_silent_patches import detect_silent_patches
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        candidates = detect_silent_patches(
+            args.repo,
+            since=args.since,
+            until=args.until,
+            max_commits=args.max_commits,
+            fast=args.fast,
+        )
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        # Strip full_message from JSON output to keep it concise
+        output_data = []
+        for c in candidates:
+            entry = {k: v for k, v in c.items() if k != "full_message"}
+            output_data.append(entry)
+        print(_json.dumps(output_data, indent=2))
+        return 0
+
+    # Text output
+    print()
+    print(f"Silent Patch Detector — {args.repo}")
+    print("=" * 60)
+    print(f"Scan window: {args.since or '(90 days ago)'} → {args.until or '(today)'}")
+    print(f"Mode: {'fast (message only)' if args.fast else 'full (message + diff)'}")
+    print(f"Candidates found: {len(candidates)}")
+    print()
+
+    if not candidates:
+        print("No silent patches detected in the scanned commits.")
+        return 0
+
+    for i, c in enumerate(candidates, 1):
+        score_bar = "█" * int(c["score"] * 10) + "░" * (10 - int(c["score"] * 10))
+        print(f"[{i}] {c['short_sha']}  {c['message']}")
+        print(f"    Score: {score_bar} {c['score']:.2f}  (msg={c['message_score']:.2f} diff={c['diff_score']:.2f})")
+        print(f"    Class: {c['classification']}  Author: {c['author']}  Date: {c['date'][:10]}")
+        print(f"    URL:   {c['url']}")
+        if len(c.get("matched_classes", [])) > 1:
+            print(f"    Also:  {', '.join(c['matched_classes'])}")
+        print()
+
+    # Summary
+    class_counts: dict[str, int] = {}
+    for c in candidates:
+        cls = c["classification"]
+        class_counts[cls] = class_counts.get(cls, 0) + 1
+    top_classes = sorted(class_counts.items(), key=lambda x: x[1], reverse=True)[:5]
+    print("Bug-class distribution:")
+    for cls, count in top_classes:
+        print(f"  {cls}: {count}")
+
+    return 0
+
+
 def _run_blast_radius(argv: list[str]) -> int:
     import json as _json
 
@@ -2268,6 +2369,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "silent-patches":
+        idx = argv.index("silent-patches")
+        sys.exit(_run_silent_patches(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/detect_silent_patches.py
+++ b/src/manus_agent/tools/detect_silent_patches.py
@@ -1,0 +1,347 @@
+"""Silent patch detector — find security fixes that were never assigned a CVE.
+
+Scans a GitHub repository's commit history for commits whose messages or diffs
+indicate a security fix but lack any associated CVE identifier. Uses two-stage
+heuristic scoring:
+
+1. **Message keywords** — commit message is checked against patterns typical
+   of security fixes (e.g. "fix buffer overflow", "sanitize input").
+2. **Diff keywords** — if enabled, the commit diff is fetched and scanned for
+   security-relevant code patterns (e.g. bounds checks added, auth guards).
+
+Each candidate commit is classified into one of 14 bug classes based on the
+matching keywords.
+
+Public API
+----------
+- ``detect_silent_patches(owner_repo, ...)`` — main entry point
+- ``BUG_CLASSES`` — the 14 supported bug-class labels
+"""
+
+from __future__ import annotations
+
+import datetime
+import os
+import re
+from typing import Any
+from urllib.parse import quote
+
+import requests
+
+# ---------------------------------------------------------------------------
+# Bug classes
+# ---------------------------------------------------------------------------
+
+BUG_CLASSES: list[str] = [
+    "auth_bypass",
+    "buffer_overflow",
+    "command_injection",
+    "csrf",
+    "directory_traversal",
+    "information_disclosure",
+    "integer_overflow",
+    "memory_corruption",
+    "null_dereference",
+    "privilege_escalation",
+    "race_condition",
+    "sql_injection",
+    "use_after_free",
+    "xss",
+]
+
+# ---------------------------------------------------------------------------
+# Keyword patterns — message stage
+# ---------------------------------------------------------------------------
+
+# Each entry maps a regex pattern (applied to the commit message, case-insensitive)
+# to a list of bug-class labels it suggests.
+_MESSAGE_PATTERNS: list[tuple[re.Pattern[str], list[str]]] = [
+    (re.compile(r"auth(?:entication|orization)?\s+bypass", re.I), ["auth_bypass"]),
+    (re.compile(r"bypass\s+(?:auth|access|permission)", re.I), ["auth_bypass"]),
+    (re.compile(r"buffer\s+over(?:flow|run)", re.I), ["buffer_overflow"]),
+    (re.compile(r"heap\s+(?:over(?:flow|run)|corrupt)", re.I), ["buffer_overflow", "memory_corruption"]),
+    (re.compile(r"stack\s+(?:over(?:flow|run)|corrupt)", re.I), ["buffer_overflow", "memory_corruption"]),
+    (re.compile(r"out[- ]of[- ]bounds?\s+(?:read|write|access)", re.I), ["buffer_overflow"]),
+    (re.compile(r"command\s+injection", re.I), ["command_injection"]),
+    (re.compile(r"(?:os|shell)\s+injection", re.I), ["command_injection"]),
+    (re.compile(r"(?:unsanitized|unescaped)\s+(?:input|command|shell)", re.I), ["command_injection"]),
+    (re.compile(r"csrf|cross[- ]site\s+request\s+forgery", re.I), ["csrf"]),
+    (re.compile(r"directory\s+traversal", re.I), ["directory_traversal"]),
+    (re.compile(r"path\s+traversal", re.I), ["directory_traversal"]),
+    (re.compile(r"\.\./\s*(?:attack|vuln|exploit)", re.I), ["directory_traversal"]),
+    (re.compile(r"information\s+(?:disclosure|leak(?:age)?)", re.I), ["information_disclosure"]),
+    (re.compile(r"(?:sensitive|private)\s+(?:data|info)\s+(?:expos|leak)", re.I), ["information_disclosure"]),
+    (re.compile(r"integer\s+over(?:flow|run)", re.I), ["integer_overflow"]),
+    (re.compile(r"(?:signed|unsigned)\s+(?:integer|int)\s+(?:wrap|trunc)", re.I), ["integer_overflow"]),
+    (re.compile(r"memory\s+corrupt", re.I), ["memory_corruption"]),
+    (re.compile(r"double\s+free", re.I), ["memory_corruption", "use_after_free"]),
+    (re.compile(r"null\s+(?:pointer\s+)?deref", re.I), ["null_dereference"]),
+    (re.compile(r"(?:nullptr|NULL)\s+(?:access|deref)", re.I), ["null_dereference"]),
+    (re.compile(r"privilege\s+escalat", re.I), ["privilege_escalation"]),
+    (re.compile(r"(?:local|remote)\s+(?:root|admin)\s+(?:access|exploit)", re.I), ["privilege_escalation"]),
+    (re.compile(r"race\s+condition", re.I), ["race_condition"]),
+    (re.compile(r"(?:toctou|time[- ]of[- ]check)", re.I), ["race_condition"]),
+    (re.compile(r"sql\s+injection", re.I), ["sql_injection"]),
+    (re.compile(r"(?:unsanitized|unescaped)\s+(?:sql|query)", re.I), ["sql_injection"]),
+    (re.compile(r"use[- ]after[- ]free", re.I), ["use_after_free"]),
+    (re.compile(r"(?:dangling|stale)\s+pointer", re.I), ["use_after_free"]),
+    (re.compile(r"xss|cross[- ]site\s+script", re.I), ["xss"]),
+    (re.compile(r"(?:reflected|stored|dom)[- ]?xss", re.I), ["xss"]),
+    # Generic security fix patterns (classify as information_disclosure fallback)
+    (re.compile(r"(?:fix|patch|resolve)\s+(?:security|vuln)", re.I), ["information_disclosure"]),
+    (re.compile(r"(?:security|vuln)\s+(?:fix|patch|update)", re.I), ["information_disclosure"]),
+    (re.compile(r"sanitize\s+(?:input|user|data)", re.I), ["xss", "command_injection"]),
+    (re.compile(r"(?:validate|check)\s+(?:bounds|size|length|limit)", re.I), ["buffer_overflow"]),
+    (re.compile(r"(?:prevent|block|mitigate)\s+(?:inject|overflow|bypass)", re.I), ["command_injection"]),
+]
+
+# ---------------------------------------------------------------------------
+# Keyword patterns — diff stage
+# ---------------------------------------------------------------------------
+
+_DIFF_PATTERNS: list[tuple[re.Pattern[str], list[str]]] = [
+    (re.compile(r"\+.*\b(?:if|assert|check)\s*\(.*(?:len|size|count|bound)", re.I), ["buffer_overflow"]),
+    (re.compile(r"\+.*\b(?:escape|sanitize|encode|quote)\s*\(", re.I), ["xss", "sql_injection", "command_injection"]),
+    (re.compile(r"\+.*csrf[_-]?token", re.I), ["csrf"]),
+    (re.compile(r"\+.*path\.(?:normalize|resolve|join)", re.I), ["directory_traversal"]),
+    (re.compile(r"\+.*realpath", re.I), ["directory_traversal"]),
+    (re.compile(r"\+.*(?:free|release|destroy)\s*\(.*(?:null|NULL)", re.I), ["use_after_free"]),
+    (re.compile(r"\+.*=\s*NULL\s*;.*(?:after|before)\s+free", re.I), ["use_after_free"]),
+    (re.compile(r"\+.*(?:mutex|lock|synchroniz|atomic)", re.I), ["race_condition"]),
+    (re.compile(r"\+.*\b(?:parameterized|prepared)\s+(?:statement|query)", re.I), ["sql_injection"]),
+    (
+        re.compile(r"\+.*\b(?:is_?admin|has_?perm|check_?auth|require_?auth)", re.I),
+        ["auth_bypass", "privilege_escalation"],
+    ),
+    (re.compile(r"\+.*\b(?:INT_MAX|SIZE_MAX|UINT_MAX|overflow)", re.I), ["integer_overflow"]),
+]
+
+# ---------------------------------------------------------------------------
+# CVE reference regex (to exclude commits that already reference a CVE)
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"CVE-\d{4}-\d{4,}", re.I)
+
+# ---------------------------------------------------------------------------
+# GitHub API helpers
+# ---------------------------------------------------------------------------
+
+_GITHUB_API = "https://api.github.com"
+_SESSION: requests.Session | None = None
+
+
+def _get_session() -> requests.Session:
+    """Return a reusable requests session with GitHub auth if available."""
+    global _SESSION
+    if _SESSION is None:
+        _SESSION = requests.Session()
+        token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+        if token:
+            _SESSION.headers["Authorization"] = f"token {token}"
+        _SESSION.headers["Accept"] = "application/vnd.github+json"
+        _SESSION.headers["X-GitHub-Api-Version"] = "2022-11-28"
+    return _SESSION
+
+
+def _fetch_commits(
+    owner_repo: str,
+    since: str | None = None,
+    until: str | None = None,
+    max_commits: int = 500,
+) -> list[dict[str, Any]]:
+    """Fetch commits from GitHub REST API with pagination."""
+    session = _get_session()
+    params: dict[str, Any] = {"per_page": min(max_commits, 100)}
+    if since:
+        params["since"] = since + "T00:00:00Z" if "T" not in since else since
+    if until:
+        params["until"] = until + "T23:59:59Z" if "T" not in until else until
+
+    url = f"{_GITHUB_API}/repos/{quote(owner_repo, safe='/')}/commits"
+    commits: list[dict[str, Any]] = []
+
+    while url and len(commits) < max_commits:
+        resp = session.get(url, params=params, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        if not data:
+            break
+        commits.extend(data)
+        # Follow pagination
+        link = resp.headers.get("Link", "")
+        url = ""
+        params = {}
+        if 'rel="next"' in link:
+            for part in link.split(","):
+                if 'rel="next"' in part:
+                    url = part.split(";")[0].strip(" <>")
+                    break
+
+    return commits[:max_commits]
+
+
+def _fetch_diff(owner_repo: str, sha: str) -> str:
+    """Fetch the diff for a specific commit."""
+    session = _get_session()
+    url = f"{_GITHUB_API}/repos/{quote(owner_repo, safe='/')}/commits/{sha}"
+    headers = {"Accept": "application/vnd.github.diff"}
+    resp = session.get(url, headers=headers, timeout=30)
+    resp.raise_for_status()
+    return resp.text
+
+
+# ---------------------------------------------------------------------------
+# Scoring engine
+# ---------------------------------------------------------------------------
+
+
+def _score_message(message: str) -> tuple[float, list[str]]:
+    """Score a commit message. Returns (score, matched_classes)."""
+    classes: set[str] = set()
+    hits = 0
+    for pattern, labels in _MESSAGE_PATTERNS:
+        if pattern.search(message):
+            hits += 1
+            classes.update(labels)
+
+    # Normalize: more hits = higher confidence, capped at 1.0
+    score = min(hits * 0.3, 1.0) if hits else 0.0
+    return score, sorted(classes)
+
+
+def _score_diff(diff_text: str) -> tuple[float, list[str]]:
+    """Score a diff. Returns (score, matched_classes)."""
+    classes: set[str] = set()
+    hits = 0
+    # Only look at added lines (limit scan to prevent huge diffs from dominating)
+    lines = diff_text[:200_000].split("\n")
+    for line in lines:
+        if not line.startswith("+"):
+            continue
+        for pattern, labels in _DIFF_PATTERNS:
+            if pattern.search(line):
+                hits += 1
+                classes.update(labels)
+                break  # one match per line is enough
+
+    score = min(hits * 0.15, 1.0) if hits else 0.0
+    return score, sorted(classes)
+
+
+def _classify(classes: list[str]) -> str:
+    """Pick the most specific class from the matched set."""
+    if not classes:
+        return "unknown"
+    # Prefer more specific classes over generic fallback
+    for c in classes:
+        if c != "information_disclosure":
+            return c
+    return classes[0]
+
+
+# ---------------------------------------------------------------------------
+# Main entry point
+# ---------------------------------------------------------------------------
+
+
+def detect_silent_patches(
+    owner_repo: str,
+    *,
+    since: str | None = None,
+    until: str | None = None,
+    max_commits: int = 500,
+    fast: bool = False,
+    min_score: float = 0.3,
+) -> list[dict[str, Any]]:
+    """Detect silently patched security fixes in a GitHub repository.
+
+    Parameters
+    ----------
+    owner_repo : str
+        GitHub repository in ``owner/repo`` format.
+    since : str, optional
+        ISO date string (YYYY-MM-DD). Defaults to 90 days ago.
+    until : str, optional
+        ISO date string (YYYY-MM-DD). Defaults to today.
+    max_commits : int
+        Maximum number of commits to fetch (default 500).
+    fast : bool
+        If True, skip diff scoring (message keywords only).
+    min_score : float
+        Minimum combined score to include a commit (default 0.3).
+
+    Returns
+    -------
+    list[dict]
+        List of candidate commits with scoring metadata.
+    """
+    if not since:
+        since = (datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=90)).strftime("%Y-%m-%d")
+    if not until:
+        until = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d")
+
+    commits = _fetch_commits(owner_repo, since=since, until=until, max_commits=max_commits)
+
+    candidates: list[dict[str, Any]] = []
+
+    for commit_data in commits:
+        sha = commit_data.get("sha", "")
+        commit_obj = commit_data.get("commit", {})
+        message = commit_obj.get("message", "")
+
+        # Skip commits that already reference a CVE
+        if _CVE_RE.search(message):
+            continue
+
+        # Stage 1: message scoring
+        msg_score, msg_classes = _score_message(message)
+        if msg_score == 0.0:
+            continue
+
+        # Stage 2: diff scoring (unless --fast)
+        diff_score = 0.0
+        diff_classes: list[str] = []
+        if not fast and msg_score >= 0.3:
+            try:
+                diff_text = _fetch_diff(owner_repo, sha)
+                diff_score, diff_classes = _score_diff(diff_text)
+            except (requests.RequestException, ValueError):
+                pass  # network failure — keep msg_score only
+
+        # Combined score: if diff was fetched and scored positively, boost the
+        # message score; otherwise fall back to message score alone
+        if not fast and diff_score > 0:
+            combined_score = msg_score + diff_score * 0.4
+        else:
+            combined_score = msg_score
+        # Cap at 1.0
+        combined_score = min(combined_score, 1.0)
+        if combined_score < min_score:
+            continue
+
+        all_classes = sorted(set(msg_classes + diff_classes))
+        classification = _classify(all_classes)
+
+        author_info = commit_data.get("author") or {}
+        commit_date = commit_obj.get("committer", {}).get("date", "")
+
+        candidates.append(
+            {
+                "sha": sha,
+                "short_sha": sha[:8],
+                "message": message.split("\n")[0][:120],
+                "full_message": message,
+                "author": author_info.get("login", commit_obj.get("author", {}).get("name", "unknown")),
+                "date": commit_date,
+                "url": commit_data.get("html_url", f"https://github.com/{owner_repo}/commit/{sha}"),
+                "score": round(combined_score, 3),
+                "message_score": round(msg_score, 3),
+                "diff_score": round(diff_score, 3),
+                "classification": classification,
+                "matched_classes": all_classes,
+            }
+        )
+
+    # Sort by score descending
+    candidates.sort(key=lambda c: c["score"], reverse=True)
+    return candidates

--- a/tests/test_detect_silent_patches.py
+++ b/tests/test_detect_silent_patches.py
@@ -1,0 +1,766 @@
+"""Comprehensive test suite for detect_silent_patches tool module."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from manus_agent.tools.detect_silent_patches import (
+    _CVE_RE,
+    BUG_CLASSES,
+    _classify,
+    _fetch_commits,
+    _fetch_diff,
+    _score_diff,
+    _score_message,
+    detect_silent_patches,
+)
+
+# ---------------------------------------------------------------------------
+# BUG_CLASSES constant
+# ---------------------------------------------------------------------------
+
+
+class TestBugClasses:
+    """Tests for the BUG_CLASSES constant."""
+
+    def test_has_14_classes(self):
+        assert len(BUG_CLASSES) == 14
+
+    def test_all_lowercase_underscore(self):
+        for cls in BUG_CLASSES:
+            assert cls == cls.lower()
+            assert " " not in cls
+
+    def test_known_classes_present(self):
+        expected = {"auth_bypass", "buffer_overflow", "xss", "sql_injection", "use_after_free"}
+        assert expected.issubset(set(BUG_CLASSES))
+
+
+# ---------------------------------------------------------------------------
+# CVE regex
+# ---------------------------------------------------------------------------
+
+
+class TestCVERegex:
+    """Tests for the CVE reference regex."""
+
+    def test_matches_standard_cve(self):
+        assert _CVE_RE.search("Fix for CVE-2024-1234")
+
+    def test_matches_long_id(self):
+        assert _CVE_RE.search("Addresses CVE-2025-123456")
+
+    def test_no_match_without_cve(self):
+        assert _CVE_RE.search("Fix buffer overflow in parser") is None
+
+    def test_case_insensitive(self):
+        assert _CVE_RE.search("fixes cve-2023-9999")
+
+
+# ---------------------------------------------------------------------------
+# _score_message
+# ---------------------------------------------------------------------------
+
+
+class TestScoreMessage:
+    """Tests for commit message scoring."""
+
+    def test_buffer_overflow_message(self):
+        score, classes = _score_message("fix buffer overflow in network parser")
+        assert score > 0
+        assert "buffer_overflow" in classes
+
+    def test_use_after_free_message(self):
+        score, classes = _score_message("fix use-after-free in memory allocator")
+        assert score > 0
+        assert "use_after_free" in classes
+
+    def test_sql_injection_message(self):
+        score, classes = _score_message("prevent sql injection in login handler")
+        assert score > 0
+        assert "sql_injection" in classes
+
+    def test_xss_message(self):
+        score, classes = _score_message("fix reflected XSS in search endpoint")
+        assert score > 0
+        assert "xss" in classes
+
+    def test_auth_bypass_message(self):
+        score, classes = _score_message("fix authentication bypass in API middleware")
+        assert score > 0
+        assert "auth_bypass" in classes
+
+    def test_command_injection_message(self):
+        score, classes = _score_message("prevent command injection via shell exec")
+        assert score > 0
+        assert "command_injection" in classes
+
+    def test_csrf_message(self):
+        score, classes = _score_message("add CSRF token validation to form handler")
+        assert score > 0
+        assert "csrf" in classes
+
+    def test_directory_traversal_message(self):
+        score, classes = _score_message("fix path traversal vulnerability in file upload")
+        assert score > 0
+        assert "directory_traversal" in classes
+
+    def test_privilege_escalation_message(self):
+        score, classes = _score_message("fix privilege escalation via symlink")
+        assert score > 0
+        assert "privilege_escalation" in classes
+
+    def test_race_condition_message(self):
+        score, classes = _score_message("fix race condition in session handler")
+        assert score > 0
+        assert "race_condition" in classes
+
+    def test_integer_overflow_message(self):
+        score, classes = _score_message("prevent integer overflow in size calculation")
+        assert score > 0
+        assert "integer_overflow" in classes
+
+    def test_null_deref_message(self):
+        score, classes = _score_message("fix null pointer dereference in parser")
+        assert score > 0
+        assert "null_dereference" in classes
+
+    def test_information_disclosure_message(self):
+        score, classes = _score_message("fix information disclosure via error messages")
+        assert score > 0
+        assert "information_disclosure" in classes
+
+    def test_memory_corruption_message(self):
+        score, classes = _score_message("fix heap corruption in allocator")
+        assert score > 0
+        assert "memory_corruption" in classes
+
+    def test_no_match_benign_message(self):
+        score, classes = _score_message("update README with installation instructions")
+        assert score == 0.0
+        assert classes == []
+
+    def test_no_match_refactor_message(self):
+        score, classes = _score_message("refactor: extract helper function")
+        assert score == 0.0
+        assert classes == []
+
+    def test_generic_security_fix(self):
+        score, classes = _score_message("fix security vulnerability in auth module")
+        assert score > 0
+
+    def test_sanitize_input(self):
+        score, classes = _score_message("sanitize user input before processing")
+        assert score > 0
+
+    def test_multiple_matches_higher_score(self):
+        score1, _ = _score_message("fix buffer overflow")
+        score2, _ = _score_message("fix buffer overflow and validate bounds and check size and check length")
+        assert score2 >= score1
+
+    def test_score_capped_at_one(self):
+        # Craft a message that hits many patterns
+        msg = "fix buffer overflow use-after-free null dereference race condition sql injection xss"
+        score, _ = _score_message(msg)
+        assert score <= 1.0
+
+    def test_double_free(self):
+        score, classes = _score_message("fix double free in cleanup path")
+        assert score > 0
+        assert "memory_corruption" in classes or "use_after_free" in classes
+
+
+# ---------------------------------------------------------------------------
+# _score_diff
+# ---------------------------------------------------------------------------
+
+
+class TestScoreDiff:
+    """Tests for diff scoring."""
+
+    def test_bounds_check_added(self):
+        diff = "+    if (len > MAX_SIZE) return -EINVAL;"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "buffer_overflow" in classes
+
+    def test_sanitize_call_added(self):
+        diff = "+    output = escape(user_input)"
+        score, classes = _score_diff(diff)
+        assert score > 0
+
+    def test_csrf_token_added(self):
+        diff = "+    validate_csrf_token(request)"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "csrf" in classes
+
+    def test_realpath_added(self):
+        diff = "+    safe_path = realpath(user_path)"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "directory_traversal" in classes
+
+    def test_mutex_added(self):
+        diff = "+    pthread_mutex_lock(&resource_mutex);"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "race_condition" in classes
+
+    def test_prepared_statement_added(self):
+        diff = "+    cursor.execute(prepared_query, params)"
+        score, classes = _score_diff(diff)
+        # May or may not match depending on wording
+        # The pattern looks for "parameterized" or "prepared" + "statement" or "query"
+        # This matches "prepared...query" — but let's test a clearer one
+        diff2 = "+    stmt = conn.prepareStatement(query)  # use parameterized query"
+        score2, classes2 = _score_diff(diff2)
+        assert score2 > 0
+        assert "sql_injection" in classes2
+
+    def test_auth_check_added(self):
+        diff = "+    if (!check_auth(user)) return FORBIDDEN;"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "auth_bypass" in classes or "privilege_escalation" in classes
+
+    def test_no_match_benign_diff(self):
+        diff = "+    // Update documentation\n+    version = '1.2.3'"
+        score, classes = _score_diff(diff)
+        assert score == 0.0
+        assert classes == []
+
+    def test_removed_lines_ignored(self):
+        diff = "-    if (len > MAX_SIZE) return -EINVAL;"
+        score, classes = _score_diff(diff)
+        assert score == 0.0
+
+    def test_score_capped(self):
+        # Many added lines with security patterns
+        lines = ["+    if (check_bounds(i, size)) break;"] * 100
+        diff = "\n".join(lines)
+        score, _ = _score_diff(diff)
+        assert score <= 1.0
+
+    def test_overflow_constant(self):
+        diff = "+    if (value > INT_MAX) return -EOVERFLOW;"
+        score, classes = _score_diff(diff)
+        assert score > 0
+        assert "integer_overflow" in classes
+
+
+# ---------------------------------------------------------------------------
+# _classify
+# ---------------------------------------------------------------------------
+
+
+class TestClassify:
+    """Tests for the classification helper."""
+
+    def test_single_class(self):
+        assert _classify(["buffer_overflow"]) == "buffer_overflow"
+
+    def test_prefers_specific_over_info_disclosure(self):
+        assert _classify(["information_disclosure", "xss"]) == "xss"
+
+    def test_empty_returns_unknown(self):
+        assert _classify([]) == "unknown"
+
+    def test_only_info_disclosure(self):
+        assert _classify(["information_disclosure"]) == "information_disclosure"
+
+    def test_multiple_specific(self):
+        result = _classify(["auth_bypass", "privilege_escalation"])
+        assert result in ("auth_bypass", "privilege_escalation")
+
+
+# ---------------------------------------------------------------------------
+# _fetch_commits (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchCommits:
+    """Tests for GitHub commit fetching."""
+
+    @patch("manus_agent.tools.detect_silent_patches._get_session")
+    def test_fetches_commits(self, mock_get_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {
+                "sha": "abc123def456",
+                "commit": {"message": "fix something", "committer": {"date": "2025-01-01T00:00:00Z"}},
+                "author": {"login": "dev"},
+            }
+        ]
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        commits = _fetch_commits("owner/repo", since="2025-01-01")
+        assert len(commits) == 1
+        assert commits[0]["sha"] == "abc123def456"
+
+    @patch("manus_agent.tools.detect_silent_patches._get_session")
+    def test_respects_max_commits(self, mock_get_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [{"sha": f"sha{i}"} for i in range(100)]
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        commits = _fetch_commits("owner/repo", max_commits=5)
+        assert len(commits) == 5
+
+    @patch("manus_agent.tools.detect_silent_patches._get_session")
+    def test_follows_pagination(self, mock_get_session):
+        page1_resp = MagicMock()
+        page1_resp.json.return_value = [{"sha": "page1_sha"}]
+        page1_resp.headers = {"Link": '<https://api.github.com/next>; rel="next"'}
+        page1_resp.raise_for_status = MagicMock()
+
+        page2_resp = MagicMock()
+        page2_resp.json.return_value = [{"sha": "page2_sha"}]
+        page2_resp.headers = {}
+        page2_resp.raise_for_status = MagicMock()
+
+        mock_session = MagicMock()
+        mock_session.get.side_effect = [page1_resp, page2_resp]
+        mock_get_session.return_value = mock_session
+
+        commits = _fetch_commits("owner/repo", max_commits=10)
+        assert len(commits) == 2
+
+    @patch("manus_agent.tools.detect_silent_patches._get_session")
+    def test_empty_response(self, mock_get_session):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        commits = _fetch_commits("owner/repo")
+        assert commits == []
+
+
+# ---------------------------------------------------------------------------
+# _fetch_diff (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestFetchDiff:
+    """Tests for GitHub diff fetching."""
+
+    @patch("manus_agent.tools.detect_silent_patches._get_session")
+    def test_fetches_diff(self, mock_get_session):
+        mock_resp = MagicMock()
+        mock_resp.text = "+    if (len > MAX) return -1;"
+        mock_resp.raise_for_status = MagicMock()
+        mock_session = MagicMock()
+        mock_session.get.return_value = mock_resp
+        mock_get_session.return_value = mock_session
+
+        diff = _fetch_diff("owner/repo", "abc123")
+        assert "MAX" in diff
+
+
+# ---------------------------------------------------------------------------
+# detect_silent_patches (integration, mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestDetectSilentPatches:
+    """Integration tests for the main entry point."""
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_basic_detection(self, mock_commits, mock_diff):
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix buffer overflow in network parser",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+        mock_diff.return_value = "+    if (len > MAX_SIZE) return -1;"
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 1
+        assert results[0]["classification"] == "buffer_overflow"
+        assert results[0]["score"] > 0
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_skips_cve_referenced_commits(self, mock_commits, mock_diff):
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix buffer overflow (CVE-2025-1234)",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 0
+        mock_diff.assert_not_called()
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_fast_mode_skips_diff(self, mock_commits, mock_diff):
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix use-after-free in allocator",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+
+        results = detect_silent_patches("owner/repo", fast=True)
+        assert len(results) == 1
+        mock_diff.assert_not_called()
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_benign_commit_not_included(self, mock_commits, mock_diff):
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "update README with new examples",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 0
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_results_sorted_by_score(self, mock_commits, mock_diff):
+        mock_commits.return_value = [
+            {
+                "sha": "low_score_sha12345",
+                "commit": {
+                    "message": "fix security vulnerability",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev1"},
+                },
+                "author": {"login": "dev1"},
+                "html_url": "https://github.com/o/r/commit/low",
+            },
+            {
+                "sha": "high_score_sha1234",
+                "commit": {
+                    "message": "fix buffer overflow use-after-free null deref race condition in parser",
+                    "committer": {"date": "2025-06-02T12:00:00Z"},
+                    "author": {"name": "dev2"},
+                },
+                "author": {"login": "dev2"},
+                "html_url": "https://github.com/o/r/commit/high",
+            },
+        ]
+        mock_diff.return_value = ""
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) >= 1
+        if len(results) > 1:
+            assert results[0]["score"] >= results[1]["score"]
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_diff_failure_graceful(self, mock_commits, mock_diff):
+        """If diff fetch fails, message score alone is used."""
+        import requests
+
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix buffer overflow in network parser",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+        mock_diff.side_effect = requests.RequestException("Network error")
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 1
+        assert results[0]["diff_score"] == 0.0
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_default_date_range(self, mock_commits, mock_diff):
+        mock_commits.return_value = []
+
+        detect_silent_patches("owner/repo")
+        call_kwargs = mock_commits.call_args
+        # since should default to approximately 90 days ago
+        assert call_kwargs[1]["since"] is not None
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_custom_date_range(self, mock_commits, mock_diff):
+        mock_commits.return_value = []
+
+        detect_silent_patches("owner/repo", since="2025-01-01", until="2025-03-01")
+        call_kwargs = mock_commits.call_args
+        assert call_kwargs[1]["since"] == "2025-01-01"
+        assert call_kwargs[1]["until"] == "2025-03-01"
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_min_score_filtering(self, mock_commits, mock_diff):
+        """Commits below min_score threshold are excluded."""
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix security vulnerability",  # generic, low score
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+        mock_diff.return_value = ""
+
+        # With very high threshold, nothing should pass
+        results = detect_silent_patches("owner/repo", min_score=0.99)
+        assert len(results) == 0
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_output_fields(self, mock_commits, mock_diff):
+        """Check that output contains expected fields."""
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344aabbccdd11223344aabbccdd",
+                "commit": {
+                    "message": "fix buffer overflow in network parser\n\nDetailed description here.",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "dev"},
+                },
+                "author": {"login": "devuser"},
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+        mock_diff.return_value = "+    if (len > MAX_SIZE) return -1;"
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 1
+        r = results[0]
+        assert "sha" in r
+        assert "short_sha" in r
+        assert len(r["short_sha"]) == 8
+        assert "message" in r
+        assert "full_message" in r
+        assert "author" in r
+        assert r["author"] == "devuser"
+        assert "date" in r
+        assert "url" in r
+        assert "score" in r
+        assert "message_score" in r
+        assert "diff_score" in r
+        assert "classification" in r
+        assert "matched_classes" in r
+
+    @patch("manus_agent.tools.detect_silent_patches._fetch_diff")
+    @patch("manus_agent.tools.detect_silent_patches._fetch_commits")
+    def test_missing_author_login(self, mock_commits, mock_diff):
+        """Falls back to commit author name when GitHub login is missing."""
+        mock_commits.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "commit": {
+                    "message": "fix sql injection in login",
+                    "committer": {"date": "2025-06-01T12:00:00Z"},
+                    "author": {"name": "Anon Dev"},
+                },
+                "author": None,
+                "html_url": "https://github.com/owner/repo/commit/aabbccdd",
+            }
+        ]
+        mock_diff.return_value = ""
+
+        results = detect_silent_patches("owner/repo")
+        assert len(results) == 1
+        assert results[0]["author"] == "Anon Dev"
+
+
+# ---------------------------------------------------------------------------
+# CLI integration (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestCLISilentPatches:
+    """Tests for the CLI _run_silent_patches function."""
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_text_output(self, mock_detect, capsys):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "short_sha": "aabbccdd",
+                "message": "fix buffer overflow",
+                "full_message": "fix buffer overflow\n\ndetails",
+                "author": "dev",
+                "date": "2025-06-01T12:00:00Z",
+                "url": "https://github.com/o/r/commit/aabbccdd",
+                "score": 0.78,
+                "message_score": 0.6,
+                "diff_score": 0.3,
+                "classification": "buffer_overflow",
+                "matched_classes": ["buffer_overflow"],
+            }
+        ]
+
+        rc = _run_silent_patches(["owner/repo"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Silent Patch Detector" in out
+        assert "owner/repo" in out
+        assert "buffer_overflow" in out
+        assert "aabbccdd" in out
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_json_output(self, mock_detect, capsys):
+        import json
+
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = [
+            {
+                "sha": "aabbccdd11223344",
+                "short_sha": "aabbccdd",
+                "message": "fix xss in search",
+                "full_message": "fix xss in search\n\nmore",
+                "author": "dev",
+                "date": "2025-06-01T12:00:00Z",
+                "url": "https://github.com/o/r/commit/aabbccdd",
+                "score": 0.65,
+                "message_score": 0.6,
+                "diff_score": 0.15,
+                "classification": "xss",
+                "matched_classes": ["xss"],
+            }
+        ]
+
+        rc = _run_silent_patches(["owner/repo", "--output", "json"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert len(data) == 1
+        assert data[0]["classification"] == "xss"
+        # full_message should be stripped from JSON output
+        assert "full_message" not in data[0]
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_no_results(self, mock_detect, capsys):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = []
+
+        rc = _run_silent_patches(["owner/repo"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No silent patches detected" in out
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_fast_flag(self, mock_detect):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = []
+
+        _run_silent_patches(["owner/repo", "--fast"])
+        mock_detect.assert_called_once()
+        assert mock_detect.call_args[1]["fast"] is True
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_since_until_flags(self, mock_detect):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = []
+
+        _run_silent_patches(["owner/repo", "--since", "2025-01-01", "--until", "2025-06-01"])
+        mock_detect.assert_called_once()
+        assert mock_detect.call_args[1]["since"] == "2025-01-01"
+        assert mock_detect.call_args[1]["until"] == "2025-06-01"
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_max_commits_flag(self, mock_detect):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = []
+
+        _run_silent_patches(["owner/repo", "--max-commits", "100"])
+        mock_detect.assert_called_once()
+        assert mock_detect.call_args[1]["max_commits"] == 100
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_error_handling(self, mock_detect, capsys):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.side_effect = RuntimeError("API rate limit exceeded")
+
+        rc = _run_silent_patches(["owner/repo"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Error" in err
+
+    @patch("manus_agent.tools.detect_silent_patches.detect_silent_patches")
+    def test_cli_multiple_results_summary(self, mock_detect, capsys):
+        from manus_agent.cli import _run_silent_patches
+
+        mock_detect.return_value = [
+            {
+                "sha": f"sha{i}" + "0" * 32,
+                "short_sha": f"sha{i}0000",
+                "message": f"fix issue {i}",
+                "full_message": f"fix issue {i}",
+                "author": "dev",
+                "date": "2025-06-01T12:00:00Z",
+                "url": f"https://github.com/o/r/commit/sha{i}",
+                "score": 0.5 + i * 0.05,
+                "message_score": 0.5,
+                "diff_score": 0.1 * i,
+                "classification": "buffer_overflow" if i % 2 == 0 else "xss",
+                "matched_classes": ["buffer_overflow"] if i % 2 == 0 else ["xss"],
+            }
+            for i in range(5)
+        ]
+
+        rc = _run_silent_patches(["owner/repo"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "Bug-class distribution" in out
+        assert "Candidates found: 5" in out


### PR DESCRIPTION
## Summary

Implement the `manus-agent silent-patches` CLI subcommand — documented in the README but previously completely unimplemented (no tool module, no CLI wiring existed).

## What it does

Scans a GitHub repository's commit history for security fixes that were **never assigned a CVE**. Uses two-stage heuristic scoring:

1. **Message keywords** — commit message is checked against patterns typical of security fixes (e.g. "fix buffer overflow", "sanitize input")
2. **Diff keywords** — if enabled, the commit diff is fetched and scanned for security-relevant code patterns (e.g. bounds checks added, auth guards, CSRF tokens)

Each candidate commit is classified into one of **14 bug classes**: `auth_bypass`, `buffer_overflow`, `command_injection`, `csrf`, `directory_traversal`, `information_disclosure`, `integer_overflow`, `memory_corruption`, `null_dereference`, `privilege_escalation`, `race_condition`, `sql_injection`, `use_after_free`, `xss`.

## Usage (matches README documentation)

```bash
manus-agent silent-patches torvalds/linux
manus-agent silent-patches torvalds/linux --since 2025-01-01
manus-agent silent-patches torvalds/linux --output json | jq .[].classification
manus-agent silent-patches owner/repo --fast --max-commits 100
```

## Flags

| Flag | Default | Description |
|------|---------|-------------|
| `--since YYYY-MM-DD` | 90 days ago | Start date for commit scan |
| `--until YYYY-MM-DD` | today | End date |
| `--max-commits N` | `500` | Hard limit on commits fetched |
| `--fast` | off | Skip diff scoring (message keywords only) |
| `--output {text,json}` | `text` | Output format |

## Files changed

- `src/manus_agent/tools/detect_silent_patches.py` — new tool module (~280 lines)
- `src/manus_agent/cli.py` — added `silent-patches` to `_SUBCOMMANDS`, parser, runner, and dispatch
- `tests/test_detect_silent_patches.py` — 68 fully-mocked tests covering message scoring, diff scoring, classification, GitHub API mocking, CLI text/JSON output, error handling, and edge cases

## Test results

- **1226 passed**, 0 failures (baseline 1158 + 68 new)
- All tests are fully mocked — no real HTTP calls

## Duplicate check

Checked all 50 open PRs (#77–#137) and 30 merged PRs (#39–#102). No open or merged PR implements `silent-patches` or a silent patch detector. Related but distinct PRs:
- #86 (patch-status) — checks if a *known CVE* has a patch; does not scan commits
- #47 (patch-diff, merged) — summarizes a known patch diff; does not detect *silent* patches
- #88 (vendor-response) — tracks vendor response to known CVEs; unrelated
