### PR TITLE
feat(tools): export_sarif — SARIF v2.1.0 vulnerability report exporter + CLI subcommand

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "export-sarif",
 }
 
 
@@ -2268,6 +2269,12 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "export-sarif":
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        idx = argv.index("export-sarif")
+        sys.exit(run_export_sarif_cli(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/export_sarif.py
+++ b/src/manus_agent/tools/export_sarif.py
@@ -1,0 +1,595 @@
+"""
+Tool: export_sarif
+
+Export vulnerability analysis results as SARIF (Static Analysis Results
+Interchange Format) v2.1.0 — the industry-standard JSON format for security
+tool output.
+
+SARIF output integrates directly with:
+  - GitHub Code Scanning (upload via ``gh api``)
+  - VS Code SARIF Viewer extension
+  - Azure DevOps Advanced Security
+  - Any SARIF-compatible security dashboard
+
+The tool accepts one or more CVE findings (as produced by the analysis pipeline)
+and renders a spec-compliant SARIF log with rule definitions, result locations,
+severity levels, and optional fix information.
+
+CLI: ``manus-agent export-sarif --input results.json --output report.sarif``
+     ``manus-agent analyze CVE-2024-3094 --format json | manus-agent export-sarif``
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+__all__ = ["export_sarif", "TOOL_SPEC", "findings_to_sarif"]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_SARIF_VERSION = "2.1.0"
+_SARIF_SCHEMA = "https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/schemas/sarif-schema-2.1.0.json"
+_TOOL_NAME = "manus-agent"
+_TOOL_INFO_URI = "https://github.com/manus-use/manus-agent"
+
+# Map CVSS severity strings to SARIF severity levels
+_SEVERITY_MAP: dict[str, str] = {
+    "CRITICAL": "error",
+    "HIGH": "error",
+    "MEDIUM": "warning",
+    "LOW": "note",
+    "NONE": "none",
+}
+
+# Map CVSS severity to SARIF security-severity scores (for GitHub Code Scanning)
+_SECURITY_SEVERITY_MAP: dict[str, str] = {
+    "CRITICAL": "9.0",
+    "HIGH": "7.0",
+    "MEDIUM": "4.0",
+    "LOW": "1.0",
+    "NONE": "0.0",
+}
+
+TOOL_SPEC = {
+    "name": "export_sarif",
+    "description": (
+        "Exports vulnerability findings as a SARIF v2.1.0 JSON document compatible with "
+        "GitHub Code Scanning, VS Code SARIF Viewer, and other security dashboards. "
+        "Accepts a list of CVE findings (each with cve_id, severity, description, and "
+        "optional affected_component/fix information) and produces a standards-compliant "
+        "SARIF log. Use this after running analysis tools to produce machine-readable output "
+        "that can be uploaded to GitHub or integrated into CI/CD pipelines."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "findings": {
+                    "type": "array",
+                    "description": (
+                        "List of vulnerability findings to export. Each finding should have: "
+                        "cve_id (required), severity (CRITICAL/HIGH/MEDIUM/LOW), "
+                        "description, affected_component, affected_versions, "
+                        "fix_version, cvss_score, epss_score, cwe_id, references (list of URLs)."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "cve_id": {
+                                "type": "string",
+                                "description": "CVE identifier (e.g. CVE-2024-3094).",
+                            },
+                            "severity": {
+                                "type": "string",
+                                "description": "Severity level: CRITICAL, HIGH, MEDIUM, LOW, or NONE.",
+                            },
+                            "description": {
+                                "type": "string",
+                                "description": "Human-readable description of the vulnerability.",
+                            },
+                            "affected_component": {
+                                "type": "string",
+                                "description": "Affected package/component name (e.g. 'xz-utils').",
+                            },
+                            "affected_versions": {
+                                "type": "string",
+                                "description": "Affected version range (e.g. '>=5.6.0, <5.6.2').",
+                            },
+                            "fix_version": {
+                                "type": "string",
+                                "description": "Version that fixes the vulnerability.",
+                            },
+                            "cvss_score": {
+                                "type": "number",
+                                "description": "CVSS v3.x base score (0.0-10.0).",
+                            },
+                            "epss_score": {
+                                "type": "number",
+                                "description": "EPSS exploitation probability (0.0-1.0).",
+                            },
+                            "cwe_id": {
+                                "type": "string",
+                                "description": "CWE weakness identifier (e.g. CWE-506).",
+                            },
+                            "references": {
+                                "type": "array",
+                                "items": {"type": "string"},
+                                "description": "List of reference URLs.",
+                            },
+                            "in_kev": {
+                                "type": "boolean",
+                                "description": "Whether the CVE is in CISA KEV catalog.",
+                            },
+                            "file_path": {
+                                "type": "string",
+                                "description": "Optional file path where the vulnerability was found (e.g. from SBOM or lockfile).",
+                            },
+                            "start_line": {
+                                "type": "integer",
+                                "description": "Optional start line in file_path.",
+                            },
+                            "end_line": {
+                                "type": "integer",
+                                "description": "Optional end line in file_path.",
+                            },
+                        },
+                        "required": ["cve_id"],
+                    },
+                },
+                "tool_version": {
+                    "type": "string",
+                    "description": "Version of manus-agent that produced the findings.",
+                },
+            },
+            "required": ["findings"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Core conversion logic
+# ---------------------------------------------------------------------------
+
+
+def _normalise_severity(severity: str | None) -> str:
+    """Normalise a severity string to uppercase; default to MEDIUM if unknown."""
+    if not severity:
+        return "MEDIUM"
+    s = severity.strip().upper()
+    if s in _SEVERITY_MAP:
+        return s
+    return "MEDIUM"
+
+
+def _make_rule(finding: dict[str, Any]) -> dict[str, Any]:
+    """Build a SARIF reportingDescriptor (rule) from a finding."""
+    cve_id = finding["cve_id"].upper()
+    severity = _normalise_severity(finding.get("severity"))
+    description = finding.get("description", f"Vulnerability {cve_id}")
+    cwe_id = finding.get("cwe_id", "")
+
+    rule: dict[str, Any] = {
+        "id": cve_id,
+        "name": cve_id.replace("-", "_"),
+        "shortDescription": {"text": f"{cve_id} ({severity})"},
+        "fullDescription": {"text": description[:1000] if description else f"Vulnerability {cve_id}"},
+        "helpUri": f"https://nvd.nist.gov/vuln/detail/{cve_id}",
+        "properties": {
+            "security-severity": _SECURITY_SEVERITY_MAP.get(severity, "4.0"),
+            "tags": ["security", "vulnerability"],
+        },
+    }
+
+    # Add CVSS score as property
+    cvss_score = finding.get("cvss_score")
+    if cvss_score is not None:
+        rule["properties"]["security-severity"] = str(float(cvss_score))
+        rule["properties"]["cvss-score"] = float(cvss_score)
+
+    # Add EPSS score as property
+    epss_score = finding.get("epss_score")
+    if epss_score is not None:
+        rule["properties"]["epss-score"] = float(epss_score)
+
+    # Add CWE tag
+    if cwe_id:
+        cwe_tag = cwe_id.upper() if cwe_id.upper().startswith("CWE-") else f"CWE-{cwe_id}"
+        rule["properties"]["tags"].append(cwe_tag)
+
+    # Add KEV tag
+    if finding.get("in_kev"):
+        rule["properties"]["tags"].append("cisa-kev")
+
+    # Help text with remediation info
+    help_lines = [f"**{cve_id}** — {severity} severity"]
+    if finding.get("affected_component"):
+        help_lines.append(f"Affected: {finding['affected_component']}")
+    if finding.get("affected_versions"):
+        help_lines.append(f"Versions: {finding['affected_versions']}")
+    if finding.get("fix_version"):
+        help_lines.append(f"Fix: upgrade to {finding['fix_version']}")
+    if finding.get("references"):
+        help_lines.append("References:")
+        for ref in finding["references"][:5]:
+            help_lines.append(f"  - {ref}")
+
+    rule["help"] = {"text": "\n".join(help_lines), "markdown": "\n".join(help_lines)}
+
+    return rule
+
+
+def _make_result(finding: dict[str, Any], rule_index: int) -> dict[str, Any]:
+    """Build a SARIF result object from a finding."""
+    cve_id = finding["cve_id"].upper()
+    severity = _normalise_severity(finding.get("severity"))
+    sarif_level = _SEVERITY_MAP.get(severity, "warning")
+
+    # Build message
+    msg_parts = [cve_id]
+    if finding.get("affected_component"):
+        msg_parts.append(f"in {finding['affected_component']}")
+    if finding.get("affected_versions"):
+        msg_parts.append(f"(versions {finding['affected_versions']})")
+    if finding.get("in_kev"):
+        msg_parts.append("⚠️  ACTIVELY EXPLOITED (CISA KEV)")
+
+    message_text = " ".join(msg_parts)
+    if finding.get("description"):
+        message_text += f": {finding['description'][:500]}"
+
+    result: dict[str, Any] = {
+        "ruleId": cve_id,
+        "ruleIndex": rule_index,
+        "level": sarif_level,
+        "message": {"text": message_text},
+    }
+
+    # Add location if file_path is provided
+    file_path = finding.get("file_path")
+    if file_path:
+        location: dict[str, Any] = {
+            "physicalLocation": {
+                "artifactLocation": {
+                    "uri": file_path,
+                    "uriBaseId": "%SRCROOT%",
+                },
+            }
+        }
+        start_line = finding.get("start_line")
+        end_line = finding.get("end_line")
+        if start_line:
+            region: dict[str, Any] = {"startLine": int(start_line)}
+            if end_line:
+                region["endLine"] = int(end_line)
+            location["physicalLocation"]["region"] = region
+        result["locations"] = [location]
+    else:
+        # Use logical location (component-based) when no file path
+        if finding.get("affected_component"):
+            result["locations"] = [
+                {
+                    "logicalLocations": [
+                        {
+                            "name": finding["affected_component"],
+                            "kind": "module",
+                        }
+                    ]
+                }
+            ]
+
+    # Add fix information
+    fix_version = finding.get("fix_version")
+    if fix_version:
+        component = finding.get("affected_component", "the affected component")
+        result["fixes"] = [
+            {
+                "description": {
+                    "text": f"Upgrade {component} to version {fix_version}",
+                },
+            }
+        ]
+
+    # Add related locations (references as related)
+    references = finding.get("references", [])
+    if references:
+        result["relatedLocations"] = [
+            {
+                "id": i,
+                "message": {"text": ref},
+                "physicalLocation": {
+                    "artifactLocation": {"uri": ref},
+                },
+            }
+            for i, ref in enumerate(references[:10])
+        ]
+
+    return result
+
+
+def findings_to_sarif(
+    findings: list[dict[str, Any]],
+    *,
+    tool_version: str | None = None,
+) -> dict[str, Any]:
+    """Convert a list of vulnerability findings into a SARIF v2.1.0 log.
+
+    Parameters
+    ----------
+    findings:
+        List of finding dicts. Each must have at least ``cve_id``.
+    tool_version:
+        Version string for the manus-agent tool driver entry.
+
+    Returns
+    -------
+    dict
+        A complete SARIF log object ready for JSON serialization.
+    """
+    if not findings:
+        findings = []
+
+    # Deduplicate by CVE ID (keep first occurrence)
+    seen_cves: set[str] = set()
+    unique_findings: list[dict[str, Any]] = []
+    for f in findings:
+        cve_id = f.get("cve_id", "").upper()
+        if not cve_id:
+            continue
+        if cve_id not in seen_cves:
+            seen_cves.add(cve_id)
+            unique_findings.append(f)
+
+    # Build rules and results
+    rules: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+
+    for i, finding in enumerate(unique_findings):
+        rules.append(_make_rule(finding))
+        results.append(_make_result(finding, rule_index=i))
+
+    # Assemble the SARIF log
+    version_str = tool_version or _get_package_version()
+
+    sarif_log: dict[str, Any] = {
+        "$schema": _SARIF_SCHEMA,
+        "version": _SARIF_VERSION,
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "name": _TOOL_NAME,
+                        "informationUri": _TOOL_INFO_URI,
+                        "version": version_str,
+                        "rules": rules,
+                    }
+                },
+                "results": results,
+                "invocations": [
+                    {
+                        "executionSuccessful": True,
+                        "endTimeUtc": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    }
+                ],
+            }
+        ],
+    }
+
+    return sarif_log
+
+
+def _get_package_version() -> str:
+    """Get the manus-agent package version, falling back to 'unknown'."""
+    try:
+        from importlib.metadata import version
+
+        return version("manus-agent")
+    except Exception:
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
+def export_sarif(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Export vulnerability findings as SARIF v2.1.0 JSON."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool["input"]
+
+    findings = tool_input.get("findings", [])
+    tool_version = tool_input.get("tool_version")
+
+    if not isinstance(findings, list):
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "'findings' must be a list of vulnerability finding objects."}],
+        }
+        log_tool_output_size("export_sarif", result)
+        return result
+
+    # Validate that each finding has at least cve_id
+    for i, finding in enumerate(findings):
+        if not isinstance(finding, dict):
+            result = {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Finding at index {i} must be an object, got {type(finding).__name__}."}],
+            }
+            log_tool_output_size("export_sarif", result)
+            return result
+        if not finding.get("cve_id"):
+            result = {
+                "toolUseId": tool_use_id,
+                "status": "error",
+                "content": [{"text": f"Finding at index {i} is missing required field 'cve_id'."}],
+            }
+            log_tool_output_size("export_sarif", result)
+            return result
+
+    try:
+        sarif_log = findings_to_sarif(findings, tool_version=tool_version)
+    except Exception as exc:
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Failed to generate SARIF output: {exc}"}],
+        }
+        log_tool_output_size("export_sarif", result)
+        return result
+
+    n_results = len(sarif_log.get("runs", [{}])[0].get("results", []))
+    summary = f"SARIF v{_SARIF_VERSION} log generated: {n_results} finding(s) exported."
+
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [
+            {"text": summary},
+            {"json": sarif_log},
+        ],
+    }
+    log_tool_output_size("export_sarif", result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CLI helper (called from cli.py)
+# ---------------------------------------------------------------------------
+
+
+def run_export_sarif_cli(argv: list[str]) -> int:
+    """CLI entry point for ``manus-agent export-sarif``.
+
+    Reads findings from --input (JSON file) or stdin, writes SARIF to
+    --output (file) or stdout.
+
+    Returns 0 on success, non-zero on failure.
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        prog="manus-agent export-sarif",
+        description=(
+            "Export vulnerability findings as SARIF v2.1.0 JSON.\n\n"
+            "Reads a JSON array of findings from --input or stdin and writes\n"
+            "a SARIF-compliant log to --output or stdout."
+        ),
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        metavar="FILE",
+        help="Input JSON file containing findings array (default: stdin)",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        metavar="FILE",
+        help="Output file for SARIF JSON (default: stdout)",
+    )
+    parser.add_argument(
+        "--pretty",
+        action="store_true",
+        default=True,
+        help="Pretty-print the SARIF output (default: true)",
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="Compact (single-line) JSON output",
+    )
+    parser.add_argument(
+        "--tool-version",
+        metavar="VER",
+        help="Override the tool version in SARIF output",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Read input
+    try:
+        if args.input:
+            with open(args.input, encoding="utf-8") as fh:
+                raw = fh.read()
+        else:
+            if sys.stdin.isatty():
+                print(
+                    "Error: No input provided. Pipe JSON findings or use --input FILE.",
+                    file=sys.stderr,
+                )
+                return 1
+            raw = sys.stdin.read()
+    except OSError as exc:
+        print(f"Error reading input: {exc}", file=sys.stderr)
+        return 1
+
+    # Parse input JSON
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"Error: Invalid JSON input: {exc}", file=sys.stderr)
+        return 1
+
+    # Accept either a bare array or an object with a "findings" key
+    if isinstance(data, list):
+        findings = data
+    elif isinstance(data, dict):
+        findings = data.get("findings", data.get("results", []))
+        if not isinstance(findings, list):
+            print("Error: Could not find a findings array in the input.", file=sys.stderr)
+            return 1
+    else:
+        print("Error: Input must be a JSON array or object with a 'findings' key.", file=sys.stderr)
+        return 1
+
+    # Validate findings
+    for i, f in enumerate(findings):
+        if not isinstance(f, dict) or not f.get("cve_id"):
+            print(
+                f"Error: Finding at index {i} is invalid (must be an object with 'cve_id').",
+                file=sys.stderr,
+            )
+            return 1
+
+    # Generate SARIF
+    try:
+        sarif_log = findings_to_sarif(findings, tool_version=args.tool_version)
+    except Exception as exc:
+        print(f"Error generating SARIF: {exc}", file=sys.stderr)
+        return 1
+
+    # Format output
+    indent = None if args.compact else 2
+    sarif_json = json.dumps(sarif_log, indent=indent, ensure_ascii=False)
+
+    # Write output
+    try:
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as fh:
+                fh.write(sarif_json)
+                fh.write("\n")
+            n_results = len(sarif_log["runs"][0]["results"])
+            print(
+                f"✓ SARIF written to {args.output} ({n_results} finding(s))",
+                file=sys.stderr,
+            )
+        else:
+            sys.stdout.write(sarif_json)
+            sys.stdout.write("\n")
+    except OSError as exc:
+        print(f"Error writing output: {exc}", file=sys.stderr)
+        return 1
+
+    return 0

--- a/tests/test_export_sarif.py
+++ b/tests/test_export_sarif.py
@@ -1,0 +1,876 @@
+"""Comprehensive test suite for the export_sarif module.
+
+Tests cover:
+- TOOL_SPEC contract validation
+- Input validation (missing/invalid findings)
+- SARIF schema compliance (version, $schema, runs structure)
+- Rule generation (severity mapping, CVSS scores, CWE tags, KEV tags)
+- Result generation (levels, messages, locations, fixes)
+- Deduplication of CVE findings
+- CLI subcommand (stdin/file input, stdout/file output, error handling)
+- Edge cases (empty findings, minimal findings, large inputs)
+
+All tests are unit tests — no network calls, no filesystem side effects.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _minimal_finding(cve_id: str = "CVE-2024-3094", **kwargs: Any) -> dict[str, Any]:
+    """Create a minimal valid finding."""
+    finding: dict[str, Any] = {"cve_id": cve_id}
+    finding.update(kwargs)
+    return finding
+
+
+def _full_finding(**kwargs: Any) -> dict[str, Any]:
+    """Create a fully-populated finding."""
+    finding = {
+        "cve_id": "CVE-2024-3094",
+        "severity": "CRITICAL",
+        "description": "A backdoor was discovered in xz-utils versions 5.6.0 and 5.6.1.",
+        "affected_component": "xz-utils",
+        "affected_versions": ">=5.6.0, <5.6.2",
+        "fix_version": "5.6.2",
+        "cvss_score": 10.0,
+        "epss_score": 0.97,
+        "cwe_id": "CWE-506",
+        "in_kev": True,
+        "references": [
+            "https://nvd.nist.gov/vuln/detail/CVE-2024-3094",
+            "https://www.openwall.com/lists/oss-security/2024/03/29/4",
+        ],
+        "file_path": "requirements.txt",
+        "start_line": 12,
+        "end_line": 12,
+    }
+    finding.update(kwargs)
+    return finding
+
+
+def _make_tool_use(findings: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+    """Build a ToolUse dict for the export_sarif function."""
+    tool_input: dict[str, Any] = {"findings": findings}
+    tool_input.update(kwargs)
+    return {"toolUseId": "test-sarif-001", "input": tool_input}
+
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC contract
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    def test_module_imports(self):
+        import manus_agent.tools.export_sarif as m
+
+        assert hasattr(m, "export_sarif")
+        assert hasattr(m, "TOOL_SPEC")
+        assert hasattr(m, "findings_to_sarif")
+
+    def test_tool_spec_name(self):
+        from manus_agent.tools.export_sarif import TOOL_SPEC
+
+        assert TOOL_SPEC["name"] == "export_sarif"
+
+    def test_tool_spec_has_input_schema(self):
+        from manus_agent.tools.export_sarif import TOOL_SPEC
+
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["type"] == "object"
+        assert "findings" in schema["properties"]
+        assert "findings" in schema["required"]
+
+    def test_tool_spec_findings_is_array(self):
+        from manus_agent.tools.export_sarif import TOOL_SPEC
+
+        findings_schema = TOOL_SPEC["inputSchema"]["json"]["properties"]["findings"]
+        assert findings_schema["type"] == "array"
+        assert "items" in findings_schema
+
+    def test_tool_spec_finding_requires_cve_id(self):
+        from manus_agent.tools.export_sarif import TOOL_SPEC
+
+        items_schema = TOOL_SPEC["inputSchema"]["json"]["properties"]["findings"]["items"]
+        assert "cve_id" in items_schema["properties"]
+        assert "cve_id" in items_schema["required"]
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    def test_findings_not_a_list_returns_error(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = {"toolUseId": "t1", "input": {"findings": "not-a-list"}}
+        result = export_sarif(tool)
+        assert result["status"] == "error"
+        assert "must be a list" in result["content"][0]["text"]
+
+    def test_finding_not_a_dict_returns_error(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = {"toolUseId": "t1", "input": {"findings": ["not-a-dict"]}}
+        result = export_sarif(tool)
+        assert result["status"] == "error"
+        assert "index 0 must be an object" in result["content"][0]["text"]
+
+    def test_finding_missing_cve_id_returns_error(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = {"toolUseId": "t1", "input": {"findings": [{"severity": "HIGH"}]}}
+        result = export_sarif(tool)
+        assert result["status"] == "error"
+        assert "missing required field 'cve_id'" in result["content"][0]["text"]
+
+    def test_empty_findings_list_succeeds(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([])
+        result = export_sarif(tool)
+        assert result["status"] == "success"
+
+    def test_minimal_finding_succeeds(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([_minimal_finding()])
+        result = export_sarif(tool)
+        assert result["status"] == "success"
+
+
+# ---------------------------------------------------------------------------
+# SARIF schema compliance
+# ---------------------------------------------------------------------------
+
+
+class TestSarifSchema:
+    def test_sarif_version(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        assert sarif["version"] == "2.1.0"
+
+    def test_sarif_schema_uri(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        assert "$schema" in sarif
+        assert "sarif-schema-2.1.0" in sarif["$schema"]
+
+    def test_sarif_has_runs_array(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        assert "runs" in sarif
+        assert isinstance(sarif["runs"], list)
+        assert len(sarif["runs"]) == 1
+
+    def test_run_has_tool_driver(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        run = sarif["runs"][0]
+        assert "tool" in run
+        assert "driver" in run["tool"]
+        assert run["tool"]["driver"]["name"] == "manus-agent"
+
+    def test_run_has_results(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        run = sarif["runs"][0]
+        assert "results" in run
+        assert isinstance(run["results"], list)
+
+    def test_run_has_invocations(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        run = sarif["runs"][0]
+        assert "invocations" in run
+        assert run["invocations"][0]["executionSuccessful"] is True
+        assert "endTimeUtc" in run["invocations"][0]
+
+    def test_tool_version_custom(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()], tool_version="1.2.3")
+        assert sarif["runs"][0]["tool"]["driver"]["version"] == "1.2.3"
+
+    def test_tool_version_defaults_to_package(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        version = sarif["runs"][0]["tool"]["driver"]["version"]
+        assert isinstance(version, str)
+        assert len(version) > 0
+
+    def test_driver_information_uri(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        driver = sarif["runs"][0]["tool"]["driver"]
+        assert driver["informationUri"] == "https://github.com/manus-use/manus-agent"
+
+    def test_sarif_is_valid_json(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_full_finding()])
+        # Should serialize without errors
+        json_str = json.dumps(sarif)
+        parsed = json.loads(json_str)
+        assert parsed["version"] == "2.1.0"
+
+
+# ---------------------------------------------------------------------------
+# Rule generation
+# ---------------------------------------------------------------------------
+
+
+class TestRuleGeneration:
+    def test_rule_id_is_cve_id(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2024-3094")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["id"] == "CVE-2024-3094"
+
+    def test_rule_name_replaces_hyphens(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2024-3094")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["name"] == "CVE_2024_3094"
+
+    def test_rule_help_uri(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2024-3094")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["helpUri"] == "https://nvd.nist.gov/vuln/detail/CVE-2024-3094"
+
+    def test_rule_severity_mapping_critical(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="CRITICAL")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "9.0"
+
+    def test_rule_severity_mapping_high(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="HIGH")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "7.0"
+
+    def test_rule_severity_mapping_medium(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="MEDIUM")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "4.0"
+
+    def test_rule_severity_mapping_low(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="LOW")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "1.0"
+
+    def test_rule_severity_unknown_defaults_medium(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="BOGUS")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "4.0"
+
+    def test_rule_cvss_score_overrides_severity_map(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="HIGH", cvss_score=8.5)])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["security-severity"] == "8.5"
+        assert rules[0]["properties"]["cvss-score"] == 8.5
+
+    def test_rule_epss_score_in_properties(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(epss_score=0.42)])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["properties"]["epss-score"] == 0.42
+
+    def test_rule_cwe_tag(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(cwe_id="CWE-79")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert "CWE-79" in rules[0]["properties"]["tags"]
+
+    def test_rule_kev_tag(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(in_kev=True)])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert "cisa-kev" in rules[0]["properties"]["tags"]
+
+    def test_rule_no_kev_tag_when_false(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(in_kev=False)])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert "cisa-kev" not in rules[0]["properties"]["tags"]
+
+    def test_rule_has_security_tag(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert "security" in rules[0]["properties"]["tags"]
+        assert "vulnerability" in rules[0]["properties"]["tags"]
+
+    def test_rule_help_contains_fix_info(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(affected_component="xz-utils", fix_version="5.6.2")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        help_text = rules[0]["help"]["text"]
+        assert "xz-utils" in help_text
+        assert "5.6.2" in help_text
+
+    def test_rule_description_truncation(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        long_desc = "A" * 2000
+        sarif = findings_to_sarif([_minimal_finding(description=long_desc)])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert len(rules[0]["fullDescription"]["text"]) <= 1000
+
+
+# ---------------------------------------------------------------------------
+# Result generation
+# ---------------------------------------------------------------------------
+
+
+class TestResultGeneration:
+    def test_result_rule_id(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2021-44228")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["ruleId"] == "CVE-2021-44228"
+
+    def test_result_rule_index(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2021-44228"), _minimal_finding("CVE-2024-3094")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["ruleIndex"] == 0
+        assert results[1]["ruleIndex"] == 1
+
+    def test_result_level_error_for_critical(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="CRITICAL")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "error"
+
+    def test_result_level_error_for_high(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="HIGH")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "error"
+
+    def test_result_level_warning_for_medium(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="MEDIUM")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "warning"
+
+    def test_result_level_note_for_low(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="LOW")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "note"
+
+    def test_result_message_contains_cve_id(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("CVE-2024-3094")])
+        results = sarif["runs"][0]["results"]
+        assert "CVE-2024-3094" in results[0]["message"]["text"]
+
+    def test_result_message_contains_component(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(affected_component="openssl")])
+        results = sarif["runs"][0]["results"]
+        assert "openssl" in results[0]["message"]["text"]
+
+    def test_result_message_contains_kev_warning(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(in_kev=True)])
+        results = sarif["runs"][0]["results"]
+        assert "ACTIVELY EXPLOITED" in results[0]["message"]["text"]
+
+    def test_result_physical_location_with_file(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(file_path="package.json", start_line=5)])
+        results = sarif["runs"][0]["results"]
+        loc = results[0]["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "package.json"
+        assert loc["region"]["startLine"] == 5
+
+    def test_result_physical_location_with_end_line(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(file_path="go.mod", start_line=10, end_line=12)])
+        results = sarif["runs"][0]["results"]
+        region = results[0]["locations"][0]["physicalLocation"]["region"]
+        assert region["startLine"] == 10
+        assert region["endLine"] == 12
+
+    def test_result_logical_location_without_file(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(affected_component="lodash")])
+        results = sarif["runs"][0]["results"]
+        logical_locs = results[0]["locations"][0]["logicalLocations"]
+        assert logical_locs[0]["name"] == "lodash"
+        assert logical_locs[0]["kind"] == "module"
+
+    def test_result_fix_information(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(affected_component="numpy", fix_version="1.26.0")])
+        results = sarif["runs"][0]["results"]
+        fixes = results[0]["fixes"]
+        assert len(fixes) == 1
+        assert "1.26.0" in fixes[0]["description"]["text"]
+        assert "numpy" in fixes[0]["description"]["text"]
+
+    def test_result_no_fix_when_no_fix_version(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        results = sarif["runs"][0]["results"]
+        assert "fixes" not in results[0]
+
+    def test_result_related_locations_from_references(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        refs = ["https://example.com/advisory", "https://github.com/fix"]
+        sarif = findings_to_sarif([_minimal_finding(references=refs)])
+        results = sarif["runs"][0]["results"]
+        related = results[0]["relatedLocations"]
+        assert len(related) == 2
+        assert related[0]["message"]["text"] == refs[0]
+
+    def test_result_references_capped_at_10(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        refs = [f"https://example.com/{i}" for i in range(20)]
+        sarif = findings_to_sarif([_minimal_finding(references=refs)])
+        results = sarif["runs"][0]["results"]
+        assert len(results[0]["relatedLocations"]) == 10
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestDeduplication:
+    def test_duplicate_cve_ids_deduplicated(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [
+            _minimal_finding("CVE-2024-3094", severity="HIGH"),
+            _minimal_finding("CVE-2024-3094", severity="CRITICAL"),
+        ]
+        sarif = findings_to_sarif(findings)
+        results = sarif["runs"][0]["results"]
+        assert len(results) == 1
+        # First occurrence wins
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert len(rules) == 1
+
+    def test_case_insensitive_deduplication(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [
+            _minimal_finding("cve-2024-3094"),
+            _minimal_finding("CVE-2024-3094"),
+        ]
+        sarif = findings_to_sarif(findings)
+        results = sarif["runs"][0]["results"]
+        assert len(results) == 1
+
+    def test_different_cves_not_deduplicated(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [
+            _minimal_finding("CVE-2024-3094"),
+            _minimal_finding("CVE-2021-44228"),
+        ]
+        sarif = findings_to_sarif(findings)
+        results = sarif["runs"][0]["results"]
+        assert len(results) == 2
+
+    def test_empty_cve_id_skipped(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [
+            {"cve_id": ""},
+            _minimal_finding("CVE-2024-3094"),
+        ]
+        sarif = findings_to_sarif(findings)
+        results = sarif["runs"][0]["results"]
+        assert len(results) == 1
+
+
+# ---------------------------------------------------------------------------
+# Tool function integration
+# ---------------------------------------------------------------------------
+
+
+class TestToolFunction:
+    def test_success_returns_text_and_json(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([_full_finding()])
+        result = export_sarif(tool)
+        assert result["status"] == "success"
+        content_types = [list(c.keys())[0] for c in result["content"]]
+        assert "text" in content_types
+        assert "json" in content_types
+
+    def test_success_text_mentions_count(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([_minimal_finding(), _minimal_finding("CVE-2021-44228")])
+        result = export_sarif(tool)
+        assert "2 finding(s)" in result["content"][0]["text"]
+
+    def test_success_json_is_valid_sarif(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([_full_finding()])
+        result = export_sarif(tool)
+        sarif_json = next(c["json"] for c in result["content"] if "json" in c)
+        assert sarif_json["version"] == "2.1.0"
+        assert len(sarif_json["runs"][0]["results"]) == 1
+
+    def test_tool_use_id_preserved(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = {"toolUseId": "custom-id-xyz", "input": {"findings": [_minimal_finding()]}}
+        result = export_sarif(tool)
+        assert result["toolUseId"] == "custom-id-xyz"
+
+    def test_custom_tool_version_passed(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([_minimal_finding()], tool_version="2.0.0-beta")
+        result = export_sarif(tool)
+        sarif_json = next(c["json"] for c in result["content"] if "json" in c)
+        assert sarif_json["runs"][0]["tool"]["driver"]["version"] == "2.0.0-beta"
+
+    def test_empty_findings_returns_zero_results(self):
+        from manus_agent.tools.export_sarif import export_sarif
+
+        tool = _make_tool_use([])
+        result = export_sarif(tool)
+        assert result["status"] == "success"
+        sarif_json = next(c["json"] for c in result["content"] if "json" in c)
+        assert len(sarif_json["runs"][0]["results"]) == 0
+        assert "0 finding(s)" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestCLI:
+    def test_subcommand_registered(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "export-sarif" in _SUBCOMMANDS
+
+    def test_cli_help_exits_zero(self):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        with pytest.raises(SystemExit) as exc_info:
+            run_export_sarif_cli(["--help"])
+        assert exc_info.value.code == 0
+
+    def test_cli_stdin_to_stdout(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps([{"cve_id": "CVE-2024-3094", "severity": "HIGH"}])
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        sarif = json.loads(out)
+        assert sarif["version"] == "2.1.0"
+        assert len(sarif["runs"][0]["results"]) == 1
+
+    def test_cli_input_file(self, tmp_path, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_file = tmp_path / "findings.json"
+        input_file.write_text(json.dumps([{"cve_id": "CVE-2021-44228", "severity": "CRITICAL"}]))
+
+        rc = run_export_sarif_cli(["--input", str(input_file)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        sarif = json.loads(out)
+        assert sarif["runs"][0]["results"][0]["ruleId"] == "CVE-2021-44228"
+
+    def test_cli_output_file(self, tmp_path, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps([{"cve_id": "CVE-2024-3094"}])
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        output_file = tmp_path / "report.sarif"
+        rc = run_export_sarif_cli(["--output", str(output_file)])
+        assert rc == 0
+        assert output_file.exists()
+        sarif = json.loads(output_file.read_text())
+        assert sarif["version"] == "2.1.0"
+        # Should print confirmation to stderr
+        err = capsys.readouterr().err
+        assert "SARIF written" in err
+
+    def test_cli_compact_output(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps([{"cve_id": "CVE-2024-3094"}])
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli(["--compact"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Compact output should be a single line
+        assert "\n" == out[-1]  # ends with newline
+        lines = out.strip().split("\n")
+        assert len(lines) == 1
+
+    def test_cli_custom_tool_version(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps([{"cve_id": "CVE-2024-3094"}])
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli(["--tool-version", "3.0.0"])
+        assert rc == 0
+        out = capsys.readouterr().out
+        sarif = json.loads(out)
+        assert sarif["runs"][0]["tool"]["driver"]["version"] == "3.0.0"
+
+    def test_cli_invalid_json_returns_error(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        monkeypatch.setattr("sys.stdin", StringIO("not json"))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Invalid JSON" in err
+
+    def test_cli_invalid_finding_returns_error(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps([{"no_cve_id": True}])
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "invalid" in err.lower()
+
+    def test_cli_accepts_object_with_findings_key(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps({"findings": [{"cve_id": "CVE-2024-3094"}]})
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        sarif = json.loads(out)
+        assert len(sarif["runs"][0]["results"]) == 1
+
+    def test_cli_accepts_object_with_results_key(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        input_data = json.dumps({"results": [{"cve_id": "CVE-2024-3094"}]})
+        monkeypatch.setattr("sys.stdin", StringIO(input_data))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 0
+        out = capsys.readouterr().out
+        sarif = json.loads(out)
+        assert len(sarif["runs"][0]["results"]) == 1
+
+    def test_cli_no_input_tty_returns_error(self, monkeypatch, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        monkeypatch.setattr("sys.stdin", StringIO(""))
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+
+        rc = run_export_sarif_cli([])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "No input" in err
+
+    def test_cli_nonexistent_input_file_returns_error(self, capsys):
+        from manus_agent.tools.export_sarif import run_export_sarif_cli
+
+        rc = run_export_sarif_cli(["--input", "/nonexistent/path/file.json"])
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "Error reading input" in err
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_full_finding_all_fields(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_full_finding()])
+        run = sarif["runs"][0]
+        rules = run["tool"]["driver"]["rules"]
+        results = run["results"]
+        assert len(rules) == 1
+        assert len(results) == 1
+        # Rule has all expected properties
+        assert rules[0]["properties"]["cvss-score"] == 10.0
+        assert rules[0]["properties"]["epss-score"] == 0.97
+        assert "CWE-506" in rules[0]["properties"]["tags"]
+        assert "cisa-kev" in rules[0]["properties"]["tags"]
+        # Result has location with region
+        loc = results[0]["locations"][0]["physicalLocation"]
+        assert loc["artifactLocation"]["uri"] == "requirements.txt"
+        assert loc["region"]["startLine"] == 12
+
+    def test_many_findings(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [_minimal_finding(f"CVE-2024-{i:04d}") for i in range(100)]
+        sarif = findings_to_sarif(findings)
+        assert len(sarif["runs"][0]["results"]) == 100
+        assert len(sarif["runs"][0]["tool"]["driver"]["rules"]) == 100
+
+    def test_cve_id_normalised_to_uppercase(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding("cve-2024-3094")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert rules[0]["id"] == "CVE-2024-3094"
+
+    def test_severity_case_insensitive(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(severity="critical")])
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "error"
+
+    def test_none_severity_defaults_medium(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])  # no severity
+        results = sarif["runs"][0]["results"]
+        assert results[0]["level"] == "warning"
+
+    def test_cwe_id_without_prefix_normalised(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(cwe_id="79")])
+        rules = sarif["runs"][0]["tool"]["driver"]["rules"]
+        assert "CWE-79" in rules[0]["properties"]["tags"]
+
+    def test_no_affected_component_no_logical_location(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding()])
+        results = sarif["runs"][0]["results"]
+        # Minimal finding has no component and no file_path, so no locations
+        assert "locations" not in results[0]
+
+    def test_description_in_message(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([_minimal_finding(description="A critical RCE vulnerability")])
+        results = sarif["runs"][0]["results"]
+        assert "A critical RCE vulnerability" in results[0]["message"]["text"]
+
+
+# ---------------------------------------------------------------------------
+# findings_to_sarif direct unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestFindingsToSarif:
+    def test_empty_list_returns_valid_sarif(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        sarif = findings_to_sarif([])
+        assert sarif["version"] == "2.1.0"
+        assert len(sarif["runs"][0]["results"]) == 0
+        assert len(sarif["runs"][0]["tool"]["driver"]["rules"]) == 0
+
+    def test_none_findings_handled(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        # The function accepts empty list; None should be handled gracefully
+        sarif = findings_to_sarif(None)  # type: ignore[arg-type]
+        assert sarif["version"] == "2.1.0"
+        assert len(sarif["runs"][0]["results"]) == 0
+
+    def test_multiple_findings_produce_indexed_rules(self):
+        from manus_agent.tools.export_sarif import findings_to_sarif
+
+        findings = [
+            _minimal_finding("CVE-2024-3094", severity="CRITICAL"),
+            _minimal_finding("CVE-2021-44228", severity="HIGH"),
+            _minimal_finding("CVE-2023-44487", severity="MEDIUM"),
+        ]
+        sarif = findings_to_sarif(findings)
+        results = sarif["runs"][0]["results"]
+        assert results[0]["ruleIndex"] == 0
+        assert results[1]["ruleIndex"] == 1
+        assert results[2]["ruleIndex"] == 2


### PR DESCRIPTION
## Summary

Add `export_sarif` — a tool and CLI subcommand that exports vulnerability findings as **SARIF v2.1.0** (Static Analysis Results Interchange Format) JSON, the industry standard for security tool output.

## What it does

Converts manus-agent vulnerability findings into spec-compliant SARIF that integrates directly with:
- **GitHub Code Scanning** (upload via `gh api`)
- **VS Code SARIF Viewer** extension
- **Azure DevOps Advanced Security**
- Any SARIF-compatible security dashboard or CI/CD pipeline

### CLI usage

```bash
# Pipe analysis results into SARIF export
manus-agent analyze CVE-2024-3094 --format json | manus-agent export-sarif -o report.sarif

# From a file of findings
manus-agent export-sarif --input findings.json --output report.sarif

# Compact output for CI
manus-agent export-sarif --input findings.json --compact
```

### Python API

```python
from manus_agent.tools.export_sarif import findings_to_sarif

findings = [
    {"cve_id": "CVE-2024-3094", "severity": "CRITICAL", "affected_component": "xz-utils",
     "fix_version": "5.6.2", "cvss_score": 10.0, "in_kev": True}
]
sarif_log = findings_to_sarif(findings)
```

## SARIF features

- **Rule definitions** with security-severity scores (maps CVSS → GitHub severity)
- **Result levels** mapped from CVSS severity (CRITICAL/HIGH → error, MEDIUM → warning, LOW → note)
- **Physical locations** when file paths are provided (e.g. from lockfile/SBOM scans)
- **Logical locations** for component-based findings (package names)
- **Fix information** with upgrade instructions
- **Related locations** from reference URLs
- **Properties**: CVSS score, EPSS score, CWE tags, CISA KEV membership
- **Deduplication** by CVE ID (case-insensitive)
- **Invocation metadata** with timestamps

## Test coverage

86 new tests covering:
- TOOL_SPEC contract (5 tests)
- Input validation (5 tests)
- SARIF schema compliance (10 tests)
- Rule generation (16 tests)
- Result generation (15 tests)
- Deduplication (4 tests)
- Tool function integration (6 tests)
- CLI subcommand (12 tests)
- Edge cases (8 tests)
- findings_to_sarif direct unit tests (3 tests)

All tests are 100% mocked — no real HTTP calls, no filesystem side effects beyond tmp_path.

**Test results:** 1244 passed (baseline 1158 + 86 new), 0 failures.

## Why this matters

The project produces excellent vulnerability intelligence but has no machine-readable export format compatible with the broader security tooling ecosystem. SARIF bridges that gap — users can now upload manus-agent results to GitHub Code Scanning, integrate with IDE security extensions, and feed findings into dashboards alongside results from other tools (Snyk, Trivy, CodeQL, etc.).

## Open PRs checked (no overlap)

Reviewed all 50 open PRs (#133–#182). None implement SARIF export or any standardised output format. Closest PRs are:
- #170 (cve-enrich) — multi-source data aggregation, not export formatting
- #133 (sbom-scan) — scans SBOMs for vulns, doesn't export SARIF
- #166 (classify-refs) — classifies NVD reference URLs, different purpose

No merged PR covers SARIF either (checked #39–#102).

## Files changed

- `src/manus_agent/tools/export_sarif.py` (new — tool + CLI helper)
- `src/manus_agent/cli.py` (add `export-sarif` to `_SUBCOMMANDS` + dispatch)
- `tests/test_export_sarif.py` (new — 86 tests)
