### PR TITLE
feat(cli): add verify-exploit subcommand

### DIFF
--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -1,0 +1,44 @@
+
+---
+
+## 2026-07-24 — PR #146: `verify-exploit` CLI subcommand
+
+**Branch:** `feat/cli-verify-exploit`
+**PR:** https://github.com/manus-use/manus-agent/pull/146
+
+### What was done
+
+Wired the existing `ExploitSandbox` (`src/manus_agent/sandbox/exploit_sandbox.py`)
+as a standalone CLI command: `manus-agent verify-exploit`.
+
+**Implementation:**
+- `_build_verify_exploit_parser()` — argparse with full help/epilog
+- `_run_verify_exploit(argv)` — main logic: Docker preflight → build → start → exploit → result
+- `_verify_exploit_output(data, fmt, status)` — text/JSON formatter
+- Dispatch entry in CLI router
+
+**Features:**
+- Remote mode (default): exploit in separate container over isolated network
+- Local mode: exploit inside target container (LPE/parsing bugs)
+- Docker preflight with diagnostic messages
+- Text + JSON output formats
+- Structured statuses: verified, failed, build_error, target_error, infra_error, exploit_error
+- `--port`, `--timeout`, `--env`, `--software`, `--versions`, `--vuln-type`
+
+**Files modified:**
+- `src/manus_agent/cli.py` (+435 lines)
+- `tests/test_cli_verify_exploit.py` (new, 797 lines)
+
+39 new tests (5 classes, all mocked):
+`TestVerifyExploitParser` (9), `TestVerifyExploitRemote` (11),
+`TestVerifyExploitLocal` (5), `TestVerifyExploitImportErrors` (1),
+`TestVerifyExploitOutput` (8), `TestVerifyExploitDispatch` (5).
+
+Suite: **1197 passed** (3 deselected, 3 warnings — pre-existing, zero regressions).
+
+### Suggested next contributions
+
+- **Hackage enricher** (`_enrich_hackage`) — Haskell package registry
+- **opam enricher** (`_enrich_opam`) — OCaml package registry
+- **CLI subcommand: `generate-exploit`** — wire the exploit generation tool
+- **CLI subcommand: `sandbox-status`** — Docker health check + cleanup orphans

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "verify-exploit",
 }
 
 
