### PR TITLE
feat(cli): add manus-agent watchlist subcommand for persistent CVE tracking with bulk EPSS + KEV status

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1802,6 +1802,179 @@ def _build_blast_radius_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _run_watchlist(argv: list[str]) -> int:
+    """CVE watchlist management CLI."""
+    import json as _json
+
+    parser = argparse.ArgumentParser(
+        prog="manus-agent watchlist",
+        description="Manage a persistent CVE watchlist with bulk EPSS + KEV status updates.",
+    )
+    sub = parser.add_subparsers(dest="subaction")
+
+    # watchlist add
+    add_p = sub.add_parser("add", help="Add CVEs to the watchlist")
+    add_p.add_argument("cve_ids", nargs="+", metavar="CVE-ID", help="One or more CVE IDs")
+    add_p.add_argument("--note", default=None, help="Optional note/tag for these CVEs")
+
+    # watchlist remove
+    rm_p = sub.add_parser("remove", help="Remove CVEs from the watchlist")
+    rm_p.add_argument("cve_ids", nargs="+", metavar="CVE-ID", help="One or more CVE IDs")
+
+    # watchlist list
+    sub.add_parser("list", help="List all tracked CVEs")
+
+    # watchlist status
+    status_p = sub.add_parser("status", help="Fetch live EPSS + KEV status for all tracked CVEs")
+    status_p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    # watchlist clear
+    sub.add_parser("clear", help="Clear the entire watchlist")
+
+    args = parser.parse_args(argv)
+
+    if args.subaction is None:
+        parser.print_help()
+        return 1
+
+    from manus_agent.tools.cve_watchlist import watchlist_manage
+
+    if args.subaction == "add":
+        result = watchlist_manage("add", cve_ids=args.cve_ids, note=args.note)
+        if result.get("added"):
+            console.print(f"[green]Added:[/green] {', '.join(result['added'])}")
+        if result.get("duplicate"):
+            console.print(f"[yellow]Already tracked:[/yellow] {', '.join(result['duplicate'])}")
+        if result.get("invalid"):
+            console.print(f"[red]Invalid:[/red] {', '.join(result['invalid'])}")
+        console.print(f"[dim]Total tracked: {result['total']}[/dim]")
+        return 0
+
+    elif args.subaction == "remove":
+        result = watchlist_manage("remove", cve_ids=args.cve_ids)
+        if result.get("removed"):
+            console.print(f"[green]Removed:[/green] {', '.join(result['removed'])}")
+        if result.get("not_found"):
+            console.print(f"[yellow]Not found:[/yellow] {', '.join(result['not_found'])}")
+        console.print(f"[dim]Total tracked: {result['total']}[/dim]")
+        return 0
+
+    elif args.subaction == "list":
+        result = watchlist_manage("list")
+        if not result["entries"]:
+            console.print("[dim]Watchlist is empty. Add CVEs with: manus-agent watchlist add CVE-...[/dim]")
+            return 0
+        table = Table(
+            title=f"CVE Watchlist ({result['total']} entries)",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("CVE ID", style="cyan")
+        table.add_column("EPSS", style="yellow", width=8)
+        table.add_column("%ile", style="blue", width=8)
+        table.add_column("KEV", width=5)
+        table.add_column("Note", style="dim")
+        table.add_column("Added", style="dim", width=12)
+        for entry in result["entries"]:
+            epss_str = f"{entry['last_epss']:.4f}" if entry["last_epss"] is not None else "-"
+            pctl_str = f"{entry['last_percentile']:.2f}" if entry["last_percentile"] is not None else "-"
+            kev_str = (
+                "[red]YES[/red]" if entry["in_kev"] else "[green]no[/green]" if entry["in_kev"] is not None else "-"
+            )
+            added_str = entry["added_at"][:10] if entry["added_at"] else "-"
+            table.add_row(entry["cve_id"], epss_str, pctl_str, kev_str, entry["note"], added_str)
+        console.print(table)
+        if result["last_checked"]:
+            console.print(f"[dim]Last status check: {result['last_checked']}[/dim]")
+        return 0
+
+    elif args.subaction == "status":
+        output_fmt = args.output
+        if output_fmt == "json":
+            result = watchlist_manage("status")
+        else:
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                console=console,
+            ) as progress:
+                progress.add_task(description="Fetching EPSS + KEV status...", total=None)
+                result = watchlist_manage("status")
+
+        if not result.get("entries"):
+            console.print("[dim]Watchlist is empty. Add CVEs with: manus-agent watchlist add CVE-...[/dim]")
+            return 0
+
+        if output_fmt == "json":
+            sys.stdout.write(_json.dumps(result, indent=2, ensure_ascii=False) + "\n")
+            return 0
+
+        # Show changes first
+        if result.get("changes"):
+            console.print("\n[bold red]⚠ Changes detected since last check:[/bold red]")
+            for change in result["changes"]:
+                if change["type"] == "kev_added":
+                    console.print(f"  [red]🚨 {change['cve_id']} — ADDED TO CISA KEV[/red]")
+                elif change["type"] == "epss_spike":
+                    console.print(
+                        f"  [yellow]📈 {change['cve_id']} — EPSS spike: "
+                        f"{change['previous']:.4f} → {change['current']:.4f} "
+                        f"(+{change['delta']:.4f})[/yellow]"
+                    )
+                elif change["type"] == "epss_drop":
+                    console.print(
+                        f"  [green]📉 {change['cve_id']} — EPSS drop: "
+                        f"{change['previous']:.4f} → {change['current']:.4f} "
+                        f"({change['delta']:.4f})[/green]"
+                    )
+            console.print()
+
+        # Status table
+        table = Table(
+            title=f"Watchlist Status ({result['total']} CVEs)",
+            show_header=True,
+            header_style="bold magenta",
+        )
+        table.add_column("CVE ID", style="cyan")
+        table.add_column("EPSS", style="yellow", width=8)
+        table.add_column("%ile", style="blue", width=8)
+        table.add_column("Δ", width=8)
+        table.add_column("KEV", width=5)
+        table.add_column("Note", style="dim")
+
+        for entry in result["entries"]:
+            epss_str = f"{entry['epss']:.4f}" if entry["epss"] is not None else "-"
+            pctl_str = f"{entry['percentile']:.2f}" if entry["percentile"] is not None else "-"
+            if entry["epss_delta"] is not None and entry["epss_delta"] != 0:
+                sign = "+" if entry["epss_delta"] > 0 else ""
+                delta_str = f"{sign}{entry['epss_delta']:.4f}"
+            else:
+                delta_str = "-"
+            kev_str = "[red]YES[/red]" if entry["in_kev"] else "[green]no[/green]"
+            table.add_row(entry["cve_id"], epss_str, pctl_str, delta_str, kev_str, entry.get("note", ""))
+
+        console.print(table)
+        summary = result["summary"]
+        console.print(
+            f"\n[dim]KEV: {summary['kev_count']}/{result['total']} | "
+            f"Avg EPSS: {summary['avg_epss']:.4f} | "
+            f"Checked: {summary['checked_at']}[/dim]"
+        )
+        return 0
+
+    elif args.subaction == "clear":
+        result = watchlist_manage("clear")
+        console.print(f"[yellow]Cleared {result['cleared']} entries from watchlist.[/yellow]")
+        return 0
+
+    return 1
+
+
 def _run_blast_radius(argv: list[str]) -> int:
     import json as _json
 
