### PR TITLE
test: add comprehensive test suite for code_execute tool (48 tests)

### DIFF
--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -1,0 +1,109 @@
+
+## PR #111 — OSV per-package CVE lookup in get_dependency_blast_radius
+
+**Branch:** `feat/osv-package-cve-lookup`
+**Date:** 2026-07-09
+**Status:** Open
+
+### Problem
+
+`get_dependency_blast_radius` showed blast-radius exposure metrics (downloads,
+dependents) for direct package queries but never asked: *does this package have
+known CVEs?*  The OSV `/v1/query` endpoint existed and was used elsewhere in the
+codebase (for CVE→affected-packages lookups) but was never called in the direct
+package path.
+
+### Solution
+
+New helper `_fetch_osv_package_vulns(name, ecosystem, version, max_vulns)`:
+- POSTs to `https://api.osv.dev/v1/query` with package + optional version
+- `_ECOSYSTEM_TO_OSV` dict maps 31 input aliases → canonical OSV ecosystem strings
+  (covers PyPI, npm, Maven, Go, crates.io, RubyGems, NuGet, Packagist, Hex, Pub, Conda)
+- Parses id, summary (≤120 chars), aliases, fixed version from range events
+- Graceful empty-list return on all errors
+
+`get_dependency_blast_radius` direct package path:
+- Calls `_fetch_osv_package_vulns` post-enrichment; version-scoped when version given
+- New output section: `Known CVEs (OSV) affecting @X.Y.Z: N` with per-advisory bullets
+- Summary line: `Known CVEs from OSV affecting version X.Y.Z: N`
+- CVE input path unchanged (function never called there)
+
+### Tests
+
+35 new tests across `TestEcosystemToOsvMapping`, `TestFetchOsvPackageVulns`,
+`TestBlastRadiusOsvIntegration`. Suite: 1193 passed (was 1158).
+
+### Suggested next contributions
+
+- **Swift Package Index enricher** — `_enrich_swift`: API at
+  `swiftpackageindex.com/api/packages/{owner}/{package}`; complication is needing
+  owner/repo format; map to OSV ecosystem `SwiftURL`
+- **Conda enricher** — `_enrich_conda` is already in PR #110; check if merged
+- **Extend `_ECOSYSTEM_TO_OSV`** to cover Conda/Bioconda once PR #110 lands
+- **`first_release_date` for crates.io** (extend PR #103 analogue)
+
+---
+
+## Session N+4 — feat/enrich-cran (PR #113)
+
+### Contribution
+
+Added `_enrich_cran()` enricher to `get_dependency_blast_radius.py`, extending
+the blast-radius tool with native **CRAN (R)** package support.
+
+### Ecosystem selection rationale
+
+- Checked all open PRs (#103–#112): none covered CRAN.
+- OSV ecosystem list confirms `CRAN` as a valid, active ecosystem with real
+  advisories (e.g., `jsonlite`, `openssl`, `httr` packages).
+- Swift Package Index API returned 401 (auth required) — ruled out.
+- ConanCenter API returned HTML/404 for REST queries — ruled out.
+- crandb and cranlogs: both free, unauthenticated, JSON, confirmed working.
+
+### Implementation summary
+
+**Constants**: `_CRANDB_URL`, `_CRANLOGS_URL`
+
+**New helper**: `_parse_cran_timestamp(ts)` — normalises crandb ISO-8601
+timestamps (`"2014-10-21T08:27:55+00:00"` or `"...Z"`) to `"YYYY-MM-DD"` by
+slicing the first 10 characters.
+
+**New enricher**: `_enrich_cran(name)`:
+- Call 1: `crandb.r-pkg.org/{name}/all` → latest version, title (max 120 chars),
+  archived flag, `revdeps` (→ `dependent_packages_count`), version timeline count,
+  first-release date, age in years, CRAN page URL.
+- Call 2: `cranlogs.r-pkg.org/downloads/total/last-month/{name}` → monthly
+  downloads; `weekly_downloads = monthly // 4` (integer floor division).
+- Independent try/except per call for graceful degradation.
+- Both-fail fallback: `{ecosystem: "CRAN", package_name: name}` without raising.
+
+**Dispatcher**: `eco_lower in ("cran", "r")` in `_enrich_package` — covers
+`cran:openssl` and `r:openssl` input forms.
+
+**Output block**: title, latest version, total versions, reverse deps, monthly
+downloads, first release + age, archived status, CRAN page URL.  Fixed npm
+dependents label to show only for npm ecosystem (previously shown for any
+ecosystem with `dependent_packages_count`).
+
+### Tests
+
+30 new tests (6 classes, all HTTP mocked):
+`TestParseCranTimestamp` (6), `TestEnrichCranHappyPath` (16),
+`TestEnrichCranDegradation` (7), `TestEnrichPackageCranDispatch` (5),
+`TestBlastScoreWithCranData` (6), `TestGetDependencyBlastRadiusCran` (9).
+
+Suite: **1206 passed** (was 1158 before this session series; +30 this PR).
+3 deselected, 3 warnings — all pre-existing, zero regressions.
+
+### Suggested next contributions
+
+- **Hackage enricher** (`_enrich_hackage`) — Haskell package registry; OSV
+  ecosystem `Hackage`; API: `hackage.haskell.org/package/{name}.json` (free,
+  unauthenticated). Revdeps via `hackage.haskell.org/package/{name}/reverse`.
+- **opam enricher** (`_enrich_opam`) — OCaml package registry; OSV ecosystem
+  `OSS-Fuzz`/`crates.io` alignment; API: `opam.ocaml.org/pkg/{name}/latest`
+  (JSON, no auth).
+- **OSV `_ECOSYSTEM_TO_OSV` coverage** — extend the mapping to include CRAN
+  once this PR merges.
+- **Per-version CVE integration for CRAN** — `manus-agent blast-radius
+  cran:openssl@2.1.1` should call `_fetch_osv_package_vulns("openssl", "CRAN", "2.1.1")`.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -198,3 +198,45 @@ timeout, and finally-block cleanup.
   PRs add new subcommands but many lack unit tests for argument parsing.
 - **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
   existing test files can be simplified.
+
+---
+
+## Session: 2026-08-01 00:00 UTC — PR #165
+
+### Contribution: test_check_cisa_kev.py — CISA KEV tool test suite
+
+**Branch:** `test/check-cisa-kev-suite`
+**PR:** https://github.com/manus-use/manus-agent/pull/165
+**Tests added:** 43
+
+### Coverage areas
+- TOOL_SPEC schema validation (5 tests)
+- `_get_kev_data` caching logic: fresh/stale/missing cache, network errors,
+  cache write, malformed cache, missing timestamp (8 tests)
+- `check_cisa_kev` main function: CVE found/not-found, case-insensitive,
+  exact match, multiple CVEs, empty catalog, missing key, invalid inputs,
+  tool_use_id propagation (15 tests)
+- `log_tool_output_size` integration — every exit path (4 tests)
+- Edge cases: single-entry catalog, mixed-case, missing key, content structure (8 tests)
+- Module constants validation (3 tests)
+
+### Discovered issue
+`_get_kev_data()` does not handle corrupted cache files gracefully —
+`json.loads()` on a malformed `.cisa_kev_cache.json` propagates
+`JSONDecodeError` instead of falling through to a fresh API fetch.
+Documented in test.
+
+### Results
+- 43 new tests pass
+- Full suite: 1201 passed, 0 failures, 0 regressions
+- Ruff clean (lint + format)
+
+### Suggested next contributions
+- **`get_cwe_details` tool tests** — another core tool with zero test coverage;
+  similar structure (HTTP fetch + HTML parsing + error paths)
+- **`obtain_cves` tool tests** — complex multi-source aggregation pipeline
+  (NVD + GitHub + EPSS + KEV + webhook) with zero unit tests
+- **`search_poc_sources` tool tests** — parallel 5-source aggregator with
+  dedup/sort logic; existing `test_search_poc_sources.py` only covers basic cases
+- **Cache robustness fix PR** — wrap `json.loads()` in `_get_kev_data` with
+  try/except to gracefully handle corrupted cache

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -263,3 +263,17 @@ Documented in test.
 **CLI:** `manus-agent enrich CVE-XXXX-YYYY [--output json|text] [--no-vulncheck]`
 **Tests:** +43 new tests (all fetchers, risk computation, CLI modes, Strands interface)
 **Suggested next:** test suite for `_run_discover` CLI execution (VulnerabilityDiscoveryAgent mocking), or `Config.from_file()` edge cases, or `obtain_cves.py` unit tests
+
+## 2026-08-03 — PR #172: Config._apply_env_overrides() + from_file() tests
+
+**Branch:** `feat/test-config-env-overrides`
+**What:** Comprehensive test suite for the untested environment-variable → config mapping pipeline. Tests `_apply_env_overrides()` (Pydantic model validator), `Config.from_file()` search-path logic, and `_load_dotenv()` behavior.
+**Tests:** +66 new tests covering:
+- MANUS_LLM_* always-override semantics (provider, model, base_url, temperature, max_tokens)
+- API key fill-when-None semantics (OPENAI_API_KEY, ANTHROPIC_API_KEY per provider)
+- AWS region resolution priority (MANUS_AWS_REGION > AWS_DEFAULT_REGION > AWS_REGION)
+- Integration env vars (OTX, GitHub, Lark, Webhooks, MCP)
+- from_file() search paths (CWD, config/, ~/.manus-agent/)
+- _load_dotenv() search, priority, override=False, missing-dotenv graceful no-op
+- Combined: full env-only, partial override, empty-string-as-unset
+**Suggested next:** test suite for `_cmd_doctor` execution logic (check_import, provider checks, docker/playwright probing), or `_run_discover` CLI execution (VulnerabilityDiscoveryAgent mocking), or `browser_agent_tool` wrapper tests

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -107,3 +107,49 @@ Suite: **1206 passed** (was 1158 before this session series; +30 this PR).
   once this PR merges.
 - **Per-version CVE integration for CRAN** — `manus-agent blast-radius
   cran:openssl@2.1.1` should call `_fetch_osv_package_vulns("openssl", "CRAN", "2.1.1")`.
+
+---
+
+## PR #158 — Shared test conftest.py with reusable fixtures (2026-07-29)
+
+### What
+Added `tests/conftest.py` with shared pytest fixtures and `tests/test_conftest_fixtures.py`
+(50 tests) that validates and documents them.
+
+### Why
+30+ test files independently define their own mock factories (tool_use dicts,
+HTTP responses, NVD/EPSS/KEV payloads). This leads to duplicated helpers,
+inconsistent mock shapes, and higher friction when writing new tests. A shared
+conftest.py is the standard pytest solution.
+
+### Fixtures provided
+- `make_tool_use` — builds Strands tool_use dicts with auto-generated IDs
+- `mock_http_response` — creates mock requests.Response with raise_for_status()
+- `nvd_cve_factory` / `nvd_api_response` — builds NVD CVE payloads
+- `epss_data_factory` — builds EPSS API responses
+- `kev_catalog_factory` — builds CISA KEV catalog payloads
+- `osv_record_factory` — builds OSV.dev records
+- Config fixtures (default, bedrock, openai, anthropic, ollama)
+- `tmp_history_file` / `tmp_config_file` — temp filesystem helpers
+- `env_override` — clean monkeypatch wrapper
+- Module constants: `SAMPLE_CVE_LOG4SHELL`, `SAMPLE_CVE_XZ`
+
+### Results
+- 50 new fixture validation tests pass
+- All 1208 existing tests unchanged / passing
+- Ruff clean
+
+### Suggested next contributions
+
+- **`_run_changelog_generate` test coverage** — the changelog CLI tests
+  (`test_changelog_cli.py`) are comprehensive but `_run_changelog_generate`
+  could use edge-case tests for merge commits, non-conventional commits mixed
+  in, and empty repos.
+- **BrowserUseAgent.stream_async tests** — `stream_async()` uses asyncio.Queue
+  with step/done callbacks; no tests cover the streaming yield/queue pattern.
+- **WorkflowAgent / Orchestrator tests** — `Orchestrator.run()` currently just
+  delegates to WorkflowAgent; tests for the `TaskPlan`, `OrchestratorResult`,
+  and `AgentType` data structures + error handling.
+- **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
+  existing test files can be simplified by replacing local helpers with shared
+  fixtures.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -153,3 +153,48 @@ conftest.py is the standard pytest solution.
 - **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
   existing test files can be simplified by replacing local helpers with shared
   fixtures.
+
+---
+
+## Contribution 6 — BrowserUseAgent.stream_async tests
+
+**PR:** #159
+**Branch:** `feat/test-stream-async-browser-agent`
+**File:** `tests/test_browser_use_stream_async.py` (+1548 lines)
+
+### Rationale
+
+`stream_async()` is a 165-line async generator with callbacks, queue management,
+error handling, and cleanup logic. Existing tests only covered the fallback path
+(2 tests when BrowserUse is None), leaving zero coverage of the real streaming
+path: step_callback, done_callback, queue draining, background task, keep_alive
+timeout, and finally-block cleanup.
+
+### What was added
+
+45 tests in 7 classes:
+- Fallback path (5): BrowserUse/BrowserProfile/Controller unavailable
+- True streaming path (11): callbacks, queue flow, extracted content, output_model
+- Error handling (7): constructor/LLM/callback failures, post-done exceptions
+- Browser cleanup (7): close(), keep_alive timeout, error resilience
+- Input handling (4): string/list/empty task parsing
+- Task cancellation (2): background task lifecycle
+- Configuration (4): headless, output_model, enable_memory, patch config
+- Edge cases (8): missing attributes, mixed types, validate_output
+
+### Results
+- 45 new tests pass
+- All 1203 tests pass (up from 1158), no regressions
+- Ruff clean
+
+### Suggested next contributions
+
+- **WorkflowAgent / Orchestrator tests** — `Orchestrator.run()` delegates to
+  WorkflowAgent; tests for `TaskPlan`, `OrchestratorResult`, `AgentType` data
+  structures + error handling.
+- **`_run_browser_task` tests** — the non-streaming browser task method has
+  complex try/finally with keep_alive/timeout logic worth covering.
+- **CLI `vendor-response` / `verify-exploit` subcommand tests** — several open
+  PRs add new subcommands but many lack unit tests for argument parsing.
+- **Refactor existing tests to use conftest fixtures** — once PR #158 merges,
+  existing test files can be simplified.

--- a/EVOLUTION_LOG.md
+++ b/EVOLUTION_LOG.md
@@ -240,3 +240,26 @@ Documented in test.
   dedup/sort logic; existing `test_search_poc_sources.py` only covers basic cases
 - **Cache robustness fix PR** — wrap `json.loads()` in `_get_kev_data` with
   try/except to gracefully handle corrupted cache
+
+## 2026-08-01 — PR #112 (updated): decode-cvss vector decoder/explainer tool
+
+**What:** New `decode_cvss_vector` tool + `decode-cvss` CLI subcommand that parses CVSS v3.0/v3.1 vector strings and produces structured breakdowns with:
+- Per-metric human-readable explanations
+- Computed base score (exact CVSS v3.1 formula)
+- Severity classification
+- Natural-language attack summary
+- Remediation priority with escalation factors
+
+**Why:** The project collects CVSS vectors from multiple sources (NVD, VulnCheck, patch-diff) but never explains what they mean. This fills the gap between raw scores and actionable security context.
+
+**Tests:** +70 new tests (1228 total passing, up from 1158 baseline)
+**Branch:** feat/cvss-vector-decoder
+**PR:** https://github.com/manus-use/manus-agent/pull/112
+
+## 2026-08-02 — PR #170: cve-enrich tool + CLI subcommand
+
+**Branch:** `feat/cve-enrich`
+**What:** Lightweight multi-source CVE enrichment tool that fetches NVD, EPSS, CISA KEV, OSV.dev, and VulnCheck data in parallel. Returns unified risk snapshot with composite scoring. No LLM agent required.
+**CLI:** `manus-agent enrich CVE-XXXX-YYYY [--output json|text] [--no-vulncheck]`
+**Tests:** +43 new tests (all fetchers, risk computation, CLI modes, Strands interface)
+**Suggested next:** test suite for `_run_discover` CLI execution (VulnerabilityDiscoveryAgent mocking), or `Config.from_file()` edge cases, or `obtain_cves.py` unit tests

--- a/tests/test_code_execute.py
+++ b/tests/test_code_execute.py
@@ -1,0 +1,713 @@
+"""Tests for code_execute tool — CodeExecutor, async pipeline, and @tool wrapper.
+
+Covers:
+- CodeExecutor initialisation and configuration
+- execute_python local mode (sandbox disabled)
+- execute_bash local mode (sandbox disabled)
+- Sandbox path (mocked DockerSandbox)
+- Async pipeline: code_execute() function with language routing, timeout, errors
+- Synchronous @tool wrapper: code_execute_sync
+- get_executor() singleton behaviour
+- Edge cases: unsupported language, empty code, timeout, exceptions
+"""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Module-level imports
+# ---------------------------------------------------------------------------
+
+
+def test_module_importable():
+    """code_execute module imports cleanly."""
+    from manus_agent.tools import code_execute  # noqa: F401
+
+
+def test_code_executor_class_importable():
+    """CodeExecutor class is importable."""
+    from manus_agent.tools.code_execute import CodeExecutor
+
+    assert CodeExecutor is not None
+
+
+def test_get_executor_importable():
+    """get_executor singleton factory is importable."""
+    from manus_agent.tools.code_execute import get_executor
+
+    assert callable(get_executor)
+
+
+def test_code_execute_sync_is_strands_tool():
+    """code_execute_sync is decorated with @tool."""
+    from manus_agent.tools.code_execute import code_execute_sync
+
+    # Strands @tool decorated functions have specific attributes
+    assert callable(code_execute_sync)
+
+
+# ---------------------------------------------------------------------------
+# CodeExecutor — initialisation
+# ---------------------------------------------------------------------------
+
+
+class TestCodeExecutorInit:
+    """Tests for CodeExecutor construction."""
+
+    def test_default_config_used_when_none(self, monkeypatch):
+        """CodeExecutor uses Config.from_file() when no config passed."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            executor = CodeExecutor()
+            assert executor.config is mock_config
+
+    def test_explicit_config_used(self):
+        """CodeExecutor uses passed config."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        executor = CodeExecutor(config=mock_config)
+        assert executor.config is mock_config
+
+    def test_sandbox_initially_none(self):
+        """Sandbox instance is None before first execution."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = True
+        executor = CodeExecutor(config=mock_config)
+        assert executor._sandbox is None
+
+
+# ---------------------------------------------------------------------------
+# CodeExecutor.execute_python — local mode (sandbox disabled)
+# ---------------------------------------------------------------------------
+
+
+class TestExecutePythonLocal:
+    """Tests for execute_python when sandbox is disabled."""
+
+    @pytest.fixture
+    def executor_no_sandbox(self):
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 30
+        return CodeExecutor(config=mock_config)
+
+    @pytest.mark.asyncio
+    async def test_simple_print(self, executor_no_sandbox):
+        """Simple print statement produces stdout."""
+        stdout, stderr, code = await executor_no_sandbox.execute_python("print('hello')")
+        assert stdout.strip() == "hello"
+        assert code == 0
+
+    @pytest.mark.asyncio
+    async def test_syntax_error_returns_nonzero(self, executor_no_sandbox):
+        """Syntax error produces nonzero exit code."""
+        stdout, stderr, code = await executor_no_sandbox.execute_python("def foo(")
+        assert code != 0
+        assert "SyntaxError" in stderr
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_in_stderr(self, executor_no_sandbox):
+        """Runtime error appears in stderr."""
+        stdout, stderr, code = await executor_no_sandbox.execute_python("raise ValueError('boom')")
+        assert code != 0
+        assert "ValueError" in stderr
+        assert "boom" in stderr
+
+    @pytest.mark.asyncio
+    async def test_stderr_independent_of_stdout(self, executor_no_sandbox):
+        """stderr and stdout are independently captured."""
+        code_text = "import sys; print('out'); print('err', file=sys.stderr)"
+        stdout, stderr, code = await executor_no_sandbox.execute_python(code_text)
+        assert "out" in stdout
+        assert "err" in stderr
+        assert code == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_override(self, executor_no_sandbox):
+        """Custom timeout is applied."""
+        with patch("manus_agent.tools.code_execute.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            await executor_no_sandbox.execute_python("pass", timeout=42)
+            call_kwargs = mock_run.call_args
+            assert call_kwargs[1]["timeout"] == 42
+
+    @pytest.mark.asyncio
+    async def test_default_timeout_from_config(self, executor_no_sandbox):
+        """Default timeout comes from config.sandbox.timeout."""
+        with patch("manus_agent.tools.code_execute.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            await executor_no_sandbox.execute_python("pass")
+            call_kwargs = mock_run.call_args
+            assert call_kwargs[1]["timeout"] == 30
+
+    @pytest.mark.asyncio
+    async def test_tempfile_cleaned_up(self, executor_no_sandbox):
+        """Temporary file is removed after execution."""
+        created_paths: list[Path] = []
+
+        original_run = subprocess.run
+
+        def capture_run(args, **kwargs):
+            # The second arg is the script path
+            if len(args) >= 2:
+                created_paths.append(Path(args[1]))
+            return original_run(args, **kwargs)
+
+        with patch("manus_agent.tools.code_execute.subprocess.run", side_effect=capture_run):
+            await executor_no_sandbox.execute_python("pass")
+
+        # Verify the temp file was deleted
+        for p in created_paths:
+            assert not p.exists(), f"Temp file was not cleaned up: {p}"
+
+    @pytest.mark.asyncio
+    async def test_multiline_code(self, executor_no_sandbox):
+        """Multiline code works correctly."""
+        code_text = "x = 2\ny = 3\nprint(x + y)"
+        stdout, stderr, code = await executor_no_sandbox.execute_python(code_text)
+        assert stdout.strip() == "5"
+        assert code == 0
+
+
+# ---------------------------------------------------------------------------
+# CodeExecutor.execute_bash — local mode (sandbox disabled)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteBashLocal:
+    """Tests for execute_bash when sandbox is disabled."""
+
+    @pytest.fixture
+    def executor_no_sandbox(self):
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 30
+        return CodeExecutor(config=mock_config)
+
+    @pytest.mark.asyncio
+    async def test_simple_echo(self, executor_no_sandbox):
+        """Simple echo command produces stdout."""
+        stdout, stderr, code = await executor_no_sandbox.execute_bash("echo hello")
+        assert stdout.strip() == "hello"
+        assert code == 0
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_command(self, executor_no_sandbox):
+        """Nonexistent command gives nonzero exit code."""
+        stdout, stderr, code = await executor_no_sandbox.execute_bash("command_that_does_not_exist_xyz123")
+        assert code != 0
+
+    @pytest.mark.asyncio
+    async def test_exit_code_propagation(self, executor_no_sandbox):
+        """Exit code is correctly propagated."""
+        stdout, stderr, code = await executor_no_sandbox.execute_bash("exit 42")
+        assert code == 42
+
+    @pytest.mark.asyncio
+    async def test_stderr_captured(self, executor_no_sandbox):
+        """stderr is captured separately."""
+        stdout, stderr, code = await executor_no_sandbox.execute_bash("echo err >&2")
+        assert "err" in stderr
+        assert code == 0
+
+    @pytest.mark.asyncio
+    async def test_piped_command(self, executor_no_sandbox):
+        """Piped commands work (shell=True)."""
+        stdout, stderr, code = await executor_no_sandbox.execute_bash("echo 'foo bar baz' | wc -w")
+        assert stdout.strip() == "3"
+        assert code == 0
+
+    @pytest.mark.asyncio
+    async def test_timeout_parameter(self, executor_no_sandbox):
+        """Custom timeout is passed to subprocess.run."""
+        with patch("manus_agent.tools.code_execute.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            await executor_no_sandbox.execute_bash("true", timeout=99)
+            call_kwargs = mock_run.call_args
+            assert call_kwargs[1]["timeout"] == 99
+
+
+# ---------------------------------------------------------------------------
+# CodeExecutor — sandbox path (mocked)
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteWithSandbox:
+    """Tests for execution when sandbox is enabled (DockerSandbox mocked)."""
+
+    @pytest.fixture
+    def executor_with_sandbox(self):
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = True
+        mock_config.sandbox.docker_image = "python:3.12-slim"
+        mock_config.sandbox.memory_limit = "512m"
+        mock_config.sandbox.cpu_limit = 1.0
+        mock_config.sandbox.timeout = 60
+        return CodeExecutor(config=mock_config)
+
+    @pytest.mark.asyncio
+    async def test_sandbox_created_on_first_call(self, executor_with_sandbox):
+        """DockerSandbox is instantiated and started on first execution."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.execute_code = AsyncMock(return_value=("output", "", 0))
+        mock_sandbox.start = AsyncMock()
+
+        with patch("manus_agent.tools.code_execute.DockerSandbox", return_value=mock_sandbox):
+            await executor_with_sandbox.execute_python("print('hi')")
+            mock_sandbox.start.assert_called_once()
+            mock_sandbox.execute_code.assert_called_once_with(
+                "print('hi')", language="python", timeout=60
+            )
+
+    @pytest.mark.asyncio
+    async def test_sandbox_reused_on_second_call(self, executor_with_sandbox):
+        """DockerSandbox is reused across calls."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.execute_code = AsyncMock(return_value=("", "", 0))
+        mock_sandbox.start = AsyncMock()
+
+        with patch("manus_agent.tools.code_execute.DockerSandbox", return_value=mock_sandbox):
+            await executor_with_sandbox.execute_python("x = 1")
+            await executor_with_sandbox.execute_python("x = 2")
+            # start called only once
+            assert mock_sandbox.start.call_count == 1
+            assert mock_sandbox.execute_code.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_bash_uses_sandbox_execute_command(self, executor_with_sandbox):
+        """execute_bash delegates to sandbox.execute_command when enabled."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.execute_command = AsyncMock(return_value=("dir listing", "", 0))
+        mock_sandbox.start = AsyncMock()
+
+        with patch("manus_agent.tools.code_execute.DockerSandbox", return_value=mock_sandbox):
+            stdout, stderr, code = await executor_with_sandbox.execute_bash("ls")
+            assert stdout == "dir listing"
+            mock_sandbox.execute_command.assert_called_once_with("ls", timeout=60)
+
+    @pytest.mark.asyncio
+    async def test_cleanup_stops_sandbox(self, executor_with_sandbox):
+        """cleanup() stops and clears sandbox reference."""
+        mock_sandbox = AsyncMock()
+        mock_sandbox.execute_code = AsyncMock(return_value=("", "", 0))
+        mock_sandbox.start = AsyncMock()
+        mock_sandbox.stop = AsyncMock()
+
+        with patch("manus_agent.tools.code_execute.DockerSandbox", return_value=mock_sandbox):
+            await executor_with_sandbox.execute_python("pass")
+            assert executor_with_sandbox._sandbox is not None
+            await executor_with_sandbox.cleanup()
+            mock_sandbox.stop.assert_called_once()
+            assert executor_with_sandbox._sandbox is None
+
+
+# ---------------------------------------------------------------------------
+# Async code_execute() function — language routing and error handling
+# ---------------------------------------------------------------------------
+
+
+class TestCodeExecuteFunction:
+    """Tests for the async code_execute() function."""
+
+    @pytest.fixture(autouse=True)
+    def reset_global_executor(self):
+        """Reset global executor between tests."""
+        import manus_agent.tools.code_execute as mod
+
+        mod._executor = None
+        yield
+        mod._executor = None
+
+    @pytest.mark.asyncio
+    async def test_python_language_routes_to_execute_python(self):
+        """language='python' routes to execute_python."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("print(42)", language="python")
+            assert result["stdout"].strip() == "42"
+            assert result["exit_code"] == 0
+            assert result["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_bash_language_routes_to_execute_bash(self):
+        """language='bash' routes to execute_bash."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("echo hi", language="bash")
+            assert result["stdout"].strip() == "hi"
+            assert result["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_sh_language_accepted(self):
+        """language='sh' routes to execute_bash."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("echo yes", language="sh")
+            assert result["stdout"].strip() == "yes"
+
+    @pytest.mark.asyncio
+    async def test_shell_language_accepted(self):
+        """language='shell' routes to execute_bash."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("echo yes", language="shell")
+            assert result["stdout"].strip() == "yes"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_language_returns_error(self):
+        """Unsupported language returns an error dict."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("print('x')", language="ruby")
+            assert result["exit_code"] == 1
+            assert "ruby" in result["error"].lower() or "ruby" in result["stderr"].lower()
+            assert result["stdout"] == ""
+
+    @pytest.mark.asyncio
+    async def test_timeout_error_caught(self):
+        """asyncio.TimeoutError is caught and returned as error dict."""
+        from manus_agent.tools.code_execute import CodeExecutor, code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 1
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            with patch.object(
+                CodeExecutor,
+                "execute_python",
+                side_effect=asyncio.TimeoutError(),
+            ):
+                result = await code_execute("import time; time.sleep(100)", language="python", timeout=1)
+                assert result["exit_code"] == -1
+                assert "Timeout" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_caught(self):
+        """Generic exceptions are caught and returned as error dict."""
+        from manus_agent.tools.code_execute import CodeExecutor, code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            with patch.object(
+                CodeExecutor,
+                "execute_python",
+                side_effect=RuntimeError("disk full"),
+            ):
+                result = await code_execute("pass", language="python")
+                assert result["exit_code"] == -1
+                assert "disk full" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_code_sets_error_field(self):
+        """Non-zero exit code populates the error field with stderr."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("import sys; sys.exit(1)", language="python")
+            assert result["exit_code"] == 1
+            # error is set to stderr content when exit_code != 0
+            assert result["error"] is not None or result["stderr"] != ""
+
+
+# ---------------------------------------------------------------------------
+# get_executor() singleton
+# ---------------------------------------------------------------------------
+
+
+class TestGetExecutor:
+    """Tests for the get_executor() singleton factory."""
+
+    @pytest.fixture(autouse=True)
+    def reset_global_executor(self):
+        """Reset global executor between tests."""
+        import manus_agent.tools.code_execute as mod
+
+        mod._executor = None
+        yield
+        mod._executor = None
+
+    def test_returns_code_executor_instance(self):
+        """get_executor() returns a CodeExecutor."""
+        from manus_agent.tools.code_execute import CodeExecutor, get_executor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            executor = get_executor()
+            assert isinstance(executor, CodeExecutor)
+
+    def test_returns_same_instance(self):
+        """get_executor() returns the same object on repeated calls."""
+        from manus_agent.tools.code_execute import get_executor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            e1 = get_executor()
+            e2 = get_executor()
+            assert e1 is e2
+
+    def test_accepts_explicit_config(self):
+        """get_executor(config=...) uses the provided config."""
+        from manus_agent.tools.code_execute import get_executor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        executor = get_executor(config=mock_config)
+        assert executor.config is mock_config
+
+
+# ---------------------------------------------------------------------------
+# code_execute_sync — @tool wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestCodeExecuteSync:
+    """Tests for the synchronous @tool wrapper."""
+
+    @pytest.fixture(autouse=True)
+    def reset_global_executor(self):
+        """Reset global executor between tests."""
+        import manus_agent.tools.code_execute as mod
+
+        mod._executor = None
+        yield
+        mod._executor = None
+
+    def test_sync_wrapper_returns_dict(self):
+        """code_execute_sync returns a dict with expected keys."""
+        from manus_agent.tools.code_execute import code_execute_sync
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = code_execute_sync("print('test')", language="python")
+            assert isinstance(result, dict)
+            assert "stdout" in result
+            assert "stderr" in result
+            assert "exit_code" in result
+
+    def test_sync_wrapper_python_execution(self):
+        """code_execute_sync executes Python code correctly."""
+        from manus_agent.tools.code_execute import code_execute_sync
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = code_execute_sync("print(2 + 2)", language="python")
+            assert result["stdout"].strip() == "4"
+            assert result["exit_code"] == 0
+
+    def test_sync_wrapper_bash_execution(self):
+        """code_execute_sync executes bash code correctly."""
+        from manus_agent.tools.code_execute import code_execute_sync
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = code_execute_sync("echo done", language="bash")
+            assert result["stdout"].strip() == "done"
+            assert result["exit_code"] == 0
+
+    def test_sync_wrapper_unsupported_language(self):
+        """code_execute_sync returns error for unsupported language."""
+        from manus_agent.tools.code_execute import code_execute_sync
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = code_execute_sync("x", language="java")
+            assert result["exit_code"] == 1
+            assert result["error"] is not None
+
+
+# ---------------------------------------------------------------------------
+# Edge cases and integration scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Edge-case tests for code_execute module."""
+
+    @pytest.fixture(autouse=True)
+    def reset_global_executor(self):
+        """Reset global executor between tests."""
+        import manus_agent.tools.code_execute as mod
+
+        mod._executor = None
+        yield
+        mod._executor = None
+
+    @pytest.mark.asyncio
+    async def test_empty_python_code(self):
+        """Empty code string executes without error."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("", language="python")
+            assert result["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_bash_code(self):
+        """Empty bash command executes without error."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("", language="bash")
+            assert result["exit_code"] == 0
+
+    @pytest.mark.asyncio
+    async def test_large_output(self):
+        """Large stdout is fully captured."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("print('x' * 10000)", language="python")
+            assert len(result["stdout"].strip()) == 10000
+
+    @pytest.mark.asyncio
+    async def test_language_case_insensitive(self):
+        """Language parameter is case-insensitive."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("print('yes')", language="Python")
+            assert result["stdout"].strip() == "yes"
+
+    @pytest.mark.asyncio
+    async def test_special_characters_in_code(self):
+        """Code with special characters executes correctly."""
+        from manus_agent.tools.code_execute import code_execute
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        with patch("manus_agent.tools.code_execute.Config.from_file", return_value=mock_config):
+            result = await code_execute("print('hello\\nworld')", language="python")
+            assert "hello" in result["stdout"]
+            assert "world" in result["stdout"]
+
+    @pytest.mark.asyncio
+    async def test_uses_sys_executable(self):
+        """execute_python uses sys.executable for the Python interpreter."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        executor = CodeExecutor(config=mock_config)
+        with patch("manus_agent.tools.code_execute.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            await executor.execute_python("pass")
+            args = mock_run.call_args[0][0]
+            assert args[0] == sys.executable
+
+    @pytest.mark.asyncio
+    async def test_bash_uses_shell_true(self):
+        """execute_bash uses shell=True."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        mock_config.sandbox.timeout = 10
+
+        executor = CodeExecutor(config=mock_config)
+        with patch("manus_agent.tools.code_execute.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(stdout="", stderr="", returncode=0)
+            await executor.execute_bash("ls")
+            call_kwargs = mock_run.call_args[1]
+            assert call_kwargs["shell"] is True
+
+    def test_cleanup_when_no_sandbox(self):
+        """cleanup() is safe when no sandbox was ever created."""
+        from manus_agent.tools.code_execute import CodeExecutor
+
+        mock_config = MagicMock()
+        mock_config.sandbox.enabled = False
+        executor = CodeExecutor(config=mock_config)
+        # Should not raise
+        loop = asyncio.new_event_loop()
+        try:
+            loop.run_until_complete(executor.cleanup())
+        finally:
+            loop.close()


### PR DESCRIPTION
## Summary

Adds a complete test suite for `src/manus_agent/tools/code_execute.py`, which previously had **zero test coverage**.

## What's Tested

| Category | Tests | Description |
|----------|-------|-------------|
| Module imports | 4 | Basic importability and @tool decoration |
| CodeExecutor init | 3 | Config injection, defaults, sandbox state |
| execute_python (local) | 8 | stdout/stderr capture, exit codes, timeout, tempfile cleanup |
| execute_bash (local) | 6 | echo, exit codes, stderr, piped commands, timeout |
| Sandbox path (mocked) | 4 | DockerSandbox creation, reuse, bash delegation, cleanup |
| Async code_execute() | 8 | Language routing (python/bash/sh/shell), unsupported lang, timeout, exceptions |
| get_executor() singleton | 3 | Instance creation, reuse, config forwarding |
| code_execute_sync @tool | 4 | Sync wrapper for python/bash/unsupported/dict return |
| Edge cases | 8 | Empty code, large output, case-insensitive lang, special chars, sys.executable |

**Total: 48 tests, all passing**

## Design Decisions

- **No network calls**: Sandbox paths use `AsyncMock`; local execution uses real subprocess (safe, fast)
- **Global state isolated**: `_executor` singleton is reset between test classes via fixtures
- **pytest-asyncio**: Used for async method tests (`@pytest.mark.asyncio`)
- **Follows project conventions**: Same patterns as test_epss_trend.py, test_exploit_complexity.py, etc.

## Test Run

```
$ python3 -m pytest tests/test_code_execute.py -v
============================== 48 passed in 1.78s ==============================
```