@@ -1421,6 +1422,436 @@ def _run_exploit_complexity(argv: list[str]) -> int:
 
 
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# verify-exploit subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_verify_exploit_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent verify-exploit",
+        description=(
+            "Verify a Proof-of-Concept exploit in an isolated Docker environment.\n"
+            "Builds a vulnerable target from a Dockerfile and executes the exploit\n"
+            "code against it on an internal Docker network. Requires Docker.\n\n"
+            "Two execution modes:\n"
+            "  remote (default): exploit runs in a separate container attacking the\n"
+            "                    target over an isolated network.\n"
+            "  local:            exploit runs INSIDE the target container (for local\n"
+            "                    privilege escalation, file parsing bugs, etc.)."
+        ),
+        add_help=True,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=(
+            "Examples:\n"
+            "  manus-agent verify-exploit CVE-2024-3094 \\\n"
+            "      --dockerfile ./target.Dockerfile \\\n"
+            "      --exploit ./exploit.py --language python\n\n"
+            "  manus-agent verify-exploit CVE-2025-1234 \\\n"
+            "      --dockerfile ./Dockerfile --exploit ./exploit.sh \\\n"
+            "      --language bash --mode local\n\n"
+            "  manus-agent verify-exploit CVE-2024-9999 \\\n"
+            "      --dockerfile ./Dockerfile --exploit ./exploit.py \\\n"
+            "      --language python --port 8080 --timeout 600 \\\n"
+            "      --env SECRET_KEY=test --output json\n"
+        ),
+    )
+    p.add_argument(
+        "cve_id",
+        metavar="CVE-ID",
+        help="CVE identifier (e.g. CVE-2024-3094)",
+    )
+    p.add_argument(
+        "--dockerfile",
+        required=True,
+        metavar="PATH",
+        help="Path to Dockerfile that sets up the vulnerable target environment",
+    )
+    p.add_argument(
+        "--exploit",
+        required=True,
+        metavar="PATH",
+        help="Path to the exploit code file",
+    )
+    p.add_argument(
+        "--language",
+        required=True,
+        choices=["python", "bash", "sh", "javascript", "ruby", "perl"],
+        help="Language/interpreter for the exploit code",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["remote", "local"],
+        default="remote",
+        help="Exploit execution mode (default: remote)",
+    )
+    p.add_argument(
+        "--port",
+        type=int,
+        default=80,
+        metavar="PORT",
+        help="Port the target service listens on (default: 80, remote mode only)",
+    )
+    p.add_argument(
+        "--timeout",
+        type=int,
+        default=300,
+        metavar="SECONDS",
+        help="Exploit execution timeout in seconds (default: 300)",
+    )
+    p.add_argument(
+        "--software",
+        default="unknown",
+        metavar="NAME",
+        help="Affected software name (for reporting)",
+    )
+    p.add_argument(
+        "--versions",
+        default="unknown",
+        metavar="RANGE",
+        help="Affected version range (for reporting)",
+    )
+    p.add_argument(
+        "--vuln-type",
+        default="unknown",
+        metavar="TYPE",
+        help="Vulnerability type, e.g. RCE, SQLi, XSS (for reporting)",
+    )
+    p.add_argument(
+        "--env",
+        action="append",
+        default=[],
+        metavar="KEY=VALUE",
+        help="Environment variable for the target container (repeatable)",
+    )
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_verify_exploit(argv: list[str]) -> int:  # noqa: C901
+    """Run the verify-exploit CLI subcommand."""
+    import re as _re
+    import time as _time
+
+    parser = _build_verify_exploit_parser()
+    args = parser.parse_args(argv)
+    cve_id: str = args.cve_id.strip()
+
+    if not _re.match(r"CVE-\d{4}-\d+", cve_id, _re.IGNORECASE):
+        parser.error(f"Invalid CVE ID: {cve_id!r}. Expected format: CVE-YYYY-NNNNN")
+
+    # Read Dockerfile content
+    import pathlib
+
+    dockerfile_path = pathlib.Path(args.dockerfile)
+    if not dockerfile_path.is_file():
+        print(f"Error: Dockerfile not found: {args.dockerfile}", file=sys.stderr)
+        return 1
+
+    exploit_path = pathlib.Path(args.exploit)
+    if not exploit_path.is_file():
+        print(f"Error: Exploit file not found: {args.exploit}", file=sys.stderr)
+        return 1
+
+    dockerfile_content = dockerfile_path.read_text(encoding="utf-8")
+    exploit_code = exploit_path.read_text(encoding="utf-8")
+
+    # Parse environment variables
+    target_env: dict[str, str] = {}
+    for env_str in args.env:
+        if "=" not in env_str:
+            print(f"Error: Invalid --env format: {env_str!r} (expected KEY=VALUE)", file=sys.stderr)
+            return 1
+        key, value = env_str.split("=", 1)
+        target_env[key] = value
+
+    # Import sandbox components
+    try:
+        from manus_agent.sandbox.exploit_sandbox import (
+            ExploitSandbox,
+            InterpreterNotFoundError,
+        )
+        from manus_agent.utils.docker_client import (
+            DockerConnectionError,
+            get_docker_client,
+            is_transient_docker_error,
+            wait_for_container_healthy,
+            wait_for_container_running,
+        )
+    except ImportError as exc:
+        print(f"Error importing sandbox modules: {exc}", file=sys.stderr)
+        return 1
+
+    sandbox = ExploitSandbox(timeout=args.timeout)
+    start_time = _time.time()
+    result_data: dict = {
+        "cve_id": cve_id.upper(),
+        "mode": args.mode,
+        "language": args.language,
+        "port": args.port,
+        "timeout": args.timeout,
+        "software": args.software,
+        "versions": args.versions,
+        "vuln_type": args.vuln_type,
+    }
+
+    try:
+        # 0. Docker preflight
+        try:
+            client = get_docker_client()
+            client.ping()
+            client.close()
+        except DockerConnectionError as e:
+            elapsed = _time.time() - start_time
+            result_data.update(
+                verification_status="infra_error",
+                error=f"Docker daemon unavailable: {e.message}",
+                diagnosis=e.diagnosis,
+                remediation=e.remediation,
+                elapsed_seconds=round(elapsed, 2),
+            )
+            return _verify_exploit_output(result_data, args.output, status="infra_error")
+        except Exception as e:
+            elapsed = _time.time() - start_time
+            result_data.update(
+                verification_status="infra_error",
+                error=f"Docker daemon unavailable: {e}",
+                elapsed_seconds=round(elapsed, 2),
+            )
+            return _verify_exploit_output(result_data, args.output, status="infra_error")
+
+        # 1. Build target image
+        if args.output == "text":
+            print(f"[verify-exploit] Building target image for {cve_id.upper()}...")
+        try:
+            image_id = sandbox.build_target(dockerfile_content)
+        except Exception as e:
+            elapsed = _time.time() - start_time
+            result_data.update(
+                verification_status="build_error",
+                error=str(e),
+                build_log=sandbox.build_log or "",
+                elapsed_seconds=round(elapsed, 2),
+            )
+            return _verify_exploit_output(result_data, args.output, status="build_error")
+
+        # 2. Start target container
+        if args.output == "text":
+            print("[verify-exploit] Starting target container...")
+        try:
+            sandbox.start_target(image_id, environment=target_env or None)
+        except Exception as e:
+            elapsed = _time.time() - start_time
+            result_data.update(
+                verification_status="target_error",
+                error=str(e),
+                build_log=sandbox.build_log or "",
+                elapsed_seconds=round(elapsed, 2),
+            )
+            return _verify_exploit_output(result_data, args.output, status="target_error")
+
+        if args.mode == "remote":
+            # 3. Wait for target service
+            if args.output == "text":
+                print(f"[verify-exploit] Waiting for target on port {args.port}...")
+            ready = sandbox.wait_for_target(port=args.port, timeout=60)
+            if not ready:
+                elapsed = _time.time() - start_time
+                result_data.update(
+                    verification_status="target_error",
+                    error=f"Target service did not become ready on port {args.port} within 60s",
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status="target_error")
+
+            # 4. Run exploit (remote mode)
+            if args.output == "text":
+                print(f"[verify-exploit] Running exploit ({args.language}) in remote mode...")
+            env = {"TARGET_PORT": str(args.port)}
+            try:
+                exploit_result = sandbox.run_exploit(
+                    code=exploit_code,
+                    language=args.language,
+                    env=env,
+                )
+            except InterpreterNotFoundError as e:
+                elapsed = _time.time() - start_time
+                result_data.update(
+                    verification_status="infra_error",
+                    error=str(e),
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status="infra_error")
+            except Exception as e:
+                elapsed = _time.time() - start_time
+                status = "infra_error" if is_transient_docker_error(e) else "exploit_error"
+                result_data.update(
+                    verification_status=status,
+                    error=str(e),
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status=status)
+
+        else:  # local mode
+            # 3. Wait for container running/healthy
+            try:
+                if sandbox.target_container is not None:
+                    wait_for_container_running(sandbox.target_container, timeout=20)
+                    wait_for_container_healthy(sandbox.target_container, timeout=30)
+            except Exception as e:
+                elapsed = _time.time() - start_time
+                status = "infra_error" if is_transient_docker_error(e) else "target_error"
+                result_data.update(
+                    verification_status=status,
+                    error=str(e),
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status=status)
+
+            # 4. Run exploit (local mode, inside target)
+            if args.output == "text":
+                print(f"[verify-exploit] Running exploit ({args.language}) in local mode...")
+            try:
+                exploit_result = sandbox.run_local_exploit(
+                    code=exploit_code,
+                    language=args.language,
+                )
+            except InterpreterNotFoundError as e:
+                elapsed = _time.time() - start_time
+                result_data.update(
+                    verification_status="infra_error",
+                    error=str(e),
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status="infra_error")
+            except Exception as e:
+                elapsed = _time.time() - start_time
+                status = "infra_error" if is_transient_docker_error(e) else "exploit_error"
+                result_data.update(
+                    verification_status=status,
+                    error=str(e),
+                    target_logs=sandbox.get_target_logs() or "",
+                    elapsed_seconds=round(elapsed, 2),
+                )
+                return _verify_exploit_output(result_data, args.output, status=status)
+
+        # 5. Determine status
+        elapsed = _time.time() - start_time
+        exit_code = exploit_result.get("exit_code", -1)
+        target_logs = sandbox.get_target_logs() or ""
+
+        if exit_code == 0:
+            verification_status = "verified"
+        else:
+            verification_status = "failed"
+
+        result_data.update(
+            verification_status=verification_status,
+            exit_code=exit_code,
+            stdout=exploit_result.get("stdout", ""),
+            stderr=exploit_result.get("stderr", ""),
+            target_logs=target_logs,
+            elapsed_seconds=round(elapsed, 2),
+        )
+        return _verify_exploit_output(result_data, args.output, status=verification_status)
+
+    except Exception as e:
+        elapsed = _time.time() - start_time
+        result_data.update(
+            verification_status="infra_error",
+            error=f"Unexpected error: {e}",
+            elapsed_seconds=round(elapsed, 2),
+        )
+        return _verify_exploit_output(result_data, args.output, status="infra_error")
+    finally:
+        if args.output == "text":
+            print("[verify-exploit] Cleaning up containers...")
+        sandbox.cleanup()
+
+
+def _verify_exploit_output(data: dict, fmt: str, status: str) -> int:
+    """Format and print verify-exploit results. Returns exit code."""
+    import json as _json
+
+    if fmt == "json":
+        print(_json.dumps(data, indent=2, default=str))
+    else:
+        # Text output
+        cve_id = data.get("cve_id", "UNKNOWN")
+        elapsed = data.get("elapsed_seconds", 0)
+        mode = data.get("mode", "remote")
+
+        print()
+        if status == "verified":
+            print(f"  \u2705  EXPLOIT VERIFIED \u2014 {cve_id}")
+            print(f"  Mode: {mode} | Exit code: 0 | Time: {elapsed:.1f}s")
+            print(f"  Software: {data.get('software', 'unknown')} ({data.get('vuln_type', 'unknown')})")
+            print()
+            stdout = data.get("stdout", "")
+            if stdout:
+                print("  \u2500\u2500 Exploit stdout \u2500\u2500")
+                for line in stdout.splitlines()[:50]:
+                    print(f"    {line}")
+                if len(stdout.splitlines()) > 50:
+                    print(f"    ... ({len(stdout.splitlines()) - 50} more lines)")
+                print()
+        elif status == "failed":
+            exit_code = data.get("exit_code", -1)
+            print(f"  \u274c  EXPLOIT FAILED \u2014 {cve_id}")
+            print(f"  Mode: {mode} | Exit code: {exit_code} | Time: {elapsed:.1f}s")
+            print(f"  Software: {data.get('software', 'unknown')} ({data.get('vuln_type', 'unknown')})")
+            print()
+            stderr = data.get("stderr", "")
+            if stderr:
+                print("  \u2500\u2500 Exploit stderr \u2500\u2500")
+                for line in stderr.splitlines()[:30]:
+                    print(f"    {line}")
+                if len(stderr.splitlines()) > 30:
+                    print(f"    ... ({len(stderr.splitlines()) - 30} more lines)")
+                print()
+        elif status == "build_error":
+            print(f"  \U0001f528  BUILD ERROR \u2014 {cve_id}")
+            print(f"  {data.get('error', 'Unknown build error')}")
+            print()
+            build_log = data.get("build_log", "")
+            if build_log:
+                print("  \u2500\u2500 Build log (last 20 lines) \u2500\u2500")
+                for line in build_log.splitlines()[-20:]:
+                    print(f"    {line}")
+                print()
+        elif status == "target_error":
+            print(f"  \U0001f3af  TARGET ERROR \u2014 {cve_id}")
+            print(f"  {data.get('error', 'Unknown target error')}")
+            print()
+            target_logs = data.get("target_logs", "")
+            if target_logs:
+                print("  \u2500\u2500 Target logs (last 20 lines) \u2500\u2500")
+                for line in target_logs.splitlines()[-20:]:
+                    print(f"    {line}")
+                print()
+        else:  # infra_error
+            print(f"  \u2699\ufe0f  INFRA ERROR \u2014 {cve_id}")
+            print(f"  {data.get('error', 'Unknown infrastructure error')}")
+            if data.get("diagnosis"):
+                print(f"  Diagnosis: {data['diagnosis']}")
+            if data.get("remediation"):
+                print(f"  Remediation: {data['remediation']}")
+            print()
+
+    # Exit 0 only for verified; any other status is non-zero
+    return 0 if status == "verified" else 1
+
+
 # poc-search subcommand
 # ---------------------------------------------------------------------------
 