@@ -2268,6 +2441,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "watchlist":
+        idx = argv.index("watchlist")
+        sys.exit(_run_watchlist(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/cve_watchlist.py
+++ b/src/manus_agent/tools/cve_watchlist.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""CVE Watchlist — persistent tracking with bulk EPSS + KEV status updates.
+
+Provides a local watchlist (~/.manus-agent/watchlist.json) where users can
+add/remove CVEs they're monitoring and retrieve bulk status updates showing
+current EPSS scores, CISA KEV membership, and status changes since the last
+check.
+
+Design principles:
+- Zero API keys required (EPSS is public, CISA KEV is public JSON feed)
+- Persistent local storage with atomic writes
+- Batch EPSS lookups (the FIRST.org API supports comma-separated CVE lists)
+- Tracks previous EPSS scores to detect movement (spikes/drops)
+- Human-friendly CLI output via Rich tables
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+__all__ = ["watchlist_manage"]
+
+# ---------------------------------------------------------------------------
+# Storage paths
+# ---------------------------------------------------------------------------
+
+_DEFAULT_WATCHLIST_DIR = Path.home() / ".manus-agent"
+_DEFAULT_WATCHLIST_FILE = _DEFAULT_WATCHLIST_DIR / "watchlist.json"
+
+# Allow override via env var (useful for tests)
+_WATCHLIST_PATH = Path(os.environ.get("MANUS_WATCHLIST_PATH", str(_DEFAULT_WATCHLIST_FILE)))
+
+# CVE ID pattern
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+
+# EPSS batch size limit (FIRST.org API accepts up to ~100 CVEs per request)
+_EPSS_BATCH_SIZE = 100
+
+# CISA KEV feed URL
+_CISA_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+
+# EPSS API base URL
+_EPSS_API_URL = "https://api.first.org/data/v1/epss"
+
+# HTTP timeout for all requests
+_HTTP_TIMEOUT = 20
+
+
+# ---------------------------------------------------------------------------
+# Watchlist data model
+# ---------------------------------------------------------------------------
+
+
+def _load_watchlist() -> dict[str, Any]:
+    """Load the watchlist from disk. Returns empty structure if not found."""
+    if not _WATCHLIST_PATH.exists():
+        return {"cves": {}, "last_checked": None}
+    try:
+        data = json.loads(_WATCHLIST_PATH.read_text(encoding="utf-8"))
+        if "cves" not in data:
+            data["cves"] = {}
+        return data
+    except (json.JSONDecodeError, OSError):
+        return {"cves": {}, "last_checked": None}
+
+
+def _save_watchlist(data: dict[str, Any]) -> None:
+    """Atomically save the watchlist to disk."""
+    _WATCHLIST_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = _WATCHLIST_PATH.with_suffix(".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+    tmp_path.replace(_WATCHLIST_PATH)
+
+
+def _validate_cve_id(cve_id: str) -> str | None:
+    """Validate and normalise a CVE ID. Returns normalised ID or None."""
+    cve_id = cve_id.strip().upper()
+    if _CVE_RE.match(cve_id):
+        return cve_id
+    return None
+
+
+# ---------------------------------------------------------------------------
+# External data fetching
+# ---------------------------------------------------------------------------
+
+
+def _fetch_epss_batch(cve_ids: list[str]) -> dict[str, dict[str, Any]]:
+    """Fetch EPSS scores for a batch of CVE IDs.
+
+    Returns a dict mapping CVE ID -> {epss, percentile, date}.
+    """
+    results: dict[str, dict[str, Any]] = {}
+    for i in range(0, len(cve_ids), _EPSS_BATCH_SIZE):
+        batch = cve_ids[i : i + _EPSS_BATCH_SIZE]
+        try:
+            resp = requests.get(
+                _EPSS_API_URL,
+                params={"cve": ",".join(batch)},
+                timeout=_HTTP_TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for item in data.get("data", []):
+                results[item["cve"].upper()] = {
+                    "epss": float(item.get("epss", 0)),
+                    "percentile": float(item.get("percentile", 0)),
+                    "date": item.get("date", ""),
+                }
+        except (requests.RequestException, ValueError, KeyError):
+            # On failure, leave those CVEs without EPSS data
+            continue
+    return results
+
+
+def _fetch_kev_set() -> set[str]:
+    """Fetch the current CISA KEV catalog and return the set of CVE IDs."""
+    try:
+        resp = requests.get(_CISA_KEV_URL, timeout=_HTTP_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+        return {v["cveID"].upper() for v in data.get("vulnerabilities", [])}
+    except (requests.RequestException, ValueError, KeyError):
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Core operations
+# ---------------------------------------------------------------------------
+
+
+def watchlist_add(cve_ids: list[str], note: str | None = None) -> dict[str, Any]:
+    """Add one or more CVEs to the watchlist.
+
+    Args:
+        cve_ids: List of CVE identifiers to add.
+        note: Optional note/tag for these CVEs.
+
+    Returns:
+        Summary dict with added/invalid/duplicate lists.
+    """
+    wl = _load_watchlist()
+    added = []
+    invalid = []
+    duplicate = []
+
+    for raw_id in cve_ids:
+        normalised = _validate_cve_id(raw_id)
+        if normalised is None:
+            invalid.append(raw_id)
+            continue
+        if normalised in wl["cves"]:
+            duplicate.append(normalised)
+            continue
+        wl["cves"][normalised] = {
+            "added_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "note": note or "",
+            "last_epss": None,
+            "last_percentile": None,
+            "in_kev": None,
+        }
+        added.append(normalised)
+
+    if added:
+        _save_watchlist(wl)
+
+    return {"added": added, "invalid": invalid, "duplicate": duplicate, "total": len(wl["cves"])}
+
+
+def watchlist_remove(cve_ids: list[str]) -> dict[str, Any]:
+    """Remove one or more CVEs from the watchlist.
+
+    Args:
+        cve_ids: List of CVE identifiers to remove.
+
+    Returns:
+        Summary dict with removed/not_found lists.
+    """
+    wl = _load_watchlist()
+    removed = []
+    not_found = []
+
+    for raw_id in cve_ids:
+        normalised = _validate_cve_id(raw_id)
+        if normalised is None:
+            not_found.append(raw_id)
+            continue
+        if normalised in wl["cves"]:
+            del wl["cves"][normalised]
+            removed.append(normalised)
+        else:
+            not_found.append(raw_id)
+
+    if removed:
+        _save_watchlist(wl)
+
+    return {"removed": removed, "not_found": not_found, "total": len(wl["cves"])}
+
+
+def watchlist_list() -> dict[str, Any]:
+    """List all CVEs currently on the watchlist.
+
+    Returns:
+        Dict with cves list and metadata.
+    """
+    wl = _load_watchlist()
+    entries = []
+    for cve_id, info in sorted(wl["cves"].items()):
+        entries.append(
+            {
+                "cve_id": cve_id,
+                "added_at": info.get("added_at", ""),
+                "note": info.get("note", ""),
+                "last_epss": info.get("last_epss"),
+                "last_percentile": info.get("last_percentile"),
+                "in_kev": info.get("in_kev"),
+            }
+        )
+    return {
+        "entries": entries,
+        "total": len(entries),
+        "last_checked": wl.get("last_checked"),
+    }
+
+
+def watchlist_status() -> dict[str, Any]:
+    """Fetch live EPSS + KEV status for all watched CVEs.
+
+    Compares current EPSS scores against last-stored values and flags
+    significant changes (spike >= 0.05, drop >= 0.05).
+
+    Returns:
+        Dict with per-CVE status, changes detected, and summary stats.
+    """
+    wl = _load_watchlist()
+    cve_ids = list(wl["cves"].keys())
+
+    if not cve_ids:
+        return {"entries": [], "total": 0, "changes": [], "summary": {"kev_count": 0, "avg_epss": 0.0}}
+
+    # Fetch live data
+    epss_data = _fetch_epss_batch(cve_ids)
+    kev_set = _fetch_kev_set()
+
+    entries = []
+    changes = []
+    total_epss = 0.0
+    epss_count = 0
+    kev_count = 0
+
+    for cve_id in sorted(cve_ids):
+        info = wl["cves"][cve_id]
+        prev_epss = info.get("last_epss")
+        prev_kev = info.get("in_kev")
+
+        # Current values
+        current_epss_data = epss_data.get(cve_id, {})
+        current_epss = current_epss_data.get("epss")
+        current_percentile = current_epss_data.get("percentile")
+        current_kev = cve_id in kev_set
+
+        # Detect changes
+        epss_delta = None
+        if current_epss is not None and prev_epss is not None:
+            epss_delta = current_epss - prev_epss
+
+        if epss_delta is not None and abs(epss_delta) >= 0.05:
+            direction = "spike" if epss_delta > 0 else "drop"
+            changes.append(
+                {
+                    "cve_id": cve_id,
+                    "type": f"epss_{direction}",
+                    "previous": prev_epss,
+                    "current": current_epss,
+                    "delta": round(epss_delta, 4),
+                }
+            )
+
+        if prev_kev is not None and current_kev and not prev_kev:
+            changes.append(
+                {
+                    "cve_id": cve_id,
+                    "type": "kev_added",
+                    "previous": False,
+                    "current": True,
+                }
+            )
+
+        # Update stored state
+        if current_epss is not None:
+            info["last_epss"] = current_epss
+            info["last_percentile"] = current_percentile
+            total_epss += current_epss
+            epss_count += 1
+        info["in_kev"] = current_kev
+
+        if current_kev:
+            kev_count += 1
+
+        entries.append(
+            {
+                "cve_id": cve_id,
+                "epss": current_epss,
+                "percentile": current_percentile,
+                "epss_delta": round(epss_delta, 4) if epss_delta is not None else None,
+                "in_kev": current_kev,
+                "note": info.get("note", ""),
+                "added_at": info.get("added_at", ""),
+            }
+        )
+
+    # Persist updated state
+    wl["last_checked"] = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _save_watchlist(wl)
+
+    avg_epss = round(total_epss / epss_count, 4) if epss_count > 0 else 0.0
+
+    return {
+        "entries": entries,
+        "total": len(entries),
+        "changes": changes,
+        "summary": {
+            "kev_count": kev_count,
+            "avg_epss": avg_epss,
+            "checked_at": wl["last_checked"],
+        },
+    }
+
+
+def watchlist_clear() -> dict[str, Any]:
+    """Clear the entire watchlist.
+
+    Returns:
+        Summary with count of removed entries.
+    """
+    wl = _load_watchlist()
+    count = len(wl["cves"])
+    wl["cves"] = {}
+    wl["last_checked"] = None
+    _save_watchlist(wl)
+    return {"cleared": count}
+
+
+# ---------------------------------------------------------------------------
+# Unified dispatch (for CLI integration)
+# ---------------------------------------------------------------------------
+
+
+def watchlist_manage(
+    action: str,
+    cve_ids: list[str] | None = None,
+    note: str | None = None,
+) -> dict[str, Any]:
+    """Unified watchlist management function.
+
+    Args:
+        action: One of 'add', 'remove', 'list', 'status', 'clear'.
+        cve_ids: CVE IDs for add/remove actions.
+        note: Optional note for add action.
+
+    Returns:
+        Action-specific result dict.
+    """
+    if action == "add":
+        if not cve_ids:
+            return {"error": "No CVE IDs provided for 'add' action."}
+        return watchlist_add(cve_ids, note=note)
+    elif action == "remove":
+        if not cve_ids:
+            return {"error": "No CVE IDs provided for 'remove' action."}
+        return watchlist_remove(cve_ids)
+    elif action == "list":
+        return watchlist_list()
+    elif action == "status":
+        return watchlist_status()
+    elif action == "clear":
+        return watchlist_clear()
+    else:
+        return {"error": f"Unknown action: {action!r}. Valid: add, remove, list, status, clear."}

--- a/tests/test_cve_watchlist.py
+++ b/tests/test_cve_watchlist.py
@@ -1,0 +1,825 @@
+"""Comprehensive test suite for cve_watchlist module.
+
+Tests cover: validation, add/remove/list/status/clear operations,
+EPSS batch fetching, KEV lookup, change detection (spikes/drops/KEV adds),
+atomic file persistence, edge cases, and the unified dispatch function.
+
+All HTTP calls are fully mocked — no real network access.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_watchlist(tmp_path, monkeypatch):
+    """Redirect watchlist storage to a temp directory for each test."""
+    wl_path = tmp_path / "watchlist.json"
+    monkeypatch.setattr(
+        "manus_agent.tools.cve_watchlist._WATCHLIST_PATH",
+        wl_path,
+    )
+    return wl_path
+
+
+@pytest.fixture
+def wl_path(tmp_path):
+    return tmp_path / "watchlist.json"
+
+
+def _mock_response(payload, status_code=200, raise_exc=None):
+    """Create a mock requests response."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = payload
+    resp.raise_for_status = MagicMock()
+    if raise_exc:
+        resp.raise_for_status.side_effect = raise_exc
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# CVE ID Validation
+# ---------------------------------------------------------------------------
+
+
+class TestCveIdValidation:
+    def test_valid_standard_format(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("CVE-2024-3094") == "CVE-2024-3094"
+
+    def test_valid_lowercase(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("cve-2021-44228") == "CVE-2021-44228"
+
+    def test_valid_mixed_case(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("Cve-2025-12345") == "CVE-2025-12345"
+
+    def test_valid_with_whitespace(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("  CVE-2024-3094  ") == "CVE-2024-3094"
+
+    def test_valid_five_digit_id(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("CVE-2024-12345") == "CVE-2024-12345"
+
+    def test_invalid_empty(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("") is None
+
+    def test_invalid_no_prefix(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("2024-3094") is None
+
+    def test_invalid_short_number(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("CVE-2024-12") is None
+
+    def test_invalid_no_year(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("CVE--3094") is None
+
+    def test_invalid_random_string(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("hello-world") is None
+
+    def test_invalid_partial_format(self):
+        from manus_agent.tools.cve_watchlist import _validate_cve_id
+
+        assert _validate_cve_id("CVE-2024") is None
+
+
+# ---------------------------------------------------------------------------
+# Watchlist Add
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistAdd:
+    def test_add_single_cve(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add
+
+        result = watchlist_add(["CVE-2024-3094"])
+        assert result["added"] == ["CVE-2024-3094"]
+        assert result["invalid"] == []
+        assert result["duplicate"] == []
+        assert result["total"] == 1
+
+    def test_add_multiple_cves(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add
+
+        result = watchlist_add(["CVE-2024-3094", "CVE-2021-44228", "CVE-2023-1234"])
+        assert len(result["added"]) == 3
+        assert result["total"] == 3
+
+    def test_add_with_note(self):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_add
+
+        watchlist_add(["CVE-2024-3094"], note="Critical log4j-like")
+        wl = _load_watchlist()
+        assert wl["cves"]["CVE-2024-3094"]["note"] == "Critical log4j-like"
+
+    def test_add_duplicate_detected(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add
+
+        watchlist_add(["CVE-2024-3094"])
+        result = watchlist_add(["CVE-2024-3094"])
+        assert result["duplicate"] == ["CVE-2024-3094"]
+        assert result["added"] == []
+        assert result["total"] == 1
+
+    def test_add_invalid_detected(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add
+
+        result = watchlist_add(["not-a-cve", "CVE-2024-3094"])
+        assert result["invalid"] == ["not-a-cve"]
+        assert result["added"] == ["CVE-2024-3094"]
+
+    def test_add_mixed_valid_invalid_duplicate(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add
+
+        watchlist_add(["CVE-2024-3094"])
+        result = watchlist_add(["CVE-2024-3094", "CVE-2021-44228", "bad-id"])
+        assert result["added"] == ["CVE-2021-44228"]
+        assert result["duplicate"] == ["CVE-2024-3094"]
+        assert result["invalid"] == ["bad-id"]
+        assert result["total"] == 2
+
+    def test_add_persists_to_disk(self, tmp_path):
+        from manus_agent.tools.cve_watchlist import _WATCHLIST_PATH, watchlist_add
+
+        watchlist_add(["CVE-2024-3094"])
+        assert _WATCHLIST_PATH.exists()
+        data = json.loads(_WATCHLIST_PATH.read_text())
+        assert "CVE-2024-3094" in data["cves"]
+
+    def test_add_stores_timestamp(self):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_add
+
+        watchlist_add(["CVE-2024-3094"])
+        wl = _load_watchlist()
+        assert "added_at" in wl["cves"]["CVE-2024-3094"]
+        # Should be a valid ISO timestamp
+        assert wl["cves"]["CVE-2024-3094"]["added_at"].endswith("Z")
+
+
+# ---------------------------------------------------------------------------
+# Watchlist Remove
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistRemove:
+    def test_remove_existing(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_remove
+
+        watchlist_add(["CVE-2024-3094", "CVE-2021-44228"])
+        result = watchlist_remove(["CVE-2024-3094"])
+        assert result["removed"] == ["CVE-2024-3094"]
+        assert result["not_found"] == []
+        assert result["total"] == 1
+
+    def test_remove_nonexistent(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_remove
+
+        watchlist_add(["CVE-2024-3094"])
+        result = watchlist_remove(["CVE-9999-9999"])
+        assert result["not_found"] == ["CVE-9999-9999"]
+        assert result["removed"] == []
+        assert result["total"] == 1
+
+    def test_remove_invalid_id(self):
+        from manus_agent.tools.cve_watchlist import watchlist_remove
+
+        result = watchlist_remove(["not-valid"])
+        assert result["not_found"] == ["not-valid"]
+
+    def test_remove_multiple(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_remove
+
+        watchlist_add(["CVE-2024-3094", "CVE-2021-44228", "CVE-2023-1234"])
+        result = watchlist_remove(["CVE-2024-3094", "CVE-2021-44228"])
+        assert len(result["removed"]) == 2
+        assert result["total"] == 1
+
+    def test_remove_persists(self):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_add, watchlist_remove
+
+        watchlist_add(["CVE-2024-3094"])
+        watchlist_remove(["CVE-2024-3094"])
+        wl = _load_watchlist()
+        assert "CVE-2024-3094" not in wl["cves"]
+
+
+# ---------------------------------------------------------------------------
+# Watchlist List
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistList:
+    def test_list_empty(self):
+        from manus_agent.tools.cve_watchlist import watchlist_list
+
+        result = watchlist_list()
+        assert result["entries"] == []
+        assert result["total"] == 0
+
+    def test_list_with_entries(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_list
+
+        watchlist_add(["CVE-2024-3094", "CVE-2021-44228"], note="test")
+        result = watchlist_list()
+        assert result["total"] == 2
+        assert len(result["entries"]) == 2
+        # Should be sorted by CVE ID
+        assert result["entries"][0]["cve_id"] == "CVE-2021-44228"
+        assert result["entries"][1]["cve_id"] == "CVE-2024-3094"
+
+    def test_list_includes_metadata(self):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_list
+
+        watchlist_add(["CVE-2024-3094"], note="high priority")
+        result = watchlist_list()
+        entry = result["entries"][0]
+        assert entry["cve_id"] == "CVE-2024-3094"
+        assert entry["note"] == "high priority"
+        assert entry["added_at"] != ""
+        assert entry["last_epss"] is None  # Not checked yet
+        assert entry["in_kev"] is None
+
+
+# ---------------------------------------------------------------------------
+# Watchlist Status (with mocked HTTP)
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistStatus:
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_empty_watchlist(self, mock_get):
+        from manus_agent.tools.cve_watchlist import watchlist_status
+
+        result = watchlist_status()
+        assert result["entries"] == []
+        assert result["total"] == 0
+        mock_get.assert_not_called()
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_fetches_epss_and_kev(self, mock_get):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        # Mock EPSS response
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.9500", "percentile": "0.9900", "date": "2026-08-05"}]}
+        )
+        # Mock KEV response
+        kev_resp = _mock_response({"vulnerabilities": [{"cveID": "CVE-2024-3094"}, {"cveID": "CVE-2021-44228"}]})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert result["total"] == 1
+        entry = result["entries"][0]
+        assert entry["cve_id"] == "CVE-2024-3094"
+        assert entry["epss"] == 0.95
+        assert entry["percentile"] == 0.99
+        assert entry["in_kev"] is True
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_detects_epss_spike(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, _save_watchlist, watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        # Set previous EPSS to simulate a spike
+        wl = _load_watchlist()
+        wl["cves"]["CVE-2024-3094"]["last_epss"] = 0.10
+        wl["cves"]["CVE-2024-3094"]["last_percentile"] = 0.50
+        _save_watchlist(wl)
+
+        # Current EPSS is much higher
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.9500", "percentile": "0.9900", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert len(result["changes"]) == 1
+        change = result["changes"][0]
+        assert change["type"] == "epss_spike"
+        assert change["cve_id"] == "CVE-2024-3094"
+        assert change["delta"] == pytest.approx(0.85, abs=0.01)
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_detects_epss_drop(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, _save_watchlist, watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        wl = _load_watchlist()
+        wl["cves"]["CVE-2024-3094"]["last_epss"] = 0.80
+        wl["cves"]["CVE-2024-3094"]["last_percentile"] = 0.95
+        _save_watchlist(wl)
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.1000", "percentile": "0.5000", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert len(result["changes"]) == 1
+        change = result["changes"][0]
+        assert change["type"] == "epss_drop"
+        assert change["delta"] == pytest.approx(-0.70, abs=0.01)
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_detects_kev_addition(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, _save_watchlist, watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        # Previously not in KEV
+        wl = _load_watchlist()
+        wl["cves"]["CVE-2024-3094"]["in_kev"] = False
+        wl["cves"]["CVE-2024-3094"]["last_epss"] = 0.50
+        _save_watchlist(wl)
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5000", "percentile": "0.8000", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": [{"cveID": "CVE-2024-3094"}]})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert any(c["type"] == "kev_added" for c in result["changes"])
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_no_change_below_threshold(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, _save_watchlist, watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        wl = _load_watchlist()
+        wl["cves"]["CVE-2024-3094"]["last_epss"] = 0.50
+        wl["cves"]["CVE-2024-3094"]["in_kev"] = False
+        _save_watchlist(wl)
+
+        # Delta of 0.01 — below threshold
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5100", "percentile": "0.8100", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert result["changes"] == []
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_persists_updated_values(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.7500", "percentile": "0.9500", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": [{"cveID": "CVE-2024-3094"}]})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        watchlist_status()
+
+        wl = _load_watchlist()
+        assert wl["cves"]["CVE-2024-3094"]["last_epss"] == 0.75
+        assert wl["cves"]["CVE-2024-3094"]["last_percentile"] == 0.95
+        assert wl["cves"]["CVE-2024-3094"]["in_kev"] is True
+        assert wl["last_checked"] is not None
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_summary_stats(self, mock_get):
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094", "CVE-2021-44228"])
+
+        epss_resp = _mock_response(
+            {
+                "data": [
+                    {"cve": "CVE-2024-3094", "epss": "0.8000", "percentile": "0.95", "date": "2026-08-05"},
+                    {"cve": "CVE-2021-44228", "epss": "0.9700", "percentile": "0.99", "date": "2026-08-05"},
+                ]
+            }
+        )
+        kev_resp = _mock_response({"vulnerabilities": [{"cveID": "CVE-2021-44228"}]})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert result["summary"]["kev_count"] == 1
+        assert result["summary"]["avg_epss"] == pytest.approx(0.885, abs=0.001)
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_handles_epss_failure_gracefully(self, mock_get):
+        import requests as _requests
+
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        # EPSS fails
+        epss_resp = _mock_response({}, status_code=500, raise_exc=_requests.HTTPError("Server Error"))
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        assert result["total"] == 1
+        entry = result["entries"][0]
+        assert entry["epss"] is None  # No data available
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_status_handles_kev_failure_gracefully(self, mock_get):
+        import requests as _requests
+
+        from manus_agent.tools.cve_watchlist import watchlist_add, watchlist_status
+
+        watchlist_add(["CVE-2024-3094"])
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5000", "percentile": "0.8000", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({}, status_code=503, raise_exc=_requests.HTTPError("Unavailable"))
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_status()
+        entry = result["entries"][0]
+        assert entry["in_kev"] is False  # Empty set -> not in KEV
+
+
+# ---------------------------------------------------------------------------
+# Watchlist Clear
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistClear:
+    def test_clear_empty(self):
+        from manus_agent.tools.cve_watchlist import watchlist_clear
+
+        result = watchlist_clear()
+        assert result["cleared"] == 0
+
+    def test_clear_with_entries(self):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_add, watchlist_clear
+
+        watchlist_add(["CVE-2024-3094", "CVE-2021-44228"])
+        result = watchlist_clear()
+        assert result["cleared"] == 2
+        wl = _load_watchlist()
+        assert wl["cves"] == {}
+        assert wl["last_checked"] is None
+
+
+# ---------------------------------------------------------------------------
+# EPSS Batch Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestEpssBatchFetch:
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_single_batch(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _fetch_epss_batch
+
+        mock_get.return_value = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5", "percentile": "0.8", "date": "2026-08-05"}]}
+        )
+        result = _fetch_epss_batch(["CVE-2024-3094"])
+        assert "CVE-2024-3094" in result
+        assert result["CVE-2024-3094"]["epss"] == 0.5
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_multiple_batches(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _EPSS_BATCH_SIZE, _fetch_epss_batch
+
+        # Create more CVEs than batch size
+        cves = [f"CVE-2024-{i:04d}" for i in range(1000, 1000 + _EPSS_BATCH_SIZE + 5)]
+
+        batch1_data = [
+            {"cve": cve, "epss": "0.1", "percentile": "0.5", "date": "2026-08-05"} for cve in cves[:_EPSS_BATCH_SIZE]
+        ]
+        batch2_data = [
+            {"cve": cve, "epss": "0.2", "percentile": "0.6", "date": "2026-08-05"} for cve in cves[_EPSS_BATCH_SIZE:]
+        ]
+
+        mock_get.side_effect = [
+            _mock_response({"data": batch1_data}),
+            _mock_response({"data": batch2_data}),
+        ]
+
+        result = _fetch_epss_batch(cves)
+        assert len(result) == len(cves)
+        assert mock_get.call_count == 2
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_network_error_returns_partial(self, mock_get):
+        import requests as _requests
+
+        from manus_agent.tools.cve_watchlist import _fetch_epss_batch
+
+        mock_get.side_effect = _requests.ConnectionError("Network error")
+        result = _fetch_epss_batch(["CVE-2024-3094"])
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# KEV Fetch
+# ---------------------------------------------------------------------------
+
+
+class TestKevFetch:
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_successful_fetch(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _fetch_kev_set
+
+        mock_get.return_value = _mock_response(
+            {"vulnerabilities": [{"cveID": "CVE-2024-3094"}, {"cveID": "CVE-2021-44228"}]}
+        )
+        result = _fetch_kev_set()
+        assert result == {"CVE-2024-3094", "CVE-2021-44228"}
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_network_error_returns_empty(self, mock_get):
+        import requests as _requests
+
+        from manus_agent.tools.cve_watchlist import _fetch_kev_set
+
+        mock_get.side_effect = _requests.ConnectionError("Timeout")
+        result = _fetch_kev_set()
+        assert result == set()
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_malformed_json_returns_empty(self, mock_get):
+        from manus_agent.tools.cve_watchlist import _fetch_kev_set
+
+        mock_get.return_value = _mock_response({})  # Missing 'vulnerabilities'
+        result = _fetch_kev_set()
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# Persistence / Edge Cases
+# ---------------------------------------------------------------------------
+
+
+class TestPersistence:
+    def test_load_missing_file(self, tmp_path, monkeypatch):
+        from manus_agent.tools.cve_watchlist import _load_watchlist
+
+        monkeypatch.setattr(
+            "manus_agent.tools.cve_watchlist._WATCHLIST_PATH",
+            tmp_path / "nonexistent.json",
+        )
+        wl = _load_watchlist()
+        assert wl == {"cves": {}, "last_checked": None}
+
+    def test_load_corrupt_file(self, tmp_path, monkeypatch):
+        from manus_agent.tools.cve_watchlist import _load_watchlist
+
+        corrupt_path = tmp_path / "corrupt.json"
+        corrupt_path.write_text("not valid json {{{{")
+        monkeypatch.setattr(
+            "manus_agent.tools.cve_watchlist._WATCHLIST_PATH",
+            corrupt_path,
+        )
+        wl = _load_watchlist()
+        assert wl == {"cves": {}, "last_checked": None}
+
+    def test_load_missing_cves_key(self, tmp_path, monkeypatch):
+        from manus_agent.tools.cve_watchlist import _load_watchlist
+
+        partial_path = tmp_path / "partial.json"
+        partial_path.write_text(json.dumps({"last_checked": "2026-01-01"}))
+        monkeypatch.setattr(
+            "manus_agent.tools.cve_watchlist._WATCHLIST_PATH",
+            partial_path,
+        )
+        wl = _load_watchlist()
+        assert wl["cves"] == {}
+        assert wl["last_checked"] == "2026-01-01"
+
+    def test_save_creates_parent_dirs(self, tmp_path, monkeypatch):
+        from manus_agent.tools.cve_watchlist import _save_watchlist
+
+        deep_path = tmp_path / "a" / "b" / "c" / "watchlist.json"
+        monkeypatch.setattr(
+            "manus_agent.tools.cve_watchlist._WATCHLIST_PATH",
+            deep_path,
+        )
+        _save_watchlist({"cves": {}, "last_checked": None})
+        assert deep_path.exists()
+
+    def test_atomic_write_no_partial_on_interrupt(self, tmp_path, monkeypatch):
+        """Verify that .tmp file is used for atomic writes."""
+        from manus_agent.tools.cve_watchlist import _WATCHLIST_PATH, watchlist_add
+
+        watchlist_add(["CVE-2024-3094"])
+        # After successful write, no .tmp should remain
+        tmp_file = _WATCHLIST_PATH.with_suffix(".tmp")
+        assert not tmp_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# Unified Dispatch (watchlist_manage)
+# ---------------------------------------------------------------------------
+
+
+class TestWatchlistManage:
+    def test_dispatch_add(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        result = watchlist_manage("add", cve_ids=["CVE-2024-3094"])
+        assert result["added"] == ["CVE-2024-3094"]
+
+    def test_dispatch_remove(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        watchlist_manage("add", cve_ids=["CVE-2024-3094"])
+        result = watchlist_manage("remove", cve_ids=["CVE-2024-3094"])
+        assert result["removed"] == ["CVE-2024-3094"]
+
+    def test_dispatch_list(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        watchlist_manage("add", cve_ids=["CVE-2024-3094"])
+        result = watchlist_manage("list")
+        assert result["total"] == 1
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_dispatch_status(self, mock_get):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        watchlist_manage("add", cve_ids=["CVE-2024-3094"])
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5", "percentile": "0.8", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = watchlist_manage("status")
+        assert result["total"] == 1
+
+    def test_dispatch_clear(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        watchlist_manage("add", cve_ids=["CVE-2024-3094"])
+        result = watchlist_manage("clear")
+        assert result["cleared"] == 1
+
+    def test_dispatch_unknown_action(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        result = watchlist_manage("explode")
+        assert "error" in result
+
+    def test_dispatch_add_no_cves(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        result = watchlist_manage("add", cve_ids=None)
+        assert "error" in result
+
+    def test_dispatch_remove_no_cves(self):
+        from manus_agent.tools.cve_watchlist import watchlist_manage
+
+        result = watchlist_manage("remove", cve_ids=None)
+        assert "error" in result
+
+    def test_dispatch_add_with_note(self):
+        from manus_agent.tools.cve_watchlist import _load_watchlist, watchlist_manage
+
+        watchlist_manage("add", cve_ids=["CVE-2024-3094"], note="urgent")
+        wl = _load_watchlist()
+        assert wl["cves"]["CVE-2024-3094"]["note"] == "urgent"
+
+
+# ---------------------------------------------------------------------------
+# CLI Integration
+# ---------------------------------------------------------------------------
+
+
+class TestCLIWatchlist:
+    """Test the CLI _run_watchlist function indirectly via argument parsing."""
+
+    def test_cli_add_runs_without_crash(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        result = _run_watchlist(["add", "CVE-2024-3094", "CVE-2021-44228"])
+        assert result == 0
+
+    def test_cli_add_with_note(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        result = _run_watchlist(["add", "CVE-2024-3094", "--note", "critical"])
+        assert result == 0
+
+    def test_cli_remove(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+        result = _run_watchlist(["remove", "CVE-2024-3094"])
+        assert result == 0
+
+    def test_cli_list_empty(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        result = _run_watchlist(["list"])
+        assert result == 0
+
+    def test_cli_list_with_entries(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+        result = _run_watchlist(["list"])
+        assert result == 0
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_cli_status_text(self, mock_get, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5", "percentile": "0.8", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = _run_watchlist(["status"])
+        assert result == 0
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_cli_status_json(self, mock_get, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+        # Clear captured output from the add command
+        capsys.readouterr()
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.5", "percentile": "0.8", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": []})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = _run_watchlist(["status", "--output", "json"])
+        assert result == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert "entries" in data
+
+    def test_cli_clear(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+        result = _run_watchlist(["clear"])
+        assert result == 0
+
+    def test_cli_no_subaction_shows_help(self, capsys):
+        from manus_agent.cli import _run_watchlist
+
+        result = _run_watchlist([])
+        assert result == 1
+
+    @patch("manus_agent.tools.cve_watchlist.requests.get")
+    def test_cli_status_with_changes(self, mock_get, capsys):
+        from manus_agent.cli import _run_watchlist
+        from manus_agent.tools.cve_watchlist import _load_watchlist, _save_watchlist
+
+        _run_watchlist(["add", "CVE-2024-3094"])
+
+        # Set previous state for change detection
+        wl = _load_watchlist()
+        wl["cves"]["CVE-2024-3094"]["last_epss"] = 0.10
+        wl["cves"]["CVE-2024-3094"]["in_kev"] = False
+        _save_watchlist(wl)
+
+        epss_resp = _mock_response(
+            {"data": [{"cve": "CVE-2024-3094", "epss": "0.9500", "percentile": "0.99", "date": "2026-08-05"}]}
+        )
+        kev_resp = _mock_response({"vulnerabilities": [{"cveID": "CVE-2024-3094"}]})
+        mock_get.side_effect = [epss_resp, kev_resp]
+
+        result = _run_watchlist(["status"])
+        assert result == 0


### PR DESCRIPTION
## Summary

Adds a persistent **CVE watchlist** feature — a new `manus-agent watchlist` CLI subcommand that lets users maintain a local list of tracked CVEs and fetch bulk EPSS + CISA KEV status updates with change detection.

## Motivation

Security teams often monitor dozens of CVEs simultaneously. The existing CLI offers excellent single-CVE analysis tools (`analyze`, `epss-trend`, `poc-search`, etc.), but no way to:

1. Maintain a persistent list of CVEs being tracked
2. Get a bulk status dashboard showing EPSS scores + KEV membership for all tracked CVEs at once
3. Detect **changes since last check** — EPSS spikes, drops, or new KEV additions

This feature fills that gap with zero API keys required (EPSS and CISA KEV are both public).

## What's Included

### New tool module: `src/manus_agent/tools/cve_watchlist.py`
- `watchlist_add()` — add CVEs with optional notes/tags
- `watchlist_remove()` — remove CVEs from tracking
- `watchlist_list()` — show all tracked CVEs with last-known status
- `watchlist_status()` — fetch live EPSS + KEV, detect changes, persist updated state
- `watchlist_clear()` — reset the watchlist
- `watchlist_manage()` — unified dispatch for CLI integration
- Atomic file writes (temp + rename) for persistence safety
- Batch EPSS API requests (handles 100+ CVEs efficiently)
- Change detection: EPSS spike/drop (±0.05 threshold) and KEV addition alerts

### New CLI subcommand: `manus-agent watchlist`
```bash
manus-agent watchlist add CVE-2024-3094 CVE-2021-44228 --note "critical"
manus-agent watchlist list
manus-agent watchlist status              # Rich table with changes highlighted
manus-agent watchlist status --output json # Machine-readable output
manus-agent watchlist remove CVE-2024-3094
manus-agent watchlist clear
```

### Comprehensive test suite: `tests/test_cve_watchlist.py` (+69 tests)
- CVE ID validation (11 tests)
- Add operations (8 tests)
- Remove operations (5 tests)
- List operations (3 tests)
- Status with mocked HTTP (10 tests) — spike/drop/KEV detection, graceful failure
- Clear (2 tests)
- EPSS batch fetch (3 tests)
- KEV fetch (3 tests)
- Persistence/edge cases (5 tests)
- Unified dispatch (9 tests)
- CLI integration (10 tests)

All tests are 100% mocked — no real HTTP calls.

## Design Decisions

- **Local storage** (`~/.manus-agent/watchlist.json`) — no server/DB required
- **Zero API keys** — uses public FIRST.org EPSS API and CISA KEV JSON feed
- **Batch efficiency** — EPSS API supports comma-separated CVE lists (batched at 100)
- **Change tracking** — stores previous EPSS scores to detect movement over time
- **Atomic writes** — uses temp file + rename pattern to prevent corruption
- **Env-var override** — `MANUS_WATCHLIST_PATH` for testing and custom locations

## Open PRs Checked (no overlap)

Verified against all 50 open PRs (#129–#178). No existing open or merged PR implements:
- A watchlist/tracking feature
- Bulk CVE status checking
- Persistent CVE monitoring with change detection

The closest features are single-CVE tools (`epss-trend`, `compare`, `temporal-priority`) which analyze individual CVEs — this provides the multi-CVE tracking layer on top.

## Test Results

```
1227 passed, 3 deselected, 3 warnings in 25.76s
```
(baseline 1158 + 69 new tests, 0 failures)
