### PR TITLE
test(config): comprehensive test suite for _apply_env_overrides and from_file (+66 tests)

### DIFF
--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -1,0 +1,109 @@
+
+## PR #111 — OSV per-package CVE lookup in get_dependency_blast_radius
+
+**Branch:** `feat/osv-package-cve-lookup`
+**Date:** 2026-07-09
+**Status:** Open
+
+### Problem
+
+`get_dependency_blast_radius` showed blast-radius exposure metrics (downloads,
+dependents) for direct package queries but never asked: *does this package have
+known CVEs?*  The OSV `/v1/query` endpoint existed and was used elsewhere in the
+codebase (for CVE→affected-packages lookups) but was never called in the direct
+package path.
+
+### Solution
+
+New helper `_fetch_osv_package_vulns(name, ecosystem, version, max_vulns)`:
+- POSTs to `https://api.osv.dev/v1/query` with package + optional version
+- `_ECOSYSTEM_TO_OSV` dict maps 31 input aliases → canonical OSV ecosystem strings
+  (covers PyPI, npm, Maven, Go, crates.io, RubyGems, NuGet, Packagist, Hex, Pub, Conda)
+- Parses id, summary (≤120 chars), aliases, fixed version from range events
+- Graceful empty-list return on all errors
+
+`get_dependency_blast_radius` direct package path:
+- Calls `_fetch_osv_package_vulns` post-enrichment; version-scoped when version given
+- New output section: `Known CVEs (OSV) affecting @X.Y.Z: N` with per-advisory bullets
+- Summary line: `Known CVEs from OSV affecting version X.Y.Z: N`
+- CVE input path unchanged (function never called there)
+
+### Tests
+
+35 new tests across `TestEcosystemToOsvMapping`, `TestFetchOsvPackageVulns`,
+`TestBlastRadiusOsvIntegration`. Suite: 1193 passed (was 1158).
+
+### Suggested next contributions
+
+- **Swift Package Index enricher** — `_enrich_swift`: API at
+  `swiftpackageindex.com/api/packages/{owner}/{package}`; complication is needing
+  owner/repo format; map to OSV ecosystem `SwiftURL`
+- **Conda enricher** — `_enrich_conda` is already in PR #110; check if merged
+- **Extend `_ECOSYSTEM_TO_OSV`** to cover Conda/Bioconda once PR #110 lands
+- **`first_release_date` for crates.io** (extend PR #103 analogue)
+
+---
+
+## Session N+4 — feat/enrich-cran (PR #113)
+
+### Contribution
+
+Added `_enrich_cran()` enricher to `get_dependency_blast_radius.py`, extending
+the blast-radius tool with native **CRAN (R)** package support.
+
+### Ecosystem selection rationale
+
+- Checked all open PRs (#103–#112): none covered CRAN.
+- OSV ecosystem list confirms `CRAN` as a valid, active ecosystem with real
+  advisories (e.g., `jsonlite`, `openssl`, `httr` packages).
+- Swift Package Index API returned 401 (auth required) — ruled out.
+- ConanCenter API returned HTML/404 for REST queries — ruled out.
+- crandb and cranlogs: both free, unauthenticated, JSON, confirmed working.
+
+### Implementation summary
+
+**Constants**: `_CRANDB_URL`, `_CRANLOGS_URL`
+
+**New helper**: `_parse_cran_timestamp(ts)` — normalises crandb ISO-8601
+timestamps (`"2014-10-21T08:27:55+00:00"` or `"...Z"`) to `"YYYY-MM-DD"` by
+slicing the first 10 characters.
+
+**New enricher**: `_enrich_cran(name)`:
+- Call 1: `crandb.r-pkg.org/{name}/all` → latest version, title (max 120 chars),
+  archived flag, `revdeps` (→ `dependent_packages_count`), version timeline count,
+  first-release date, age in years, CRAN page URL.
+- Call 2: `cranlogs.r-pkg.org/downloads/total/last-month/{name}` → monthly
+  downloads; `weekly_downloads = monthly // 4` (integer floor division).
+- Independent try/except per call for graceful degradation.
+- Both-fail fallback: `{ecosystem: "CRAN", package_name: name}` without raising.
+
+**Dispatcher**: `eco_lower in ("cran", "r")` in `_enrich_package` — covers
+`cran:openssl` and `r:openssl` input forms.
+
+**Output block**: title, latest version, total versions, reverse deps, monthly
+downloads, first release + age, archived status, CRAN page URL.  Fixed npm
+dependents label to show only for npm ecosystem (previously shown for any
+ecosystem with `dependent_packages_count`).
+
+### Tests
+
+30 new tests (6 classes, all HTTP mocked):
+`TestParseCranTimestamp` (6), `TestEnrichCranHappyPath` (16),
+`TestEnrichCranDegradation` (7), `TestEnrichPackageCranDispatch` (5),
+`TestBlastScoreWithCranData` (6), `TestGetDependencyBlastRadiusCran` (9).
+
+Suite: **1206 passed** (was 1158 before this session series; +30 this PR).
+3 deselected, 3 warnings — all pre-existing, zero regressions.
+
+### Suggested next contributions
+
+- **Hackage enricher** (`_enrich_hackage`) — Haskell package registry; OSV
+  ecosystem `Hackage`; API: `hackage.haskell.org/package/{name}.json` (free,
+  unauthenticated). Revdeps via `hackage.haskell.org/package/{name}/reverse`.
+- **opam enricher** (`_enrich_opam`) — OCaml package registry; OSV ecosystem
+  `OSS-Fuzz`/`crates.io` alignment; API: `opam.ocaml.org/pkg/{name}/latest`
+  (JSON, no auth).
+- **OSV `_ECOSYSTEM_TO_OSV` coverage** — extend the mapping to include CRAN
+  once this PR merges.
+- **Per-version CVE integration for CRAN** — `manus-agent blast-radius
+  cran:openssl@2.1.1` should call `_fetch_osv_package_vulns("openssl", "CRAN", "2.1.1")`.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -198,3 +198,45 @@ timeout, and finally-block cleanup.
   PRs add new subcommands but many lack unit tests for argument parsing.
 - **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
   existing test files can be simplified.
+
+---
+
+## Session: 2026-08-01 00:00 UTC — PR #165
+
+### Contribution: test_check_cisa_kev.py — CISA KEV tool test suite
+
+**Branch:** `test/check-cisa-kev-suite`
+**PR:** https://github.com/manus-use/manus-agent/pull/165
+**Tests added:** 43
+
+### Coverage areas
+- TOOL_SPEC schema validation (5 tests)
+- `_get_kev_data` caching logic: fresh/stale/missing cache, network errors,
+  cache write, malformed cache, missing timestamp (8 tests)
+- `check_cisa_kev` main function: CVE found/not-found, case-insensitive,
+  exact match, multiple CVEs, empty catalog, missing key, invalid inputs,
+  tool_use_id propagation (15 tests)
+- `log_tool_output_size` integration — every exit path (4 tests)
+- Edge cases: single-entry catalog, mixed-case, missing key, content structure (8 tests)
+- Module constants validation (3 tests)
+
+### Discovered issue
+`_get_kev_data()` does not handle corrupted cache files gracefully —
+`json.loads()` on a malformed `.cisa_kev_cache.json` propagates
+`JSONDecodeError` instead of falling through to a fresh API fetch.
+Documented in test.
+
+### Results
+- 43 new tests pass
+- Full suite: 1201 passed, 0 failures, 0 regressions
+- Ruff clean (lint + format)
+
+### Suggested next contributions
+- **`get_cwe_details` tool tests** — another core tool with zero test coverage;
+  similar structure (HTTP fetch + HTML parsing + error paths)
+- **`obtain_cves` tool tests** — complex multi-source aggregation pipeline
+  (NVD + GitHub + EPSS + KEV + webhook) with zero unit tests
+- **`search_poc_sources` tool tests** — parallel 5-source aggregator with
+  dedup/sort logic; existing `test_search_poc_sources.py` only covers basic cases
+- **Cache robustness fix PR** — wrap `json.loads()` in `_get_kev_data` with
+  try/except to gracefully handle corrupted cache

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -107,3 +107,49 @@ Suite: **1206 passed** (was 1158 before this session series; +30 this PR).
   once this PR merges.
 - **Per-version CVE integration for CRAN** — `manus-agent blast-radius
   cran:openssl@2.1.1` should call `_fetch_osv_package_vulns("openssl", "CRAN", "2.1.1")`.
+
+---
+
+## PR #158 — Shared test conftest.py with reusable fixtures (2026-07-29)
+
+### What
+Added `tests/conftest.py` with shared pytest fixtures and `tests/test_conftest_fixtures.py`
+(50 tests) that validates and documents them.
+
+### Why
+30+ test files independently define their own mock factories (tool_use dicts,
+HTTP responses, NVD/EPSS/KEV payloads). This leads to duplicated helpers,
+inconsistent mock shapes, and higher friction when writing new tests. A shared
+conftest.py is the standard pytest solution.
+
+### Fixtures provided
+- `make_tool_use` — builds Strands tool_use dicts with auto-generated IDs
+- `mock_http_response` — creates mock requests.Response with raise_for_status()
+- `nvd_cve_factory` / `nvd_api_response` — builds NVD CVE payloads
+- `epss_data_factory` — builds EPSS API responses
+- `kev_catalog_factory` — builds CISA KEV catalog payloads
+- `osv_record_factory` — builds OSV.dev records
+- Config fixtures (default, bedrock, openai, anthropic, ollama)
+- `tmp_history_file` / `tmp_config_file` — temp filesystem helpers
+- `env_override` — clean monkeypatch wrapper
+- Module constants: `SAMPLE_CVE_LOG4SHELL`, `SAMPLE_CVE_XZ`
+
+### Results
+- 50 new fixture validation tests pass
+- All 1208 existing tests unchanged / passing
+- Ruff clean
+
+### Suggested next contributions
+
+- **`_run_changelog_generate` test coverage** — the changelog CLI tests
+  (`test_changelog_cli.py`) are comprehensive but `_run_changelog_generate`
+  could use edge-case tests for merge commits, non-conventional commits mixed
+  in, and empty repos.
+- **BrowserUseAgent.stream_async tests** — `stream_async()` uses asyncio.Queue
+  with step/done callbacks; no tests cover the streaming yield/queue pattern.
+- **WorkflowAgent / Orchestrator tests** — `Orchestrator.run()` currently just
+  delegates to WorkflowAgent; tests for the `TaskPlan`, `OrchestratorResult`,
+  and `AgentType` data structures + error handling.
+- **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
+  existing test files can be simplified by replacing local helpers with shared
+  fixtures.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -153,3 +153,48 @@ conftest.py is the standard pytest solution.
 - **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
   existing test files can be simplified by replacing local helpers with shared
   fixtures.
+
+---
+
+## Contribution 6 — BrowserUseAgent.stream_async tests
+
+**PR:** #159
+**Branch:** `feat/test-stream-async-browser-agent`
+**File:** `tests/test_browser_use_stream_async.py` (+1548 lines)
+
+### Rationale
+
+`stream_async()` is a 165-line async generator with callbacks, queue management,
+error handling, and cleanup logic. Existing tests only covered the fallback path
+(2 tests when BrowserUse is None), leaving zero coverage of the real streaming
+path: step_callback, done_callback, queue draining, background task, keep_alive
+timeout, and finally-block cleanup.
+
+### What was added
+
+45 tests in 7 classes:
+- Fallback path (5): BrowserUse/BrowserProfile/Controller unavailable
+- True streaming path (11): callbacks, queue flow, extracted content, output_model
+- Error handling (7): constructor/LLM/callback failures, post-done exceptions
+- Browser cleanup (7): close(), keep_alive timeout, error resilience
+- Input handling (4): string/list/empty task parsing
+- Task cancellation (2): background task lifecycle
+- Configuration (4): headless, output_model, enable_memory, patch config
+- Edge cases (8): missing attributes, mixed types, validate_output
+
+### Results
+- 45 new tests pass
+- All 1203 tests pass (up from 1158), no regressions
+- Ruff clean
+
+### Suggested next contributions
+
+- **WorkflowAgent / Orchestrator tests** — `Orchestrator.run()` delegates to
+  WorkflowAgent; tests for `TaskPlan`, `OrchestratorResult`, `AgentType` data
+  structures + error handling.
+- **`_run_browser_task` tests** — the non-streaming browser task method has
+  complex try/finally with keep_alive/timeout logic worth covering.
+- **CLI `vendor-response` / `verify-exploit` subcommand tests** — several open
+  PRs add new subcommands but many lack unit tests for argument parsing.
+- **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
+  existing test files can be simplified.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -240,3 +240,26 @@ Documented in test.
   dedup/sort logic; existing `test_search_poc_sources.py` only covers basic cases
 - **Cache robustness fix PR** — wrap `json.loads()` in `_get_kev_data` with
   try/except to gracefully handle corrupted cache
+
+## 2026-08-01 — PR #112 (updated): decode-cvss vector decoder/explainer tool
+
+**What:** New `decode_cvss_vector` tool + `decode-cvss` CLI subcommand that parses CVSS v3.0/v3.1 vector strings and produces structured breakdowns with:
+- Per-metric human-readable explanations
+- Computed base score (exact CVSS v3.1 formula)
+- Severity classification
+- Natural-language attack summary
+- Remediation priority with escalation factors
+
+**Why:** The project collects CVSS vectors from multiple sources (NVD, VulnCheck, patch-diff) but never explains what they mean. This fills the gap between raw scores and actionable security context.
+
+**Tests:** +70 new tests (1228 total passing, up from 1158 baseline)
+**Branch:** feat/cvss-vector-decoder
+**PR:** https://github.com/manus-use/manus-agent/pull/112
+
+## 2026-08-02 — PR #170: cve-enrich tool + CLI subcommand
+
+**Branch:** `feat/cve-enrich`
+**What:** Lightweight multi-source CVE enrichment tool that fetches NVD, EPSS, CISA KEV, OSV.dev, and VulnCheck data in parallel. Returns unified risk snapshot with composite scoring. No LLM agent required.
+**CLI:** `manus-agent enrich CVE-XXXX-YYYY [--output json|text] [--no-vulncheck]`
+**Tests:** +43 new tests (all fetchers, risk computation, CLI modes, Strands interface)
+**Suggested next:** test suite for `_run_discover` CLI execution (VulnerabilityDiscoveryAgent mocking), or `Config.from_file()` edge cases, or `obtain_cves.py` unit tests

--- a/tests/test_config_env_overrides.py
+++ b/tests/test_config_env_overrides.py
@@ -1,0 +1,707 @@
+"""Comprehensive tests for Config._apply_env_overrides() and Config.from_file().
+
+Tests the environment-variable → config mapping pipeline, including:
+- MANUS_LLM_* overrides (always-override semantics)
+- Provider-specific API key resolution (fill-when-None semantics)
+- AWS region resolution from multiple env var names
+- Integration config env vars (OTX, GitHub, Lark, Webhooks, MCP)
+- .env file loading and search-path resolution
+- from_file() search-path discovery
+- Priority: env vars > config.toml > pydantic defaults
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import toml
+
+from manus_agent.config import Config, LLMConfig, _load_dotenv
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_config(**llm_kwargs) -> Config:
+    """Build a Config with explicit LLM settings (skipping env override via direct construction)."""
+    return Config.model_construct(
+        llm=LLMConfig(**llm_kwargs),
+        sandbox=Config.model_fields["sandbox"].default_factory(),
+        tools=Config.model_fields["tools"].default_factory(),
+        browser_use=Config.model_fields["browser_use"].default_factory(),
+        otx=Config.model_fields["otx"].default_factory(),
+        github=Config.model_fields["github"].default_factory(),
+        mcp=Config.model_fields["mcp"].default_factory(),
+        webhooks=Config.model_fields["webhooks"].default_factory(),
+        lark=Config.model_fields["lark"].default_factory(),
+        agent=Config.model_fields["agent"].default_factory(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# MANUS_LLM_PROVIDER override
+# ---------------------------------------------------------------------------
+
+
+class TestLLMProviderOverride:
+    """MANUS_LLM_PROVIDER always overrides the configured provider."""
+
+    def test_overrides_default_provider(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_PROVIDER": "anthropic"}, clear=False):
+            cfg = Config()
+        assert cfg.llm.provider == "anthropic"
+
+    def test_overrides_explicit_provider(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_PROVIDER": "bedrock"}, clear=False):
+            cfg = Config(llm=LLMConfig(provider="openai"))
+        assert cfg.llm.provider == "bedrock"
+
+    def test_no_override_when_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MANUS_LLM_PROVIDER"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = Config(llm=LLMConfig(provider="ollama"))
+        assert cfg.llm.provider == "ollama"
+
+    def test_empty_string_does_not_override(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_PROVIDER": ""}, clear=False):
+            cfg = Config(llm=LLMConfig(provider="openai"))
+        assert cfg.llm.provider == "openai"
+
+
+# ---------------------------------------------------------------------------
+# MANUS_LLM_MODEL override
+# ---------------------------------------------------------------------------
+
+
+class TestLLMModelOverride:
+    """MANUS_LLM_MODEL always overrides the configured model."""
+
+    def test_overrides_default_model(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_MODEL": "claude-3-opus"}, clear=False):
+            cfg = Config()
+        assert cfg.llm.model == "claude-3-opus"
+
+    def test_overrides_explicit_model(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_MODEL": "gpt-4-turbo"}, clear=False):
+            cfg = Config(llm=LLMConfig(model="gpt-3.5-turbo"))
+        assert cfg.llm.model == "gpt-4-turbo"
+
+    def test_no_override_when_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MANUS_LLM_MODEL"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = Config(llm=LLMConfig(model="my-model"))
+        assert cfg.llm.model == "my-model"
+
+
+# ---------------------------------------------------------------------------
+# MANUS_LLM_BASE_URL override
+# ---------------------------------------------------------------------------
+
+
+class TestLLMBaseURLOverride:
+    """MANUS_LLM_BASE_URL always overrides the configured base_url."""
+
+    def test_overrides_base_url(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_BASE_URL": "http://custom:8080"}, clear=False):
+            cfg = Config()
+        assert cfg.llm.base_url == "http://custom:8080"
+
+    def test_overrides_explicit_base_url(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_BASE_URL": "http://new:9090"}, clear=False):
+            cfg = Config(llm=LLMConfig(base_url="http://old:1234"))
+        assert cfg.llm.base_url == "http://new:9090"
+
+    def test_no_override_when_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MANUS_LLM_BASE_URL"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = Config(llm=LLMConfig(base_url="http://keep-me"))
+        assert cfg.llm.base_url == "http://keep-me"
+
+
+# ---------------------------------------------------------------------------
+# MANUS_LLM_TEMPERATURE override
+# ---------------------------------------------------------------------------
+
+
+class TestLLMTemperatureOverride:
+    """MANUS_LLM_TEMPERATURE overrides the configured temperature."""
+
+    def test_overrides_temperature(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_TEMPERATURE": "0.7"}, clear=False):
+            cfg = Config()
+        assert cfg.llm.temperature == 0.7
+
+    def test_float_precision(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_TEMPERATURE": "1.5"}, clear=False):
+            cfg = Config(llm=LLMConfig(temperature=0.0))
+        assert cfg.llm.temperature == 1.5
+
+    def test_no_override_when_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MANUS_LLM_TEMPERATURE"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = Config(llm=LLMConfig(temperature=0.3))
+        assert cfg.llm.temperature == 0.3
+
+
+# ---------------------------------------------------------------------------
+# MANUS_LLM_MAX_TOKENS override
+# ---------------------------------------------------------------------------
+
+
+class TestLLMMaxTokensOverride:
+    """MANUS_LLM_MAX_TOKENS overrides the configured max_tokens."""
+
+    def test_overrides_max_tokens(self):
+        with mock.patch.dict(os.environ, {"MANUS_LLM_MAX_TOKENS": "8192"}, clear=False):
+            cfg = Config()
+        assert cfg.llm.max_tokens == 8192
+
+    def test_no_override_when_unset(self):
+        env = {k: v for k, v in os.environ.items() if k != "MANUS_LLM_MAX_TOKENS"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            cfg = Config(llm=LLMConfig(max_tokens=2048))
+        assert cfg.llm.max_tokens == 2048
+
+
+# ---------------------------------------------------------------------------
+# API key resolution — fill-when-None semantics
+# ---------------------------------------------------------------------------
+
+
+class TestAPIKeyResolution:
+    """API keys are only filled from env when not already set in config."""
+
+    def test_openai_key_from_env(self):
+        env = {"OPENAI_API_KEY": "sk-test-123"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="openai", api_key=None))
+        assert cfg.llm.api_key == "sk-test-123"
+
+    def test_openai_key_not_overwritten_by_env(self):
+        env = {"OPENAI_API_KEY": "sk-env-key"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="openai", api_key="sk-config-key"))
+        assert cfg.llm.api_key == "sk-config-key"
+
+    def test_anthropic_key_from_env(self):
+        env = {"ANTHROPIC_API_KEY": "ant-key-456"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="anthropic", api_key=None))
+        assert cfg.llm.api_key == "ant-key-456"
+
+    def test_anthropic_key_not_overwritten_by_env(self):
+        env = {"ANTHROPIC_API_KEY": "ant-env-key"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="anthropic", api_key="ant-config-key"))
+        assert cfg.llm.api_key == "ant-config-key"
+
+    def test_bedrock_no_api_key_lookup(self):
+        """Bedrock doesn't use API keys (uses AWS credentials), so no env lookup."""
+        env = {"OPENAI_API_KEY": "sk-wrong", "ANTHROPIC_API_KEY": "ant-wrong"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="bedrock", api_key=None))
+        assert cfg.llm.api_key is None
+
+    def test_ollama_no_api_key_lookup(self):
+        """Ollama doesn't use API keys."""
+        env = {"OPENAI_API_KEY": "sk-wrong", "ANTHROPIC_API_KEY": "ant-wrong"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="ollama", api_key=None))
+        assert cfg.llm.api_key is None
+
+    def test_unknown_provider_no_api_key_lookup(self):
+        """Unknown providers don't get env-based API keys."""
+        env = {"OPENAI_API_KEY": "sk-wrong"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="custom", api_key=None))
+        assert cfg.llm.api_key is None
+
+
+# ---------------------------------------------------------------------------
+# AWS region resolution
+# ---------------------------------------------------------------------------
+
+
+class TestAWSRegionResolution:
+    """AWS region resolved from multiple env var names with priority."""
+
+    def test_manus_aws_region_takes_priority(self):
+        env = {
+            "MANUS_AWS_REGION": "us-west-2",
+            "AWS_DEFAULT_REGION": "eu-west-1",
+            "AWS_REGION": "ap-east-1",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(aws_region=None))
+        assert cfg.llm.aws_region == "us-west-2"
+
+    def test_aws_default_region_fallback(self):
+        env = {"AWS_DEFAULT_REGION": "eu-central-1"}
+        clean = {k: v for k, v in os.environ.items() if k not in ("MANUS_AWS_REGION", "AWS_REGION")}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config(llm=LLMConfig(aws_region=None))
+        assert cfg.llm.aws_region == "eu-central-1"
+
+    def test_aws_region_fallback(self):
+        env = {"AWS_REGION": "ap-southeast-1"}
+        clean = {k: v for k, v in os.environ.items() if k not in ("MANUS_AWS_REGION", "AWS_DEFAULT_REGION")}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config(llm=LLMConfig(aws_region=None))
+        assert cfg.llm.aws_region == "ap-southeast-1"
+
+    def test_no_region_env_vars_leaves_none(self):
+        clean = {k: v for k, v in os.environ.items() if k not in ("MANUS_AWS_REGION", "AWS_DEFAULT_REGION", "AWS_REGION")}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config(llm=LLMConfig(aws_region=None))
+        assert cfg.llm.aws_region is None
+
+    def test_config_region_not_overwritten(self):
+        """When aws_region is already set in config, env vars don't overwrite."""
+        env = {"MANUS_AWS_REGION": "us-west-1"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(aws_region="eu-north-1"))
+        assert cfg.llm.aws_region == "eu-north-1"
+
+
+# ---------------------------------------------------------------------------
+# Integration configs — OTX
+# ---------------------------------------------------------------------------
+
+
+class TestOTXConfig:
+    """MANUS_OTX_API_KEY env var fills OTX config when None."""
+
+    def test_otx_key_from_env(self):
+        env = {"MANUS_OTX_API_KEY": "otx-key-abc"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.otx.api_key == "otx-key-abc"
+
+    def test_otx_key_not_overwritten(self):
+        env = {"MANUS_OTX_API_KEY": "otx-env"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(otx={"api_key": "otx-config"})
+        assert cfg.otx.api_key == "otx-config"
+
+    def test_otx_key_stays_none_when_no_env(self):
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_OTX_API_KEY"}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.otx.api_key is None
+
+
+# ---------------------------------------------------------------------------
+# Integration configs — GitHub
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubConfig:
+    """MANUS_GITHUB_TOKEN / GITHUB_TOKEN env vars fill GitHub config."""
+
+    def test_manus_github_token_takes_priority(self):
+        env = {"MANUS_GITHUB_TOKEN": "ghp-manus", "GITHUB_TOKEN": "ghp-generic"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.github.api_token == "ghp-manus"
+
+    def test_github_token_fallback(self):
+        env = {"GITHUB_TOKEN": "ghp-fallback"}
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_GITHUB_TOKEN"}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.github.api_token == "ghp-fallback"
+
+    def test_not_overwritten_when_set(self):
+        env = {"MANUS_GITHUB_TOKEN": "ghp-env"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(github={"api_token": "ghp-config"})
+        assert cfg.github.api_token == "ghp-config"
+
+    def test_stays_none_when_no_env(self):
+        clean = {k: v for k, v in os.environ.items() if k not in ("MANUS_GITHUB_TOKEN", "GITHUB_TOKEN")}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.github.api_token is None
+
+
+# ---------------------------------------------------------------------------
+# Integration configs — Lark
+# ---------------------------------------------------------------------------
+
+
+class TestLarkConfig:
+    """MANUS_LARK_API_TOKEN and MANUS_LARK_DOCUMENT_URL env vars."""
+
+    def test_lark_token_from_manus_env(self):
+        env = {"MANUS_LARK_API_TOKEN": "lark-manus", "LARK_API_TOKEN": "lark-generic"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.lark.api_token == "lark-manus"
+
+    def test_lark_token_from_generic_env(self):
+        env = {"LARK_API_TOKEN": "lark-generic"}
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_LARK_API_TOKEN"}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.lark.api_token == "lark-generic"
+
+    def test_lark_doc_url_from_manus_env(self):
+        env = {"MANUS_LARK_DOCUMENT_URL": "https://lark.example.com/doc/1"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.lark.document_url == "https://lark.example.com/doc/1"
+
+    def test_lark_doc_url_from_generic_env(self):
+        env = {"LARK_DOCUMENT_URL": "https://generic.example.com/doc/2"}
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_LARK_DOCUMENT_URL"}
+        clean.update(env)
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.lark.document_url == "https://generic.example.com/doc/2"
+
+    def test_lark_not_overwritten(self):
+        env = {"MANUS_LARK_API_TOKEN": "lark-env", "MANUS_LARK_DOCUMENT_URL": "https://env.url"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(lark={"api_token": "lark-config", "document_url": "https://config.url"})
+        assert cfg.lark.api_token == "lark-config"
+        assert cfg.lark.document_url == "https://config.url"
+
+
+# ---------------------------------------------------------------------------
+# Integration configs — Webhooks
+# ---------------------------------------------------------------------------
+
+
+class TestWebhooksConfig:
+    """MANUS_WEBHOOK_CVE_SUBMIT_URL env var."""
+
+    def test_webhook_url_from_env(self):
+        env = {"MANUS_WEBHOOK_CVE_SUBMIT_URL": "https://hooks.example.com/cve"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.webhooks.cve_submit_url == "https://hooks.example.com/cve"
+
+    def test_webhook_not_overwritten(self):
+        env = {"MANUS_WEBHOOK_CVE_SUBMIT_URL": "https://env.url"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(webhooks={"cve_submit_url": "https://config.url"})
+        assert cfg.webhooks.cve_submit_url == "https://config.url"
+
+    def test_webhook_stays_none(self):
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_WEBHOOK_CVE_SUBMIT_URL"}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.webhooks.cve_submit_url is None
+
+
+# ---------------------------------------------------------------------------
+# Integration configs — MCP
+# ---------------------------------------------------------------------------
+
+
+class TestMCPConfig:
+    """MANUS_MCP_SERVER_URL env var."""
+
+    def test_mcp_url_from_env(self):
+        env = {"MANUS_MCP_SERVER_URL": "http://mcp:3000"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.mcp.server_url == "http://mcp:3000"
+
+    def test_mcp_not_overwritten(self):
+        env = {"MANUS_MCP_SERVER_URL": "http://env-mcp"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(mcp={"server_url": "http://config-mcp"})
+        assert cfg.mcp.server_url == "http://config-mcp"
+
+    def test_mcp_stays_none(self):
+        clean = {k: v for k, v in os.environ.items() if k != "MANUS_MCP_SERVER_URL"}
+        with mock.patch.dict(os.environ, clean, clear=True):
+            cfg = Config()
+        assert cfg.mcp.server_url is None
+
+
+# ---------------------------------------------------------------------------
+# Config.from_file() — search path logic
+# ---------------------------------------------------------------------------
+
+
+class TestFromFileSearchPaths:
+    """Config.from_file() discovers config.toml from standard locations."""
+
+    def test_explicit_path(self, tmp_path):
+        cfg_file = tmp_path / "custom.toml"
+        cfg_file.write_text('[llm]\nprovider = "anthropic"\nmodel = "claude-3"\n')
+        with mock.patch.dict(os.environ, {}, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.provider == "anthropic"
+        assert cfg.llm.model == "claude-3"
+
+    def test_cwd_config_toml(self, tmp_path, monkeypatch):
+        """config.toml in CWD is discovered first."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config.toml").write_text('[llm]\nprovider = "ollama"\n')
+        with mock.patch.dict(os.environ, {}, clear=False):
+            cfg = Config.from_file()
+        assert cfg.llm.provider == "ollama"
+
+    def test_config_dir_config_toml(self, tmp_path, monkeypatch):
+        """config/config.toml is discovered if CWD config.toml doesn't exist."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / "config.toml").write_text('[llm]\nprovider = "bedrock"\n')
+        with mock.patch.dict(os.environ, {}, clear=False):
+            cfg = Config.from_file()
+        assert cfg.llm.provider == "bedrock"
+
+    def test_home_dir_config(self, tmp_path, monkeypatch):
+        """~/.manus-agent/config.toml is discovered as last resort."""
+        monkeypatch.chdir(tmp_path)
+        home_cfg_dir = tmp_path / ".manus-agent"
+        home_cfg_dir.mkdir()
+        (home_cfg_dir / "config.toml").write_text('[llm]\nmodel = "home-model"\n')
+        with mock.patch.object(Path, "home", return_value=tmp_path):
+            with mock.patch.dict(os.environ, {}, clear=False):
+                cfg = Config.from_file()
+        assert cfg.llm.model == "home-model"
+
+    def test_no_config_file_returns_defaults(self, tmp_path, monkeypatch):
+        """When no config.toml is found, defaults are returned."""
+        monkeypatch.chdir(tmp_path)
+        with mock.patch.object(Path, "home", return_value=tmp_path):
+            with mock.patch.dict(os.environ, {}, clear=False):
+                cfg = Config.from_file()
+        assert cfg.llm.provider == "openai"
+        assert cfg.llm.model == "gpt-4o"
+
+    def test_nonexistent_explicit_path_returns_defaults(self, tmp_path):
+        """Explicit path that doesn't exist returns defaults."""
+        with mock.patch.dict(os.environ, {}, clear=False):
+            cfg = Config.from_file(tmp_path / "does_not_exist.toml")
+        assert cfg.llm.provider == "openai"
+
+    def test_from_file_loads_all_sections(self, tmp_path):
+        """All config sections are loaded from TOML."""
+        cfg_file = tmp_path / "full.toml"
+        cfg_file.write_text(
+            "[llm]\n"
+            'provider = "anthropic"\n'
+            'model = "claude-3-haiku"\n'
+            "temperature = 0.5\n"
+            "max_tokens = 2048\n\n"
+            "[sandbox]\n"
+            "enabled = false\n\n"
+            "[github]\n"
+            'api_token = "ghp-from-file"\n\n'
+            "[otx]\n"
+            'api_key = "otx-from-file"\n'
+        )
+        with mock.patch.dict(os.environ, {}, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.provider == "anthropic"
+        assert cfg.llm.model == "claude-3-haiku"
+        assert cfg.llm.temperature == 0.5
+        assert cfg.llm.max_tokens == 2048
+        assert cfg.sandbox.enabled is False
+        assert cfg.github.api_token == "ghp-from-file"
+        assert cfg.otx.api_key == "otx-from-file"
+
+
+# ---------------------------------------------------------------------------
+# Config.from_file() — env overrides applied after TOML load
+# ---------------------------------------------------------------------------
+
+
+class TestFromFileEnvOverridePriority:
+    """Env vars override config.toml values for MANUS_LLM_* (always-override semantics)."""
+
+    def test_env_overrides_toml_provider(self, tmp_path):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-4o"\n')
+        env = {"MANUS_LLM_PROVIDER": "anthropic"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.provider == "anthropic"
+
+    def test_env_overrides_toml_model(self, tmp_path):
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-4o"\n')
+        env = {"MANUS_LLM_MODEL": "gpt-4-turbo"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.model == "gpt-4-turbo"
+
+    def test_toml_api_key_not_overwritten_by_env(self, tmp_path):
+        """API key set in TOML is preserved (fill-when-None semantics)."""
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('[llm]\nprovider = "openai"\napi_key = "sk-from-toml"\n')
+        env = {"OPENAI_API_KEY": "sk-from-env"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.api_key == "sk-from-toml"
+
+    def test_toml_no_api_key_filled_from_env(self, tmp_path):
+        """API key absent in TOML is filled from env."""
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text('[llm]\nprovider = "openai"\nmodel = "gpt-4o"\n')
+        env = {"OPENAI_API_KEY": "sk-from-env"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.api_key == "sk-from-env"
+
+
+# ---------------------------------------------------------------------------
+# _load_dotenv — .env file search and loading
+# ---------------------------------------------------------------------------
+
+
+class TestLoadDotenv:
+    """_load_dotenv() searches CWD, config/, and ~/.manus-agent/ for .env files."""
+
+    def test_loads_cwd_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("TEST_DOTENV_VAR=cwd_value\n")
+        # Remove the var if it happens to be set
+        env = {k: v for k, v in os.environ.items() if k != "TEST_DOTENV_VAR"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            _load_dotenv()
+            assert os.environ.get("TEST_DOTENV_VAR") == "cwd_value"
+
+    def test_loads_config_dir_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / ".env").write_text("TEST_DOTENV_VAR2=config_value\n")
+        env = {k: v for k, v in os.environ.items() if k != "TEST_DOTENV_VAR2"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            _load_dotenv()
+            assert os.environ.get("TEST_DOTENV_VAR2") == "config_value"
+
+    def test_loads_home_dir_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        home_dir = tmp_path / "fakehome"
+        home_dir.mkdir()
+        (home_dir / ".manus-agent").mkdir()
+        (home_dir / ".manus-agent" / ".env").write_text("TEST_DOTENV_VAR3=home_value\n")
+        env = {k: v for k, v in os.environ.items() if k != "TEST_DOTENV_VAR3"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with mock.patch.object(Path, "home", return_value=home_dir):
+                _load_dotenv()
+            assert os.environ.get("TEST_DOTENV_VAR3") == "home_value"
+
+    def test_cwd_dotenv_takes_priority(self, tmp_path, monkeypatch):
+        """CWD .env is loaded first — stops looking after first found."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("TEST_DOTENV_PRIO=cwd\n")
+        (tmp_path / "config").mkdir()
+        (tmp_path / "config" / ".env").write_text("TEST_DOTENV_PRIO=config\n")
+        env = {k: v for k, v in os.environ.items() if k != "TEST_DOTENV_PRIO"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            _load_dotenv()
+            assert os.environ.get("TEST_DOTENV_PRIO") == "cwd"
+
+    def test_no_dotenv_file_no_error(self, tmp_path, monkeypatch):
+        """No .env file anywhere doesn't raise."""
+        monkeypatch.chdir(tmp_path)
+        with mock.patch.object(Path, "home", return_value=tmp_path):
+            _load_dotenv()  # Should not raise
+
+    def test_dotenv_import_failure_graceful(self, monkeypatch):
+        """If python-dotenv is not installed, _load_dotenv is a no-op."""
+        import importlib
+        import builtins
+
+        original_import = builtins.__import__
+
+        def mock_import(name, *args, **kwargs):
+            if name == "dotenv":
+                raise ImportError("No module named 'dotenv'")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", mock_import)
+        _load_dotenv()  # Should not raise
+
+    def test_existing_env_vars_not_overwritten_by_dotenv(self, tmp_path, monkeypatch):
+        """python-dotenv with override=False preserves existing env vars."""
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / ".env").write_text("TEST_ALREADY_SET=dotenv_value\n")
+        env = dict(os.environ)
+        env["TEST_ALREADY_SET"] = "shell_value"
+        with mock.patch.dict(os.environ, env, clear=True):
+            _load_dotenv()
+            assert os.environ["TEST_ALREADY_SET"] == "shell_value"
+
+
+# ---------------------------------------------------------------------------
+# Combined env override scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedOverrides:
+    """Multiple env overrides applied together."""
+
+    def test_full_env_only_config(self):
+        """All LLM settings from env vars — no config file needed."""
+        env = {
+            "MANUS_LLM_PROVIDER": "anthropic",
+            "MANUS_LLM_MODEL": "claude-3-5-sonnet",
+            "MANUS_LLM_TEMPERATURE": "0.3",
+            "MANUS_LLM_MAX_TOKENS": "16384",
+            "ANTHROPIC_API_KEY": "ant-full-env-key",
+            "MANUS_GITHUB_TOKEN": "ghp-full-env",
+            "MANUS_OTX_API_KEY": "otx-full-env",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config()
+        assert cfg.llm.provider == "anthropic"
+        assert cfg.llm.model == "claude-3-5-sonnet"
+        assert cfg.llm.temperature == 0.3
+        assert cfg.llm.max_tokens == 16384
+        assert cfg.llm.api_key == "ant-full-env-key"
+        assert cfg.github.api_token == "ghp-full-env"
+        assert cfg.otx.api_key == "otx-full-env"
+
+    def test_partial_override_preserves_file_values(self, tmp_path):
+        """Only override what env provides; keep the rest from file."""
+        cfg_file = tmp_path / "config.toml"
+        cfg_file.write_text(
+            "[llm]\n"
+            'provider = "openai"\n'
+            'model = "gpt-4o"\n'
+            "temperature = 0.2\n"
+            "max_tokens = 4096\n\n"
+            "[github]\n"
+            'api_token = "ghp-file-token"\n'
+        )
+        env = {"MANUS_LLM_MODEL": "gpt-4-turbo"}  # Only override model
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config.from_file(cfg_file)
+        assert cfg.llm.provider == "openai"  # Unchanged
+        assert cfg.llm.model == "gpt-4-turbo"  # Overridden
+        assert cfg.llm.temperature == 0.2  # Unchanged
+        assert cfg.github.api_token == "ghp-file-token"  # Unchanged
+
+    def test_empty_env_values_treated_as_unset(self):
+        """Empty strings in env vars are treated as not set (falsy check)."""
+        env = {
+            "MANUS_LLM_PROVIDER": "",
+            "MANUS_LLM_MODEL": "",
+            "MANUS_LLM_BASE_URL": "",
+            "MANUS_OTX_API_KEY": "",
+            "MANUS_GITHUB_TOKEN": "",
+            "GITHUB_TOKEN": "",
+        }
+        with mock.patch.dict(os.environ, env, clear=False):
+            cfg = Config(llm=LLMConfig(provider="bedrock", model="my-model"))
+        assert cfg.llm.provider == "bedrock"
+        assert cfg.llm.model == "my-model"
+        assert cfg.otx.api_key is None
+        assert cfg.github.api_token is None


### PR DESCRIPTION
## Summary

Comprehensive test suite for `Config._apply_env_overrides()` and `Config.from_file()` — the untested configuration loading pipeline that maps environment variables to config fields.

## What's tested (66 new tests)

### MANUS_LLM_* overrides — always-override semantics (12 tests)
- `MANUS_LLM_PROVIDER` always overrides configured provider
- `MANUS_LLM_MODEL` always overrides configured model
- `MANUS_LLM_BASE_URL` always overrides configured base_url
- `MANUS_LLM_TEMPERATURE` float parsing and override
- `MANUS_LLM_MAX_TOKENS` int parsing and override
- Empty string treated as unset (no override)

### API key resolution — fill-when-None semantics (7 tests)
- `OPENAI_API_KEY` fills openai provider key only when None
- `ANTHROPIC_API_KEY` fills anthropic provider key only when None
- Bedrock/Ollama/unknown providers don't get env-based keys
- Explicit config.toml keys are never overwritten by env

### AWS region resolution (5 tests)
- Priority: `MANUS_AWS_REGION` > `AWS_DEFAULT_REGION` > `AWS_REGION`
- Returns None when no env vars set
- Config-set region not overwritten

### Integration configs (15 tests)
- OTX: `MANUS_OTX_API_KEY` fill-when-None
- GitHub: `MANUS_GITHUB_TOKEN` > `GITHUB_TOKEN` priority
- Lark: `MANUS_LARK_API_TOKEN` > `LARK_API_TOKEN`, same for document URL
- Webhooks: `MANUS_WEBHOOK_CVE_SUBMIT_URL`
- MCP: `MANUS_MCP_SERVER_URL`

### Config.from_file() search paths (7 tests)
- Explicit path loading
- CWD `config.toml` auto-discovery
- `config/config.toml` fallback
- `~/.manus-agent/config.toml` last resort
- Missing path returns defaults
- All TOML sections loaded correctly

### from_file() + env override priority (4 tests)
- Env vars override TOML values for MANUS_LLM_*
- API keys from TOML preserved (fill-when-None)
- API keys absent in TOML filled from env

### _load_dotenv() behavior (8 tests)
- CWD `.env` found and loaded
- `config/.env` fallback
- `~/.manus-agent/.env` fallback
- CWD takes priority over config/
- No .env file doesn't error
- Missing python-dotenv is graceful no-op
- Existing shell vars not overwritten (override=False)

### Combined scenarios (3 tests)
- Full env-only configuration (no file)
- Partial env override preserving file values
- Empty env var strings treated as unset

## Testing approach

- Pure unit tests with `mock.patch.dict(os.environ, ...)` for isolation
- `tmp_path` and `monkeypatch.chdir` for filesystem tests
- No network calls, no external dependencies
- Tests verify both the documented semantics (always-override vs fill-when-None) and edge cases

## Why this matters

`_apply_env_overrides()` is a Pydantic `@model_validator` that runs on every `Config()` construction — it's the central env→config mapping pipeline. Previously untested, meaning:
- Typos in env var names would go undetected
- Priority rule regressions (e.g. env accidentally overwriting explicit config) would be silent
- New integration configs added without env var tests could have broken mappings

All 66 tests pass. No existing tests affected.