@@ -2260,6 +2691,10 @@ def main() -> None:
     if first_positional == "poc-search":
         idx = argv.index("poc-search")
         sys.exit(_run_poc_search(argv[idx + 1 :]))
+
+    if first_positional == "verify-exploit":
+        idx = argv.index("verify-exploit")
+        sys.exit(_run_verify_exploit(argv[idx + 1 :]))
 
     if first_positional == "changelog":
         idx = argv.index("changelog")

--- a/tests/test_cli_verify_exploit.py
+++ b/tests/test_cli_verify_exploit.py
@@ -1,0 +1,797 @@
+"""
+Tests for the verify-exploit CLI subcommand in src/manus_agent/cli.py.
+
+All Docker/sandbox interactions are mocked — no real Docker daemon required.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+SANDBOX_MODULE = "manus_agent.sandbox.exploit_sandbox"
+DOCKER_MODULE = "manus_agent.utils.docker_client"
+
+
+@pytest.fixture()
+def tmp_dockerfile(tmp_path: Path) -> Path:
+    p = tmp_path / "Dockerfile"
+    p.write_text("FROM ubuntu:22.04\nRUN apt-get update\n")
+    return p
+
+
+@pytest.fixture()
+def tmp_exploit(tmp_path: Path) -> Path:
+    p = tmp_path / "exploit.py"
+    p.write_text("import socket\nprint('exploiting')\n")
+    return p
+
+
+class FakeDockerConnectionError(Exception):
+    def __init__(self, msg="Cannot connect"):
+        self.message = msg
+        self.diagnosis = "Docker not running"
+        self.remediation = "Start Docker"
+        super().__init__(msg)
+
+
+class FakeInterpreterNotFoundError(Exception):
+    pass
+
+
+def _mock_sandbox(
+    build_ok: bool = True,
+    start_ok: bool = True,
+    wait_ok: bool = True,
+    exploit_result: dict | None = None,
+    build_log: str = "",
+    target_logs: str = "",
+):
+    """Return a mock ExploitSandbox with configurable behavior."""
+    sandbox = MagicMock()
+    sandbox.build_log = build_log
+
+    if build_ok:
+        sandbox.build_target.return_value = "sha256:abcdef1234"
+    else:
+        sandbox.build_target.side_effect = RuntimeError("Build failed: missing base")
+
+    if start_ok:
+        sandbox.start_target.return_value = None
+    else:
+        sandbox.start_target.side_effect = RuntimeError("Container start failed")
+
+    sandbox.wait_for_target.return_value = wait_ok
+    sandbox.target_container = MagicMock()
+
+    if exploit_result is None:
+        exploit_result = {"exit_code": 0, "stdout": "pwned!", "stderr": ""}
+    sandbox.run_exploit.return_value = exploit_result
+    sandbox.run_local_exploit.return_value = exploit_result
+    sandbox.get_target_logs.return_value = target_logs
+    sandbox.cleanup.return_value = None
+
+    return sandbox
+
+
+@pytest.fixture()
+def sandbox_patches():
+    """Context manager fixture that patches sandbox and docker imports."""
+    mock_sandbox_mod = MagicMock()
+    mock_docker_mod = MagicMock()
+
+    mock_sandbox_mod.ExploitSandbox = MagicMock
+    mock_sandbox_mod.InterpreterNotFoundError = FakeInterpreterNotFoundError
+    mock_docker_mod.DockerConnectionError = FakeDockerConnectionError
+    mock_docker_mod.get_docker_client = MagicMock
+    mock_docker_mod.is_transient_docker_error = MagicMock(return_value=False)
+    mock_docker_mod.wait_for_container_healthy = MagicMock()
+    mock_docker_mod.wait_for_container_running = MagicMock()
+
+    return mock_sandbox_mod, mock_docker_mod
+
+
+def _run(args: list[str]) -> int:
+    """Import and call _run_verify_exploit with the given args."""
+    from manus_agent.cli import _run_verify_exploit
+
+    return _run_verify_exploit(args)
+
+
+def _run_with_mocked_sandbox(
+    args: list[str],
+    sandbox: MagicMock,
+    docker_ping_ok: bool = True,
+    docker_ping_error: Exception | None = None,
+    wait_for_healthy_error: Exception | None = None,
+    wait_for_running_error: Exception | None = None,
+    is_transient: bool = False,
+) -> int:
+    """Run _run_verify_exploit with fully mocked sandbox/docker modules."""
+    mock_client = MagicMock()
+    if docker_ping_error:
+        mock_client.ping.side_effect = docker_ping_error
+    else:
+        mock_client.ping.return_value = True
+
+    mock_get_docker_client = MagicMock(return_value=mock_client)
+    mock_is_transient = MagicMock(return_value=is_transient)
+
+    mock_wait_healthy = MagicMock()
+    if wait_for_healthy_error:
+        mock_wait_healthy.side_effect = wait_for_healthy_error
+
+    mock_wait_running = MagicMock()
+    if wait_for_running_error:
+        mock_wait_running.side_effect = wait_for_running_error
+
+    sandbox_class = MagicMock(return_value=sandbox)
+
+    with patch.dict(
+        "sys.modules",
+        {
+            SANDBOX_MODULE: MagicMock(
+                ExploitSandbox=sandbox_class,
+                InterpreterNotFoundError=FakeInterpreterNotFoundError,
+            ),
+            DOCKER_MODULE: MagicMock(
+                DockerConnectionError=FakeDockerConnectionError,
+                get_docker_client=mock_get_docker_client,
+                is_transient_docker_error=mock_is_transient,
+                wait_for_container_healthy=mock_wait_healthy,
+                wait_for_container_running=mock_wait_running,
+            ),
+        },
+    ):
+        from manus_agent.cli import _run_verify_exploit
+
+        return _run_verify_exploit(args)
+
+
+# ===========================================================================
+# Parser / validation tests
+# ===========================================================================
+
+
+class TestVerifyExploitParser:
+    def test_missing_cve_id_exits(self, tmp_dockerfile, tmp_exploit):
+        """Missing positional CVE-ID triggers argparse error."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(
+                [
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    "python",
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_invalid_cve_id_exits(self, tmp_dockerfile, tmp_exploit):
+        """Non-CVE identifier fails validation."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(
+                [
+                    "NOTACVE",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    "python",
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_missing_dockerfile_returns_1(self, tmp_exploit, capsys):
+        """Non-existent Dockerfile returns 1."""
+        rc = _run(
+            [
+                "CVE-2024-1234",
+                "--dockerfile",
+                "/nonexistent/Dockerfile",
+                "--exploit",
+                str(tmp_exploit),
+                "--language",
+                "python",
+            ]
+        )
+        assert rc == 1
+        assert "Dockerfile not found" in capsys.readouterr().err
+
+    def test_missing_exploit_returns_1(self, tmp_dockerfile, capsys):
+        """Non-existent exploit file returns 1."""
+        rc = _run(
+            [
+                "CVE-2024-1234",
+                "--dockerfile",
+                str(tmp_dockerfile),
+                "--exploit",
+                "/nonexistent/exploit.py",
+                "--language",
+                "python",
+            ]
+        )
+        assert rc == 1
+        assert "Exploit file not found" in capsys.readouterr().err
+
+    def test_missing_language_exits(self, tmp_dockerfile, tmp_exploit):
+        """Missing --language triggers argparse error."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(
+                [
+                    "CVE-2024-1234",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_invalid_language_exits(self, tmp_dockerfile, tmp_exploit):
+        """Unsupported language triggers argparse error."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(
+                [
+                    "CVE-2024-1234",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    "cobol",
+                ]
+            )
+        assert exc_info.value.code != 0
+
+    def test_invalid_env_format_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        """--env without = separator returns 1."""
+        rc = _run(
+            [
+                "CVE-2024-1234",
+                "--dockerfile",
+                str(tmp_dockerfile),
+                "--exploit",
+                str(tmp_exploit),
+                "--language",
+                "python",
+                "--env",
+                "NOEQUALS",
+            ]
+        )
+        assert rc == 1
+        assert "Invalid --env format" in capsys.readouterr().err
+
+    def test_cve_case_insensitive(self, tmp_dockerfile, tmp_exploit, capsys):
+        """CVE IDs are accepted case-insensitively."""
+        sandbox = _mock_sandbox()
+        rc = _run_with_mocked_sandbox(
+            [
+                "cve-2024-1234",
+                "--dockerfile",
+                str(tmp_dockerfile),
+                "--exploit",
+                str(tmp_exploit),
+                "--language",
+                "python",
+            ],
+            sandbox=sandbox,
+        )
+        assert rc == 0
+
+    def test_help_flag(self, capsys):
+        """--help exits 0 with usage info."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(["--help"])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "CVE-ID" in out
+
+
+# ===========================================================================
+# Remote mode tests (default)
+# ===========================================================================
+
+
+class TestVerifyExploitRemote:
+    def _base_args(self, dockerfile: Path, exploit: Path) -> list[str]:
+        return [
+            "CVE-2024-3094",
+            "--dockerfile",
+            str(dockerfile),
+            "--exploit",
+            str(exploit),
+            "--language",
+            "python",
+            "--port",
+            "8080",
+            "--software",
+            "xz-utils",
+            "--vuln-type",
+            "RCE",
+        ]
+
+    def test_verified_text_output(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 0, "stdout": "root shell!", "stderr": ""})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "EXPLOIT VERIFIED" in out
+        assert "CVE-2024-3094" in out
+        sandbox.cleanup.assert_called_once()
+
+    def test_verified_json_output(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 0, "stdout": "ok", "stderr": ""})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit) + ["--output", "json"],
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["verification_status"] == "verified"
+        assert data["cve_id"] == "CVE-2024-3094"
+        assert data["exit_code"] == 0
+
+    def test_failed_exploit_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 1, "stdout": "", "stderr": "segfault"})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "EXPLOIT FAILED" in out
+
+    def test_build_error_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(build_ok=False, build_log="Step 3: apt-get not found")
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "BUILD ERROR" in out
+
+    def test_target_start_error_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(start_ok=False)
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "TARGET ERROR" in out
+
+    def test_target_not_ready_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(wait_ok=False, target_logs="error: bind failed")
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "TARGET ERROR" in out
+
+    def test_docker_connection_error_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        """DockerConnectionError during preflight returns infra_error."""
+        sandbox = _mock_sandbox()
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit) + ["--output", "json"],
+            sandbox=sandbox,
+            docker_ping_error=FakeDockerConnectionError("Cannot connect to Docker"),
+        )
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["verification_status"] == "infra_error"
+        assert "Docker" in data["error"]
+
+    def test_cleanup_called_on_success(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox()
+        _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        sandbox.cleanup.assert_called_once()
+
+    def test_cleanup_called_on_failure(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(build_ok=False)
+        _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        sandbox.cleanup.assert_called_once()
+
+    def test_timeout_passed_to_sandbox_constructor(self, tmp_dockerfile, tmp_exploit, capsys):
+        """--timeout value is passed to ExploitSandbox constructor."""
+        sandbox = _mock_sandbox()
+        mock_client = MagicMock()
+        mock_client.ping.return_value = True
+        mock_get_docker_client = MagicMock(return_value=mock_client)
+        sandbox_class = MagicMock(return_value=sandbox)
+
+        with patch.dict(
+            "sys.modules",
+            {
+                SANDBOX_MODULE: MagicMock(
+                    ExploitSandbox=sandbox_class,
+                    InterpreterNotFoundError=FakeInterpreterNotFoundError,
+                ),
+                DOCKER_MODULE: MagicMock(
+                    DockerConnectionError=FakeDockerConnectionError,
+                    get_docker_client=mock_get_docker_client,
+                    is_transient_docker_error=MagicMock(return_value=False),
+                    wait_for_container_healthy=MagicMock(),
+                    wait_for_container_running=MagicMock(),
+                ),
+            },
+        ):
+            from manus_agent.cli import _run_verify_exploit
+
+            _run_verify_exploit(self._base_args(tmp_dockerfile, tmp_exploit) + ["--timeout", "600"])
+
+        sandbox_class.assert_called_once_with(timeout=600)
+
+    def test_port_defaults_to_80(self, tmp_dockerfile, tmp_exploit, capsys):
+        """Default port is 80 when not specified."""
+        sandbox = _mock_sandbox()
+        rc = _run_with_mocked_sandbox(
+            [
+                "CVE-2024-3094",
+                "--dockerfile",
+                str(tmp_dockerfile),
+                "--exploit",
+                str(tmp_exploit),
+                "--language",
+                "python",
+            ],
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        # Check that wait_for_target was called with port=80
+        sandbox.wait_for_target.assert_called_once_with(port=80, timeout=60)
+
+    def test_json_includes_metadata_fields(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox()
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit)
+            + [
+                "--output",
+                "json",
+                "--versions",
+                "5.6.0-5.6.1",
+            ],
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["software"] == "xz-utils"
+        assert data["vuln_type"] == "RCE"
+        assert data["port"] == 8080
+        assert data["language"] == "python"
+        assert data["versions"] == "5.6.0-5.6.1"
+
+
+# ===========================================================================
+# Local mode tests
+# ===========================================================================
+
+
+class TestVerifyExploitLocal:
+    def _base_args(self, dockerfile: Path, exploit: Path) -> list[str]:
+        return [
+            "CVE-2025-9999",
+            "--dockerfile",
+            str(dockerfile),
+            "--exploit",
+            str(exploit),
+            "--language",
+            "bash",
+            "--mode",
+            "local",
+            "--software",
+            "sudo",
+            "--vuln-type",
+            "LPE",
+        ]
+
+    def test_local_verified(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 0, "stdout": "uid=0(root)", "stderr": ""})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "EXPLOIT VERIFIED" in out
+        sandbox.run_local_exploit.assert_called_once()
+        sandbox.run_exploit.assert_not_called()
+
+    def test_local_failed(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 127, "stdout": "", "stderr": "not found"})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "EXPLOIT FAILED" in out
+
+    def test_local_json_output(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox(exploit_result={"exit_code": 0, "stdout": "ok", "stderr": ""})
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit) + ["--output", "json"],
+            sandbox=sandbox,
+        )
+        assert rc == 0
+        data = json.loads(capsys.readouterr().out)
+        assert data["mode"] == "local"
+        assert data["verification_status"] == "verified"
+
+    def test_local_container_health_error(self, tmp_dockerfile, tmp_exploit, capsys):
+        sandbox = _mock_sandbox()
+        rc = _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit) + ["--output", "json"],
+            sandbox=sandbox,
+            wait_for_healthy_error=RuntimeError("unhealthy"),
+        )
+        assert rc == 1
+        data = json.loads(capsys.readouterr().out)
+        assert data["verification_status"] == "target_error"
+
+    def test_local_does_not_call_wait_for_target(self, tmp_dockerfile, tmp_exploit, capsys):
+        """Local mode should not call wait_for_target (no port listening)."""
+        sandbox = _mock_sandbox()
+        _run_with_mocked_sandbox(
+            self._base_args(tmp_dockerfile, tmp_exploit),
+            sandbox=sandbox,
+        )
+        sandbox.wait_for_target.assert_not_called()
+
+
+# ===========================================================================
+# Import error handling
+# ===========================================================================
+
+
+class TestVerifyExploitImportErrors:
+    def test_sandbox_import_error_returns_1(self, tmp_dockerfile, tmp_exploit, capsys):
+        """If sandbox modules cannot be imported, return 1 with message."""
+        import builtins
+
+        real_import = builtins.__import__
+
+        def _fail_sandbox_import(name, *args, **kwargs):
+            if "exploit_sandbox" in name or "docker_client" in name:
+                raise ImportError(f"No module: {name}")
+            return real_import(name, *args, **kwargs)
+
+        with patch("builtins.__import__", side_effect=_fail_sandbox_import):
+            from manus_agent.cli import _run_verify_exploit
+
+            rc = _run_verify_exploit(
+                [
+                    "CVE-2024-5555",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    "python",
+                ]
+            )
+
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Error importing sandbox modules" in err
+
+
+# ===========================================================================
+# Output formatting tests
+# ===========================================================================
+
+
+class TestVerifyExploitOutput:
+    def test_output_function_verified(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-1111",
+            "mode": "remote",
+            "software": "nginx",
+            "vuln_type": "RCE",
+            "elapsed_seconds": 5.2,
+            "stdout": "root shell obtained\nid=0\n",
+        }
+        rc = _verify_exploit_output(data, "text", "verified")
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "EXPLOIT VERIFIED" in out
+        assert "CVE-2024-1111" in out
+        assert "nginx" in out
+
+    def test_output_function_failed(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-2222",
+            "mode": "local",
+            "software": "sudo",
+            "vuln_type": "LPE",
+            "elapsed_seconds": 2.1,
+            "exit_code": 1,
+            "stderr": "permission denied",
+        }
+        rc = _verify_exploit_output(data, "text", "failed")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "EXPLOIT FAILED" in out
+        assert "permission denied" in out
+
+    def test_output_function_build_error(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-3333",
+            "mode": "remote",
+            "error": "dockerfile syntax error",
+            "build_log": "Step 1: OK\nStep 2: FAIL\n",
+            "elapsed_seconds": 1.0,
+        }
+        rc = _verify_exploit_output(data, "text", "build_error")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "BUILD ERROR" in out
+
+    def test_output_function_target_error(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-4444",
+            "mode": "remote",
+            "error": "port not open",
+            "target_logs": "segfault\n",
+            "elapsed_seconds": 61.0,
+        }
+        rc = _verify_exploit_output(data, "text", "target_error")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "TARGET ERROR" in out
+
+    def test_output_function_infra_error(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-5555",
+            "mode": "remote",
+            "error": "Docker daemon crashed",
+            "diagnosis": "OOM kill",
+            "remediation": "Increase memory",
+            "elapsed_seconds": 0.1,
+        }
+        rc = _verify_exploit_output(data, "text", "infra_error")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "INFRA ERROR" in out
+        assert "OOM kill" in out
+        assert "Increase memory" in out
+
+    def test_output_function_json_format(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        data = {
+            "cve_id": "CVE-2024-6666",
+            "verification_status": "verified",
+            "exit_code": 0,
+        }
+        rc = _verify_exploit_output(data, "json", "verified")
+        assert rc == 0
+        parsed = json.loads(capsys.readouterr().out)
+        assert parsed["cve_id"] == "CVE-2024-6666"
+
+    def test_output_long_stdout_truncated(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        long_stdout = "\n".join(f"line {i}" for i in range(100))
+        data = {
+            "cve_id": "CVE-2024-7777",
+            "mode": "remote",
+            "software": "test",
+            "vuln_type": "test",
+            "elapsed_seconds": 1.0,
+            "stdout": long_stdout,
+        }
+        rc = _verify_exploit_output(data, "text", "verified")
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "more lines" in out
+
+    def test_output_long_stderr_truncated(self, capsys):
+        from manus_agent.cli import _verify_exploit_output
+
+        long_stderr = "\n".join(f"err {i}" for i in range(60))
+        data = {
+            "cve_id": "CVE-2024-8888",
+            "mode": "remote",
+            "software": "test",
+            "vuln_type": "test",
+            "elapsed_seconds": 1.0,
+            "exit_code": 1,
+            "stderr": long_stderr,
+        }
+        rc = _verify_exploit_output(data, "text", "failed")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "more lines" in out
+
+
+# ===========================================================================
+# Dispatch integration
+# ===========================================================================
+
+
+class TestVerifyExploitDispatch:
+    def test_subcommand_in_source(self):
+        """verify-exploit is registered in the subcommands set."""
+        import manus_agent.cli as cli_mod
+
+        source = Path(cli_mod.__file__).read_text()
+        assert '"verify-exploit"' in source
+
+    def test_help_flag(self, capsys):
+        """--help exits 0 with usage info."""
+        with pytest.raises(SystemExit) as exc_info:
+            _run(["--help"])
+        assert exc_info.value.code == 0
+        out = capsys.readouterr().out
+        assert "CVE-ID" in out
+
+    def test_all_languages_accepted(self, tmp_dockerfile, tmp_exploit, capsys):
+        """All documented language choices are accepted by the parser."""
+        for lang in ["python", "bash", "sh", "javascript", "ruby", "perl"]:
+            sandbox = _mock_sandbox()
+            rc = _run_with_mocked_sandbox(
+                [
+                    "CVE-2024-1234",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    lang,
+                ],
+                sandbox=sandbox,
+            )
+            assert rc == 0, f"Failed for language: {lang}"
+
+    def test_mode_choices(self, tmp_dockerfile, tmp_exploit, capsys):
+        """Both remote and local modes are accepted."""
+        for mode in ["remote", "local"]:
+            sandbox = _mock_sandbox()
+            rc = _run_with_mocked_sandbox(
+                [
+                    "CVE-2024-1234",
+                    "--dockerfile",
+                    str(tmp_dockerfile),
+                    "--exploit",
+                    str(tmp_exploit),
+                    "--language",
+                    "python",
+                    "--mode",
+                    mode,
+                ],
+                sandbox=sandbox,
+            )
+            assert rc == 0, f"Failed for mode: {mode}"


### PR DESCRIPTION
## Summary

Wires the existing `ExploitSandbox` as a standalone CLI command:

```bash
manus-agent verify-exploit CVE-2024-3094 \
    --dockerfile ./target.Dockerfile \
    --exploit ./exploit.py --language python
```

## Features

- **Remote mode** (default): exploit runs in separate container attacking the target over an isolated Docker network
- **Local mode**: exploit runs inside target container (for LPE, file parsing bugs, etc.)
- Docker preflight check with clear diagnostics on failure
- Text and JSON output formats
- Structured error handling with distinct statuses: `verified`, `failed`, `build_error`, `target_error`, `infra_error`, `exploit_error`
- Cleanup guaranteed via `finally` block
- Supports `--port`, `--timeout`, `--env`, `--software`, `--versions`, `--vuln-type` metadata

## Usage

```bash
# Remote RCE verification
manus-agent verify-exploit CVE-2024-3094 \
    --dockerfile ./target.Dockerfile \
    --exploit ./exploit.py --language python \
    --port 8080 --software xz-utils --vuln-type RCE

# Local privilege escalation
manus-agent verify-exploit CVE-2025-1234 \
    --dockerfile ./Dockerfile --exploit ./exploit.sh \
    --language bash --mode local

# JSON output for CI integration
manus-agent verify-exploit CVE-2024-9999 \
    --dockerfile ./Dockerfile --exploit ./exploit.py \
    --language python --output json
```

## Tests

- **39 new tests** covering parser validation, remote/local modes, error paths, output formatting, import errors, and dispatch integration
- All fully mocked — no Docker daemon required
- `ruff check` and `ruff format` clean
- Full test suite passes (1197 tests)

## Implementation Pattern

Follows the established CLI subcommand pattern (`_run_poc_search`, `_run_blast_radius`):
1. `_build_verify_exploit_parser()` — argparse setup
2. `_run_verify_exploit(argv)` — main logic
3. `_verify_exploit_output(data, fmt, status)` — formatting helper
4. Dispatch entry in the main CLI router