### PR TITLE
test: add shared conftest.py with reusable test fixtures

### DIFF
--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -1,0 +1,109 @@
+
+## PR #111 — OSV per-package CVE lookup in get_dependency_blast_radius
+
+**Branch:** `feat/osv-package-cve-lookup`
+**Date:** 2026-07-09
+**Status:** Open
+
+### Problem
+
+`get_dependency_blast_radius` showed blast-radius exposure metrics (downloads,
+dependents) for direct package queries but never asked: *does this package have
+known CVEs?*  The OSV `/v1/query` endpoint existed and was used elsewhere in the
+codebase (for CVE→affected-packages lookups) but was never called in the direct
+package path.
+
+### Solution
+
+New helper `_fetch_osv_package_vulns(name, ecosystem, version, max_vulns)`:
+- POSTs to `https://api.osv.dev/v1/query` with package + optional version
+- `_ECOSYSTEM_TO_OSV` dict maps 31 input aliases → canonical OSV ecosystem strings
+  (covers PyPI, npm, Maven, Go, crates.io, RubyGems, NuGet, Packagist, Hex, Pub, Conda)
+- Parses id, summary (≤120 chars), aliases, fixed version from range events
+- Graceful empty-list return on all errors
+
+`get_dependency_blast_radius` direct package path:
+- Calls `_fetch_osv_package_vulns` post-enrichment; version-scoped when version given
+- New output section: `Known CVEs (OSV) affecting @X.Y.Z: N` with per-advisory bullets
+- Summary line: `Known CVEs from OSV affecting version X.Y.Z: N`
+- CVE input path unchanged (function never called there)
+
+### Tests
+
+35 new tests across `TestEcosystemToOsvMapping`, `TestFetchOsvPackageVulns`,
+`TestBlastRadiusOsvIntegration`. Suite: 1193 passed (was 1158).
+
+### Suggested next contributions
+
+- **Swift Package Index enricher** — `_enrich_swift`: API at
+  `swiftpackageindex.com/api/packages/{owner}/{package}`; complication is needing
+  owner/repo format; map to OSV ecosystem `SwiftURL`
+- **Conda enricher** — `_enrich_conda` is already in PR #110; check if merged
+- **Extend `_ECOSYSTEM_TO_OSV`** to cover Conda/Bioconda once PR #110 lands
+- **`first_release_date` for crates.io** (extend PR #103 analogue)
+
+---
+
+## Session N+4 — feat/enrich-cran (PR #113)
+
+### Contribution
+
+Added `_enrich_cran()` enricher to `get_dependency_blast_radius.py`, extending
+the blast-radius tool with native **CRAN (R)** package support.
+
+### Ecosystem selection rationale
+
+- Checked all open PRs (#103–#112): none covered CRAN.
+- OSV ecosystem list confirms `CRAN` as a valid, active ecosystem with real
+  advisories (e.g., `jsonlite`, `openssl`, `httr` packages).
+- Swift Package Index API returned 401 (auth required) — ruled out.
+- ConanCenter API returned HTML/404 for REST queries — ruled out.
+- crandb and cranlogs: both free, unauthenticated, JSON, confirmed working.
+
+### Implementation summary
+
+**Constants**: `_CRANDB_URL`, `_CRANLOGS_URL`
+
+**New helper**: `_parse_cran_timestamp(ts)` — normalises crandb ISO-8601
+timestamps (`"2014-10-21T08:27:55+00:00"` or `"...Z"`) to `"YYYY-MM-DD"` by
+slicing the first 10 characters.
+
+**New enricher**: `_enrich_cran(name)`:
+- Call 1: `crandb.r-pkg.org/{name}/all` → latest version, title (max 120 chars),
+  archived flag, `revdeps` (→ `dependent_packages_count`), version timeline count,
+  first-release date, age in years, CRAN page URL.
+- Call 2: `cranlogs.r-pkg.org/downloads/total/last-month/{name}` → monthly
+  downloads; `weekly_downloads = monthly // 4` (integer floor division).
+- Independent try/except per call for graceful degradation.
+- Both-fail fallback: `{ecosystem: "CRAN", package_name: name}` without raising.
+
+**Dispatcher**: `eco_lower in ("cran", "r")` in `_enrich_package` — covers
+`cran:openssl` and `r:openssl` input forms.
+
+**Output block**: title, latest version, total versions, reverse deps, monthly
+downloads, first release + age, archived status, CRAN page URL.  Fixed npm
+dependents label to show only for npm ecosystem (previously shown for any
+ecosystem with `dependent_packages_count`).
+
+### Tests
+
+30 new tests (6 classes, all HTTP mocked):
+`TestParseCranTimestamp` (6), `TestEnrichCranHappyPath` (16),
+`TestEnrichCranDegradation` (7), `TestEnrichPackageCranDispatch` (5),
+`TestBlastScoreWithCranData` (6), `TestGetDependencyBlastRadiusCran` (9).
+
+Suite: **1206 passed** (was 1158 before this session series; +30 this PR).
+3 deselected, 3 warnings — all pre-existing, zero regressions.
+
+### Suggested next contributions
+
+- **Hackage enricher** (`_enrich_hackage`) — Haskell package registry; OSV
+  ecosystem `Hackage`; API: `hackage.haskell.org/package/{name}.json` (free,
+  unauthenticated). Revdeps via `hackage.haskell.org/package/{name}/reverse`.
+- **opam enricher** (`_enrich_opam`) — OCaml package registry; OSV ecosystem
+  `OSS-Fuzz`/`crates.io` alignment; API: `opam.ocaml.org/pkg/{name}/latest`
+  (JSON, no auth).
+- **OSV `_ECOSYSTEM_TO_OSV` coverage** — extend the mapping to include CRAN
+  once this PR merges.
+- **Per-version CVE integration for CRAN** — `manus-agent blast-radius
+  cran:openssl@2.1.1` should call `_fetch_osv_package_vulns("openssl", "CRAN", "2.1.1")`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,559 @@
+"""Shared pytest fixtures and factories for manus-agent tests.
+
+This module provides reusable test infrastructure that eliminates common
+boilerplate across test files:
+
+- **Tool-use factories**: build valid Strands tool_use dicts with minimal args
+- **HTTP response mocks**: construct ``requests.Response``-like mocks
+- **CVE data factories**: realistic NVD, EPSS, KEV, and OSV payloads
+- **Config fixtures**: pre-built Config objects for common provider scenarios
+- **Temporary paths**: isolated tmp directories for history/config files
+
+Usage
+-----
+Fixtures are auto-discovered by pytest. Import nothing — just declare the
+fixture name as a test function parameter::
+
+    def test_something(make_tool_use, mock_http_response):
+        tool_use = make_tool_use("get_nvd_data", cve_id="CVE-2024-1234")
+        response = mock_http_response(200, {"vulnerabilities": []})
+        ...
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+import requests.exceptions
+
+# ===========================================================================
+# Tool-use factories
+# ===========================================================================
+
+
+@pytest.fixture
+def make_tool_use():
+    """Factory fixture for creating Strands tool_use dicts.
+
+    Returns a callable: ``make_tool_use(tool_name_or_id=None, **input_kwargs)``
+
+    Examples::
+
+        tool_use = make_tool_use(cve_id="CVE-2024-3094")
+        tool_use = make_tool_use("get_nvd_data", cve_id="CVE-2024-3094")
+        tool_use = make_tool_use(tool_use_id="custom-id", cve_id="CVE-2024-3094")
+    """
+
+    def _factory(tool_name: str | None = None, *, tool_use_id: str | None = None, **input_kwargs) -> dict[str, Any]:
+        return {
+            "toolUseId": tool_use_id or f"test-{uuid.uuid4().hex[:8]}",
+            "name": tool_name or "test_tool",
+            "input": input_kwargs,
+        }
+
+    return _factory
+
+
+# ===========================================================================
+# HTTP response mocks
+# ===========================================================================
+
+
+@pytest.fixture
+def mock_http_response():
+    """Factory fixture for creating mock ``requests.Response`` objects.
+
+    Returns a callable: ``mock_http_response(status_code, json_payload=None, text=None)``
+
+    The returned mock supports:
+    - ``.status_code``
+    - ``.json()`` → returns *json_payload*
+    - ``.text`` → returns *text* or serialised JSON
+    - ``.raise_for_status()`` → raises HTTPError for 4xx/5xx
+    - ``.headers`` → empty dict (overridable)
+    - ``.links`` → empty dict (overridable, useful for pagination mocks)
+
+    Examples::
+
+        resp = mock_http_response(200, {"data": [...]})
+        resp = mock_http_response(429)  # triggers raise_for_status
+        resp = mock_http_response(200, text="plain text body")
+    """
+
+    def _factory(
+        status_code: int = 200,
+        json_payload: Any = None,
+        *,
+        text: str | None = None,
+        headers: dict[str, str] | None = None,
+        links: dict | None = None,
+    ) -> MagicMock:
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = headers or {}
+        resp.links = links or {}
+
+        if json_payload is not None:
+            resp.json.return_value = json_payload
+            resp.text = text if text is not None else json.dumps(json_payload)
+        else:
+            resp.json.side_effect = ValueError("No JSON payload configured")
+            resp.text = text or ""
+
+        if status_code >= 400:
+            http_error = requests.exceptions.HTTPError(
+                f"{status_code} Error",
+                response=resp,
+            )
+            resp.raise_for_status.side_effect = http_error
+        else:
+            resp.raise_for_status.return_value = None
+
+        return resp
+
+    return _factory
+
+
+# ===========================================================================
+# CVE data factories
+# ===========================================================================
+
+
+@pytest.fixture
+def nvd_cve_factory():
+    """Factory for building realistic NVD CVE response payloads.
+
+    Returns a callable that produces a single NVD vulnerability entry::
+
+        cve = nvd_cve_factory("CVE-2024-3094", base_score=10.0, severity="CRITICAL")
+    """
+
+    def _factory(
+        cve_id: str = "CVE-2024-1234",
+        *,
+        base_score: float = 9.8,
+        severity: str = "CRITICAL",
+        attack_vector: str = "NETWORK",
+        privileges_required: str = "NONE",
+        user_interaction: str = "NONE",
+        scope: str = "UNCHANGED",
+        description: str = "A critical vulnerability.",
+        cwe: str = "CWE-79",
+        published: str = "2024-01-15T10:00:00.000",
+        cpe_criteria: str | None = None,
+    ) -> dict[str, Any]:
+        cve_entry: dict[str, Any] = {
+            "id": cve_id,
+            "published": published,
+            "descriptions": [{"lang": "en", "value": description}],
+            "metrics": {
+                "cvssMetricV31": [
+                    {
+                        "cvssData": {
+                            "version": "3.1",
+                            "baseScore": base_score,
+                            "baseSeverity": severity,
+                            "vectorString": (
+                                f"CVSS:3.1/AV:{attack_vector[0]}/AC:L"
+                                f"/PR:{privileges_required[0]}/UI:{user_interaction[0]}"
+                                f"/S:{scope[0]}/C:H/I:H/A:H"
+                            ),
+                            "attackVector": attack_vector,
+                            "privilegesRequired": privileges_required,
+                            "userInteraction": user_interaction,
+                            "scope": scope,
+                        }
+                    }
+                ]
+            },
+            "weaknesses": [{"description": [{"lang": "en", "value": cwe}]}],
+        }
+
+        if cpe_criteria:
+            cve_entry["configurations"] = [{"nodes": [{"cpeMatch": [{"criteria": cpe_criteria, "vulnerable": True}]}]}]
+
+        return cve_entry
+
+    return _factory
+
+
+@pytest.fixture
+def nvd_api_response(nvd_cve_factory):
+    """Factory for building a full NVD API JSON response wrapping one or more CVEs.
+
+    Returns a callable::
+
+        payload = nvd_api_response("CVE-2024-3094")
+        payload = nvd_api_response(cve_entries=[cve1, cve2])
+    """
+
+    def _factory(
+        cve_id: str | None = None,
+        *,
+        cve_entries: list[dict] | None = None,
+        **cve_kwargs,
+    ) -> dict[str, Any]:
+        if cve_entries is not None:
+            vulns = [{"cve": entry} for entry in cve_entries]
+        else:
+            entry = nvd_cve_factory(cve_id or "CVE-2024-1234", **cve_kwargs)
+            vulns = [{"cve": entry}]
+
+        return {
+            "resultsPerPage": len(vulns),
+            "startIndex": 0,
+            "totalResults": len(vulns),
+            "vulnerabilities": vulns,
+        }
+
+    return _factory
+
+
+@pytest.fixture
+def epss_data_factory():
+    """Factory for building EPSS API response payloads.
+
+    Returns a callable::
+
+        payload = epss_data_factory("CVE-2024-3094", epss=0.95, percentile=0.99)
+    """
+
+    def _factory(
+        cve_id: str = "CVE-2024-1234",
+        *,
+        epss: float = 0.5,
+        percentile: float = 0.85,
+        date: str = "2024-06-01",
+        time_series: list[dict[str, str]] | None = None,
+    ) -> dict[str, Any]:
+        entry: dict[str, Any] = {
+            "cve": cve_id,
+            "epss": str(epss),
+            "percentile": str(percentile),
+            "date": date,
+        }
+        if time_series is not None:
+            entry["time-series"] = time_series
+
+        return {
+            "status": "OK",
+            "status-code": 200,
+            "version": "1.0",
+            "total": 1,
+            "offset": 0,
+            "limit": 100,
+            "data": [entry],
+        }
+
+    return _factory
+
+
+@pytest.fixture
+def kev_catalog_factory():
+    """Factory for building a CISA KEV catalog payload.
+
+    Returns a callable::
+
+        catalog = kev_catalog_factory(["CVE-2021-44228", "CVE-2024-3094"])
+        catalog = kev_catalog_factory()  # empty catalog
+    """
+
+    def _factory(
+        cve_ids: list[str] | None = None,
+    ) -> dict[str, Any]:
+        vulns = []
+        for cve_id in cve_ids or []:
+            vulns.append(
+                {
+                    "cveID": cve_id,
+                    "vendorProject": "TestVendor",
+                    "product": "TestProduct",
+                    "vulnerabilityName": f"Test Vulnerability {cve_id}",
+                    "dateAdded": "2024-01-01",
+                    "dueDate": "2024-01-15",
+                    "requiredAction": "Apply updates per vendor guidance.",
+                    "knownRansomwareCampaignUse": "Unknown",
+                }
+            )
+
+        return {
+            "title": "CISA KEV Catalog",
+            "catalogVersion": "2024.01.01",
+            "dateReleased": "2024-01-01T00:00:00.000Z",
+            "count": len(vulns),
+            "vulnerabilities": vulns,
+        }
+
+    return _factory
+
+
+@pytest.fixture
+def osv_record_factory():
+    """Factory for building OSV.dev vulnerability records.
+
+    Returns a callable::
+
+        record = osv_record_factory("CVE-2021-44228", ecosystem="Maven",
+                                     package="org.apache.logging.log4j:log4j-core")
+    """
+
+    def _factory(
+        cve_id: str = "CVE-2024-1234",
+        *,
+        osv_id: str | None = None,
+        ecosystem: str = "PyPI",
+        package: str = "example-package",
+        introduced: str = "0",
+        fixed: str = "2.0.0",
+        summary: str = "A vulnerability.",
+    ) -> dict[str, Any]:
+        return {
+            "id": osv_id or f"GHSA-{uuid.uuid4().hex[:4]}-{uuid.uuid4().hex[:4]}-{uuid.uuid4().hex[:4]}",
+            "aliases": [cve_id],
+            "summary": summary,
+            "modified": "2024-06-01T00:00:00Z",
+            "published": "2024-01-15T00:00:00Z",
+            "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"}],
+            "affected": [
+                {
+                    "package": {"ecosystem": ecosystem, "name": package},
+                    "ranges": [
+                        {
+                            "type": "ECOSYSTEM",
+                            "events": [{"introduced": introduced}, {"fixed": fixed}],
+                        }
+                    ],
+                }
+            ],
+            "references": [{"type": "WEB", "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}"}],
+        }
+
+    return _factory
+
+
+# ===========================================================================
+# Config fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def default_config():
+    """A default Config instance with no overrides (uses built-in defaults)."""
+    from manus_agent.config import Config
+
+    return Config()
+
+
+@pytest.fixture
+def bedrock_config():
+    """A Config instance configured for AWS Bedrock."""
+    from manus_agent.config import Config, LLMConfig
+
+    return Config(llm=LLMConfig(provider="bedrock", model="us.anthropic.claude-sonnet-4-20250514-v1:0"))
+
+
+@pytest.fixture
+def openai_config():
+    """A Config instance configured for OpenAI."""
+    from manus_agent.config import Config, LLMConfig
+
+    return Config(llm=LLMConfig(provider="openai", model="gpt-4o", api_key="sk-test-key"))
+
+
+@pytest.fixture
+def anthropic_config():
+    """A Config instance configured for Anthropic."""
+    from manus_agent.config import Config, LLMConfig
+
+    return Config(llm=LLMConfig(provider="anthropic", model="claude-3-5-sonnet-20241022", api_key="test-key"))
+
+
+@pytest.fixture
+def ollama_config():
+    """A Config instance configured for Ollama (local)."""
+    from manus_agent.config import Config, LLMConfig
+
+    return Config(llm=LLMConfig(provider="ollama", model="llama3", base_url="http://localhost:11434"))
+
+
+# ===========================================================================
+# Temporary file system fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def tmp_history_file(tmp_path: Path):
+    """Provides a temporary history.jsonl file path.
+
+    Returns a tuple: ``(history_path, write_record_fn)``
+
+    The *write_record_fn* appends a record and returns the path::
+
+        history_path, write = tmp_history_file
+        write(task="analyse CVE", success=True)
+    """
+    history_path = tmp_path / "history.jsonl"
+
+    def _write_record(
+        task: str = "test task",
+        success: bool = True,
+        agent: str = "manus",
+        mode: str = "single",
+        format: str = "text",
+        result: str = "ok",
+    ) -> Path:
+        import datetime
+
+        record = {
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "task": task,
+            "agent": agent,
+            "mode": mode,
+            "format": format,
+            "success": success,
+            "result": result,
+        }
+        with history_path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        return history_path
+
+    return history_path, _write_record
+
+
+@pytest.fixture
+def tmp_config_file(tmp_path: Path):
+    """Provides a temporary config.toml file path.
+
+    Returns a callable: ``tmp_config_file(content_dict)`` that writes TOML
+    and returns the path::
+
+        config_path = tmp_config_file({"llm": {"provider": "openai", "model": "gpt-4"}})
+    """
+    import toml
+
+    config_path = tmp_path / "config.toml"
+
+    def _write(content: dict[str, Any]) -> Path:
+        config_path.write_text(toml.dumps(content), encoding="utf-8")
+        return config_path
+
+    return _write
+
+
+# ===========================================================================
+# Environment helpers
+# ===========================================================================
+
+
+@pytest.fixture
+def env_override(monkeypatch):
+    """Fixture for setting environment variables cleanly.
+
+    Returns a callable: ``env_override(VAR_NAME="value", OTHER="value")``
+
+    Variables are automatically restored after the test.
+
+    Examples::
+
+        env_override(NVD_API_KEY="test-key", VULNCHECK_API_KEY="vc-key")
+    """
+
+    def _set(**kwargs: str | None) -> None:
+        for key, value in kwargs.items():
+            if value is None:
+                monkeypatch.delenv(key, raising=False)
+            else:
+                monkeypatch.setenv(key, value)
+
+    return _set
+
+
+# ===========================================================================
+# Well-known CVE data constants (importable from conftest)
+# ===========================================================================
+
+# These are module-level constants that can be imported directly in tests
+# that need pre-built CVE data without going through fixtures.
+
+SAMPLE_CVE_LOG4SHELL = {
+    "id": "CVE-2021-44228",
+    "published": "2021-12-10T10:15:09.143",
+    "descriptions": [{"lang": "en", "value": "Apache Log4j2 RCE vulnerability via JNDI lookup injection"}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 10.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                    "scope": "CHANGED",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"lang": "en", "value": "CWE-917"}]}],
+    "configurations": [
+        {
+            "nodes": [
+                {
+                    "cpeMatch": [
+                        {
+                            "criteria": "cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*",
+                            "vulnerable": True,
+                            "versionStartIncluding": "2.0-beta9",
+                            "versionEndExcluding": "2.15.0",
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+}
+
+SAMPLE_CVE_XZ = {
+    "id": "CVE-2024-3094",
+    "published": "2024-03-29T17:15:21.940",
+    "descriptions": [{"lang": "en", "value": "Malicious code in xz/liblzma leading to SSH auth bypass"}],
+    "metrics": {
+        "cvssMetricV31": [
+            {
+                "cvssData": {
+                    "version": "3.1",
+                    "baseScore": 10.0,
+                    "baseSeverity": "CRITICAL",
+                    "vectorString": "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:C/C:H/I:H/A:H",
+                    "attackVector": "NETWORK",
+                    "privilegesRequired": "NONE",
+                    "userInteraction": "NONE",
+                    "scope": "CHANGED",
+                }
+            }
+        ]
+    },
+    "weaknesses": [{"description": [{"lang": "en", "value": "CWE-506"}]}],
+    "configurations": [
+        {
+            "nodes": [
+                {
+                    "cpeMatch": [
+                        {
+                            "criteria": "cpe:2.3:a:tukaani:xz:*:*:*:*:*:*:*:*",
+                            "vulnerable": True,
+                            "versionStartIncluding": "5.6.0",
+                            "versionEndIncluding": "5.6.1",
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+}

--- a/tests/test_conftest_fixtures.py
+++ b/tests/test_conftest_fixtures.py
@@ -1,0 +1,398 @@
+"""Tests validating the conftest.py shared fixtures themselves.
+
+These tests serve dual purposes:
+1. Verify that all shared fixtures work correctly (regression guard)
+2. Document usage patterns for future test authors
+
+Run with: pytest tests/test_conftest_fixtures.py -v
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+import requests.exceptions
+
+# ===========================================================================
+# make_tool_use fixture
+# ===========================================================================
+
+
+class TestMakeToolUse:
+    """Verify the make_tool_use factory fixture."""
+
+    def test_creates_valid_tool_use_dict(self, make_tool_use):
+        tool_use = make_tool_use(cve_id="CVE-2024-3094")
+        assert "toolUseId" in tool_use
+        assert "input" in tool_use
+        assert tool_use["input"]["cve_id"] == "CVE-2024-3094"
+
+    def test_auto_generates_unique_ids(self, make_tool_use):
+        t1 = make_tool_use(cve_id="CVE-2024-0001")
+        t2 = make_tool_use(cve_id="CVE-2024-0002")
+        assert t1["toolUseId"] != t2["toolUseId"]
+
+    def test_accepts_custom_tool_use_id(self, make_tool_use):
+        tool_use = make_tool_use(tool_use_id="my-custom-id", cve_id="CVE-2024-1234")
+        assert tool_use["toolUseId"] == "my-custom-id"
+
+    def test_accepts_tool_name(self, make_tool_use):
+        tool_use = make_tool_use("get_nvd_data", cve_id="CVE-2024-1234")
+        assert tool_use["name"] == "get_nvd_data"
+
+    def test_multiple_input_kwargs(self, make_tool_use):
+        tool_use = make_tool_use("compare_cves", cve_id_a="CVE-2021-44228", cve_id_b="CVE-2024-3094")
+        assert tool_use["input"]["cve_id_a"] == "CVE-2021-44228"
+        assert tool_use["input"]["cve_id_b"] == "CVE-2024-3094"
+
+    def test_empty_input_valid(self, make_tool_use):
+        tool_use = make_tool_use("check_cisa_kev")
+        assert tool_use["input"] == {}
+
+
+# ===========================================================================
+# mock_http_response fixture
+# ===========================================================================
+
+
+class TestMockHttpResponse:
+    """Verify the mock_http_response factory fixture."""
+
+    def test_200_response_with_json(self, mock_http_response):
+        resp = mock_http_response(200, {"data": [1, 2, 3]})
+        assert resp.status_code == 200
+        assert resp.json() == {"data": [1, 2, 3]}
+        resp.raise_for_status()  # should not raise
+
+    def test_429_raises_on_raise_for_status(self, mock_http_response):
+        resp = mock_http_response(429)
+        assert resp.status_code == 429
+        with pytest.raises(requests.exceptions.HTTPError):
+            resp.raise_for_status()
+
+    def test_500_raises_on_raise_for_status(self, mock_http_response):
+        resp = mock_http_response(500)
+        with pytest.raises(requests.exceptions.HTTPError):
+            resp.raise_for_status()
+
+    def test_text_body_override(self, mock_http_response):
+        resp = mock_http_response(200, text="plain text body")
+        assert resp.text == "plain text body"
+
+    def test_json_serialised_as_text_by_default(self, mock_http_response):
+        payload = {"key": "value"}
+        resp = mock_http_response(200, payload)
+        assert json.loads(resp.text) == payload
+
+    def test_no_json_raises_valueerror(self, mock_http_response):
+        resp = mock_http_response(200, text="not json")
+        with pytest.raises(ValueError):
+            resp.json()
+
+    def test_custom_headers(self, mock_http_response):
+        resp = mock_http_response(200, headers={"X-Custom": "yes"})
+        assert resp.headers["X-Custom"] == "yes"
+
+    def test_links_for_pagination(self, mock_http_response):
+        resp = mock_http_response(200, {"items": []}, links={"next": {"url": "http://example.com/page2"}})
+        assert "next" in resp.links
+
+
+# ===========================================================================
+# nvd_cve_factory fixture
+# ===========================================================================
+
+
+class TestNvdCveFactory:
+    """Verify the NVD CVE data factory."""
+
+    def test_default_cve_has_required_fields(self, nvd_cve_factory):
+        cve = nvd_cve_factory()
+        assert cve["id"] == "CVE-2024-1234"
+        assert cve["published"]
+        assert len(cve["descriptions"]) >= 1
+        assert "cvssMetricV31" in cve["metrics"]
+
+    def test_custom_cve_id(self, nvd_cve_factory):
+        cve = nvd_cve_factory("CVE-2021-44228")
+        assert cve["id"] == "CVE-2021-44228"
+
+    def test_custom_cvss_score(self, nvd_cve_factory):
+        cve = nvd_cve_factory(base_score=7.5, severity="HIGH")
+        cvss = cve["metrics"]["cvssMetricV31"][0]["cvssData"]
+        assert cvss["baseScore"] == 7.5
+        assert cvss["baseSeverity"] == "HIGH"
+
+    def test_custom_attack_vector(self, nvd_cve_factory):
+        cve = nvd_cve_factory(attack_vector="LOCAL", privileges_required="HIGH")
+        cvss = cve["metrics"]["cvssMetricV31"][0]["cvssData"]
+        assert cvss["attackVector"] == "LOCAL"
+        assert cvss["privilegesRequired"] == "HIGH"
+
+    def test_cpe_criteria_creates_configurations(self, nvd_cve_factory):
+        cve = nvd_cve_factory(cpe_criteria="cpe:2.3:a:apache:log4j:*:*:*:*:*:*:*:*")
+        assert "configurations" in cve
+        assert cve["configurations"][0]["nodes"][0]["cpeMatch"][0]["vulnerable"] is True
+
+    def test_no_cpe_means_no_configurations(self, nvd_cve_factory):
+        cve = nvd_cve_factory()
+        assert "configurations" not in cve
+
+    def test_custom_cwe(self, nvd_cve_factory):
+        cve = nvd_cve_factory(cwe="CWE-502")
+        assert cve["weaknesses"][0]["description"][0]["value"] == "CWE-502"
+
+
+# ===========================================================================
+# nvd_api_response fixture
+# ===========================================================================
+
+
+class TestNvdApiResponse:
+    """Verify the full NVD API response wrapper."""
+
+    def test_single_cve_response(self, nvd_api_response):
+        payload = nvd_api_response("CVE-2024-3094")
+        assert payload["totalResults"] == 1
+        assert payload["vulnerabilities"][0]["cve"]["id"] == "CVE-2024-3094"
+
+    def test_multiple_cves(self, nvd_api_response, nvd_cve_factory):
+        cve1 = nvd_cve_factory("CVE-2024-0001")
+        cve2 = nvd_cve_factory("CVE-2024-0002")
+        payload = nvd_api_response(cve_entries=[cve1, cve2])
+        assert payload["totalResults"] == 2
+
+    def test_passes_kwargs_to_cve_factory(self, nvd_api_response):
+        payload = nvd_api_response("CVE-2024-3094", base_score=10.0)
+        cvss = payload["vulnerabilities"][0]["cve"]["metrics"]["cvssMetricV31"][0]["cvssData"]
+        assert cvss["baseScore"] == 10.0
+
+
+# ===========================================================================
+# epss_data_factory fixture
+# ===========================================================================
+
+
+class TestEpssDataFactory:
+    """Verify the EPSS data factory."""
+
+    def test_default_payload_structure(self, epss_data_factory):
+        payload = epss_data_factory()
+        assert payload["status"] == "OK"
+        assert len(payload["data"]) == 1
+        assert payload["data"][0]["cve"] == "CVE-2024-1234"
+
+    def test_custom_epss_values(self, epss_data_factory):
+        payload = epss_data_factory("CVE-2021-44228", epss=0.975, percentile=0.999)
+        entry = payload["data"][0]
+        assert entry["epss"] == "0.975"
+        assert entry["percentile"] == "0.999"
+
+    def test_with_time_series(self, epss_data_factory):
+        series = [
+            {"date": "2024-06-01", "epss": "0.5", "percentile": "0.85"},
+            {"date": "2024-06-02", "epss": "0.6", "percentile": "0.87"},
+        ]
+        payload = epss_data_factory(time_series=series)
+        assert payload["data"][0]["time-series"] == series
+
+
+# ===========================================================================
+# kev_catalog_factory fixture
+# ===========================================================================
+
+
+class TestKevCatalogFactory:
+    """Verify the KEV catalog factory."""
+
+    def test_empty_catalog(self, kev_catalog_factory):
+        catalog = kev_catalog_factory()
+        assert catalog["vulnerabilities"] == []
+        assert catalog["count"] == 0
+
+    def test_catalog_with_cves(self, kev_catalog_factory):
+        catalog = kev_catalog_factory(["CVE-2021-44228", "CVE-2024-3094"])
+        assert catalog["count"] == 2
+        cve_ids = [v["cveID"] for v in catalog["vulnerabilities"]]
+        assert "CVE-2021-44228" in cve_ids
+        assert "CVE-2024-3094" in cve_ids
+
+    def test_catalog_entries_have_required_fields(self, kev_catalog_factory):
+        catalog = kev_catalog_factory(["CVE-2024-1234"])
+        entry = catalog["vulnerabilities"][0]
+        assert "cveID" in entry
+        assert "vendorProject" in entry
+        assert "dateAdded" in entry
+        assert "requiredAction" in entry
+
+
+# ===========================================================================
+# osv_record_factory fixture
+# ===========================================================================
+
+
+class TestOsvRecordFactory:
+    """Verify the OSV record factory."""
+
+    def test_default_record_structure(self, osv_record_factory):
+        record = osv_record_factory()
+        assert "id" in record
+        assert "aliases" in record
+        assert "affected" in record
+        assert record["aliases"] == ["CVE-2024-1234"]
+
+    def test_custom_ecosystem_and_package(self, osv_record_factory):
+        record = osv_record_factory(
+            "CVE-2021-44228",
+            ecosystem="Maven",
+            package="org.apache.logging.log4j:log4j-core",
+        )
+        affected = record["affected"][0]
+        assert affected["package"]["ecosystem"] == "Maven"
+        assert affected["package"]["name"] == "org.apache.logging.log4j:log4j-core"
+
+    def test_custom_version_range(self, osv_record_factory):
+        record = osv_record_factory(introduced="2.0-beta9", fixed="2.15.0")
+        events = record["affected"][0]["ranges"][0]["events"]
+        assert events[0]["introduced"] == "2.0-beta9"
+        assert events[1]["fixed"] == "2.15.0"
+
+    def test_custom_osv_id(self, osv_record_factory):
+        record = osv_record_factory(osv_id="GHSA-jfh8-c2jp-5v3q")
+        assert record["id"] == "GHSA-jfh8-c2jp-5v3q"
+
+
+# ===========================================================================
+# Config fixtures
+# ===========================================================================
+
+
+class TestConfigFixtures:
+    """Verify pre-built Config fixtures."""
+
+    def test_default_config(self, default_config):
+        from manus_agent.config import Config
+
+        assert isinstance(default_config, Config)
+
+    def test_bedrock_config(self, bedrock_config):
+        assert bedrock_config.llm.provider == "bedrock"
+
+    def test_openai_config(self, openai_config):
+        assert openai_config.llm.provider == "openai"
+        assert openai_config.llm.model == "gpt-4o"
+
+    def test_anthropic_config(self, anthropic_config):
+        assert anthropic_config.llm.provider == "anthropic"
+
+    def test_ollama_config(self, ollama_config):
+        assert ollama_config.llm.provider == "ollama"
+        assert ollama_config.llm.base_url == "http://localhost:11434"
+
+
+# ===========================================================================
+# Temporary file fixtures
+# ===========================================================================
+
+
+class TestTmpHistoryFile:
+    """Verify the tmp_history_file fixture."""
+
+    def test_creates_file_on_write(self, tmp_history_file):
+        history_path, write = tmp_history_file
+        write(task="test task")
+        assert history_path.exists()
+
+    def test_appends_valid_jsonl(self, tmp_history_file):
+        history_path, write = tmp_history_file
+        write(task="first task", success=True)
+        write(task="second task", success=False)
+
+        lines = history_path.read_text().strip().split("\n")
+        assert len(lines) == 2
+        rec1 = json.loads(lines[0])
+        rec2 = json.loads(lines[1])
+        assert rec1["task"] == "first task"
+        assert rec2["success"] is False
+
+    def test_records_have_expected_fields(self, tmp_history_file):
+        _, write = tmp_history_file
+        path = write(task="analyse CVE", agent="browser", mode="multi")
+        record = json.loads(path.read_text().strip())
+        assert record["agent"] == "browser"
+        assert record["mode"] == "multi"
+        assert "timestamp" in record
+
+
+class TestTmpConfigFile:
+    """Verify the tmp_config_file fixture."""
+
+    def test_writes_valid_toml(self, tmp_config_file):
+        import toml
+
+        config_path = tmp_config_file({"llm": {"provider": "openai", "model": "gpt-4"}})
+        assert config_path.exists()
+        parsed = toml.loads(config_path.read_text())
+        assert parsed["llm"]["provider"] == "openai"
+
+
+# ===========================================================================
+# env_override fixture
+# ===========================================================================
+
+
+class TestEnvOverride:
+    """Verify the env_override fixture."""
+
+    def test_sets_env_var(self, env_override):
+        import os
+
+        env_override(TEST_CONFTEST_VAR="hello")
+        assert os.environ.get("TEST_CONFTEST_VAR") == "hello"
+
+    def test_removes_env_var_with_none(self, env_override):
+        import os
+
+        os.environ["TEST_CONFTEST_REMOVE"] = "exists"
+        env_override(TEST_CONFTEST_REMOVE=None)
+        assert "TEST_CONFTEST_REMOVE" not in os.environ
+
+    def test_multiple_vars(self, env_override):
+        import os
+
+        env_override(VAR_A="a", VAR_B="b")
+        assert os.environ.get("VAR_A") == "a"
+        assert os.environ.get("VAR_B") == "b"
+
+
+# ===========================================================================
+# Module-level constants
+# ===========================================================================
+
+
+class TestSampleCveConstants:
+    """Verify the module-level CVE data constants."""
+
+    def test_log4shell_has_id(self):
+        from tests.conftest import SAMPLE_CVE_LOG4SHELL
+
+        assert SAMPLE_CVE_LOG4SHELL["id"] == "CVE-2021-44228"
+
+    def test_xz_has_id(self):
+        from tests.conftest import SAMPLE_CVE_XZ
+
+        assert SAMPLE_CVE_XZ["id"] == "CVE-2024-3094"
+
+    def test_log4shell_has_cvss_score_10(self):
+        from tests.conftest import SAMPLE_CVE_LOG4SHELL
+
+        score = SAMPLE_CVE_LOG4SHELL["metrics"]["cvssMetricV31"][0]["cvssData"]["baseScore"]
+        assert score == 10.0
+
+    def test_xz_has_configurations(self):
+        from tests.conftest import SAMPLE_CVE_XZ
+
+        assert "configurations" in SAMPLE_CVE_XZ
+        cpe = SAMPLE_CVE_XZ["configurations"][0]["nodes"][0]["cpeMatch"][0]
+        assert "tukaani" in cpe["criteria"]


### PR DESCRIPTION
## Summary

Adds `tests/conftest.py` with shared pytest fixtures that eliminate common boilerplate repeated across the 30+ test files in this project. Also includes `tests/test_conftest_fixtures.py` (50 tests) that validates the fixtures and documents usage patterns for contributors.

## Motivation

Currently, each test file independently defines its own mock factories (e.g. tool\_use dicts, HTTP responses, NVD/EPSS/KEV payloads). This leads to:
- Duplicated helper functions across files
- Inconsistent mock data shapes
- Higher friction when writing new tests

A shared `conftest.py` is the standard pytest solution — fixtures are auto-discovered with zero imports needed.

## Fixtures provided

| Fixture | Purpose |
|---------|---------|
| `make_tool_use` | Build valid Strands `tool_use` dicts with auto-generated IDs |
| `mock_http_response` | Create mock `requests.Response` objects with proper `raise_for_status()` |
| `nvd_cve_factory` | Build NVD CVE entries with customisable CVSS/CWE/CPE |
| `nvd_api_response` | Wrap CVE entries in a full NVD API response envelope |
| `epss_data_factory` | Build EPSS API responses with optional time-series |
| `kev_catalog_factory` | Build CISA KEV catalog payloads |
| `osv_record_factory` | Build OSV.dev vulnerability records |
| `default_config` / `bedrock_config` / `openai_config` / etc. | Pre-built Config objects |
| `tmp_history_file` | Isolated temp history.jsonl with write helper |
| `tmp_config_file` | Writes temp config.toml from a dict |
| `env_override` | Clean monkeypatch wrapper for env vars |

Plus module-level constants: `SAMPLE_CVE_LOG4SHELL`, `SAMPLE_CVE_XZ`

## Testing

- All 50 new fixture tests pass
- All 1208 existing tests continue to pass unchanged
- `ruff check` and `ruff format` clean

## Usage example

```python
def test_nvd_tool_handles_404(make_tool_use, mock_http_response):
    tool_use = make_tool_use("get_nvd_data", cve_id="CVE-2024-9999")
    response = mock_http_response(404)
    # ... mock and assert
```

No imports needed — pytest auto-discovers conftest fixtures.