### PR TITLE
feat(tools): get_temporal_priority — 0-100 CVE urgency scorer + CLI subcommand

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "temporal-priority",
 }
 
 
@@ -1935,6 +1936,69 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# temporal-priority subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_temporal_priority_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent temporal-priority",
+        description=(
+            "Compute a 0–100 temporal priority (urgency) score for a CVE combining\n"
+            "CVSS base score, current EPSS, EPSS spike recency, CISA KEV membership,\n"
+            "patch availability, and CVE age."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2024-3094")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_temporal_priority(argv: list[str]) -> int:
+    import json as _json
+
+    parser = _build_temporal_priority_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.get_temporal_priority import (
+            compute_temporal_priority,
+            render_text,
+        )
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    import re as _re
+
+    if not _re.match(r"^CVE-\d{4}-\d{4,}$", cve_id, _re.IGNORECASE):
+        print(f"[error] Invalid CVE format: '{cve_id}'. Expected: CVE-YYYY-NNNNN", file=sys.stderr)
+        return 1
+
+    try:
+        result = compute_temporal_priority(cve_id)
+    except Exception as exc:
+        print(f"[error] Failed to compute temporal priority: {exc}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    print(render_text(result))
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2332,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "temporal-priority":
+        idx = argv.index("temporal-priority")
+        sys.exit(_run_temporal_priority(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_temporal_priority.py
+++ b/src/manus_agent/tools/get_temporal_priority.py
@@ -1,0 +1,605 @@
+"""
+Tool for computing a temporal priority score (0–100) for a CVE.
+
+Combines six signals into a single urgency score to answer:
+"Given everything I know today, how urgent is this CVE?"
+
+Signals and default weights:
+  1. CVSS base score (0–10 → 0–25 pts)        weight=25
+  2. Current EPSS probability (0–1 → 0–25 pts)  weight=25
+  3. EPSS spike recency (recent jump → bonus)    weight=15
+  4. CISA KEV membership (boolean → 0 or max)    weight=20
+  5. Patch availability (patched → reduce urgency) weight=10
+  6. CVE age decay (older → lower urgency)       weight=5
+
+All HTTP calls use retry/back-off.  Graceful degradation: if any data source
+is unavailable, remaining signals still produce a partial score.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import re
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC — Strands SDK module-based tool specification
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "get_temporal_priority",
+    "description": (
+        "Computes a 0–100 temporal priority (urgency) score for a given CVE by combining "
+        "CVSS base score, current EPSS probability, EPSS spike recency, CISA KEV membership, "
+        "patch availability, and CVE age. Higher scores mean more urgent. "
+        "Designed to answer: 'given everything I know today, how urgent is this CVE?'"
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier to score (e.g., 'CVE-2024-3094').",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Configuration (overridable via env vars)
+# ---------------------------------------------------------------------------
+
+_MAX_RETRIES = int(os.environ.get("TEMPORAL_PRIORITY_MAX_RETRIES", "3"))
+_RETRY_BASE_DELAY = float(os.environ.get("TEMPORAL_PRIORITY_RETRY_DELAY", "2.0"))
+_REQUEST_TIMEOUT = int(os.environ.get("TEMPORAL_PRIORITY_TIMEOUT", "20"))
+
+# Weight configuration
+_W_CVSS = int(os.environ.get("TEMPORAL_PRIORITY_W_CVSS", "25"))
+_W_EPSS = int(os.environ.get("TEMPORAL_PRIORITY_W_EPSS", "25"))
+_W_SPIKE = int(os.environ.get("TEMPORAL_PRIORITY_W_SPIKE", "15"))
+_W_KEV = int(os.environ.get("TEMPORAL_PRIORITY_W_KEV", "20"))
+_W_PATCH = int(os.environ.get("TEMPORAL_PRIORITY_W_PATCH", "10"))
+_W_AGE = int(os.environ.get("TEMPORAL_PRIORITY_W_AGE", "5"))
+
+# EPSS spike threshold (absolute jump in 30 days considered a spike)
+_SPIKE_THRESHOLD = float(os.environ.get("TEMPORAL_PRIORITY_SPIKE_THRESHOLD", "0.05"))
+
+# Age half-life in days: after this many days, the age component halves
+_AGE_HALF_LIFE_DAYS = float(os.environ.get("TEMPORAL_PRIORITY_AGE_HALF_LIFE", "180"))
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper with retry/back-off
+# ---------------------------------------------------------------------------
+
+
+def _http_get(url: str, params: dict | None = None, headers: dict | None = None) -> requests.Response:
+    """GET with retry + exponential back-off."""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=_REQUEST_TIMEOUT)
+            if resp.status_code == 429:
+                delay = _RETRY_BASE_DELAY * (2**attempt)
+                time.sleep(delay)
+                last_exc = requests.exceptions.HTTPError("429 Too Many Requests")
+                continue
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(_RETRY_BASE_DELAY * (2**attempt))
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Signal fetchers
+# ---------------------------------------------------------------------------
+
+
+def fetch_nvd_data(cve_id: str) -> dict[str, Any]:
+    """Fetch NVD vulnerability data. Returns dict with cvss_score, published_date, has_patch."""
+    url = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("NVD_API_KEY", "")
+    if api_key:
+        headers["apiKey"] = api_key
+
+    try:
+        resp = _http_get(url, params={"cveId": cve_id.upper()}, headers=headers or None)
+        data = resp.json()
+    except Exception:
+        return {"cvss_score": None, "published_date": None, "has_patch": None}
+
+    vulns = data.get("vulnerabilities", [])
+    if not vulns:
+        return {"cvss_score": None, "published_date": None, "has_patch": None}
+
+    cve_item = vulns[0].get("cve", {})
+
+    # Extract CVSS score (prefer v3.1, fallback to v3.0, then v2.0)
+    cvss_score = _extract_cvss(cve_item)
+
+    # Published date
+    published_date = cve_item.get("published")
+
+    # Patch availability: look for references with tag "Patch"
+    has_patch = _check_patch_refs(cve_item)
+
+    return {
+        "cvss_score": cvss_score,
+        "published_date": published_date,
+        "has_patch": has_patch,
+    }
+
+
+def _extract_cvss(cve_item: dict) -> float | None:
+    """Extract highest CVSS base score from NVD metrics."""
+    metrics = cve_item.get("metrics", {})
+
+    # Try CVSS 3.1
+    for m in metrics.get("cvssMetricV31", []):
+        score = m.get("cvssData", {}).get("baseScore")
+        if score is not None:
+            return float(score)
+
+    # Try CVSS 3.0
+    for m in metrics.get("cvssMetricV30", []):
+        score = m.get("cvssData", {}).get("baseScore")
+        if score is not None:
+            return float(score)
+
+    # Try CVSS 2.0
+    for m in metrics.get("cvssMetricV2", []):
+        score = m.get("cvssData", {}).get("baseScore")
+        if score is not None:
+            return float(score)
+
+    return None
+
+
+def _check_patch_refs(cve_item: dict) -> bool:
+    """Check if any NVD references have the 'Patch' tag."""
+    refs = cve_item.get("references", [])
+    for ref in refs:
+        tags = ref.get("tags", [])
+        if "Patch" in tags:
+            return True
+    return False
+
+
+def fetch_epss_data(cve_id: str) -> dict[str, Any]:
+    """Fetch current EPSS score and recent time-series for spike detection."""
+    url = "https://api.first.org/data/v1/epss"
+    try:
+        resp = _http_get(url, params={"cve": cve_id.upper(), "scope": "time-series", "limit": "30"})
+        data = resp.json()
+    except Exception:
+        return {"current_epss": None, "spike_detected": None, "max_jump": None}
+
+    entries = data.get("data", [])
+    if not entries:
+        return {"current_epss": None, "spike_detected": None, "max_jump": None}
+
+    entry = entries[0]
+    current_epss = _safe_float(entry.get("epss"))
+
+    # Analyse time-series for spike
+    series = entry.get("time-series", [])
+    spike_info = _analyse_spike(series)
+
+    return {
+        "current_epss": current_epss,
+        "spike_detected": spike_info["spike_detected"],
+        "max_jump": spike_info["max_jump"],
+        "days_since_spike": spike_info["days_since_spike"],
+    }
+
+
+def _analyse_spike(series: list[dict]) -> dict[str, Any]:
+    """Detect the largest recent spike in EPSS scores."""
+    if not series or len(series) < 2:
+        return {"spike_detected": False, "max_jump": 0.0, "days_since_spike": None}
+
+    # Sort by date oldest-first
+    sorted_pts = sorted(series, key=lambda p: p.get("date", ""))
+    scores = [_safe_float(p.get("epss", "0")) or 0.0 for p in sorted_pts]
+    dates = [p.get("date", "") for p in sorted_pts]
+
+    max_jump = 0.0
+    max_jump_idx = 0
+    for i in range(1, len(scores)):
+        jump = scores[i] - scores[i - 1]
+        if jump > max_jump:
+            max_jump = jump
+            max_jump_idx = i
+
+    spike_detected = max_jump >= _SPIKE_THRESHOLD
+
+    # Days since the spike
+    days_since_spike: int | None = None
+    if spike_detected and max_jump_idx < len(dates) and dates[max_jump_idx]:
+        try:
+            spike_date = datetime.strptime(dates[max_jump_idx], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            now = datetime.now(timezone.utc)
+            days_since_spike = (now - spike_date).days
+        except (ValueError, TypeError):
+            pass
+
+    return {
+        "spike_detected": spike_detected,
+        "max_jump": max_jump,
+        "days_since_spike": days_since_spike,
+    }
+
+
+def fetch_kev_status(cve_id: str) -> dict[str, Any]:
+    """Check CISA KEV catalog for the CVE."""
+    url = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    try:
+        resp = _http_get(url)
+        data = resp.json()
+    except Exception:
+        return {"in_kev": None, "date_added": None}
+
+    vulnerabilities = data.get("vulnerabilities", [])
+    cve_upper = cve_id.upper()
+    for vuln in vulnerabilities:
+        if vuln.get("cveID", "").upper() == cve_upper:
+            return {"in_kev": True, "date_added": vuln.get("dateAdded")}
+
+    return {"in_kev": False, "date_added": None}
+
+
+# ---------------------------------------------------------------------------
+# Score computation
+# ---------------------------------------------------------------------------
+
+
+def compute_score(
+    cvss_score: float | None,
+    current_epss: float | None,
+    spike_detected: bool | None,
+    days_since_spike: int | None,
+    in_kev: bool | None,
+    has_patch: bool | None,
+    published_date: str | None,
+) -> dict[str, Any]:
+    """
+    Compute the 0–100 temporal priority score from individual signals.
+
+    Returns a dict with the overall score, label, and per-signal breakdown.
+    """
+    breakdown: dict[str, Any] = {}
+    total = 0.0
+    max_possible = 0.0
+
+    # 1. CVSS component (0–25)
+    if cvss_score is not None:
+        # Linear scale: 0 maps to 0, 10 maps to _W_CVSS
+        cvss_pts = (cvss_score / 10.0) * _W_CVSS
+        breakdown["cvss"] = {"raw": cvss_score, "points": round(cvss_pts, 2), "max": _W_CVSS}
+        total += cvss_pts
+        max_possible += _W_CVSS
+    else:
+        breakdown["cvss"] = {"raw": None, "points": 0, "max": _W_CVSS, "note": "unavailable"}
+        max_possible += _W_CVSS
+
+    # 2. EPSS component (0–25)
+    if current_epss is not None:
+        # Non-linear: use sqrt to amplify mid-range values
+        # EPSS of 0.5 → sqrt(0.5) ≈ 0.71 → 17.7 pts
+        epss_pts = math.sqrt(min(current_epss, 1.0)) * _W_EPSS
+        breakdown["epss"] = {"raw": current_epss, "points": round(epss_pts, 2), "max": _W_EPSS}
+        total += epss_pts
+        max_possible += _W_EPSS
+    else:
+        breakdown["epss"] = {"raw": None, "points": 0, "max": _W_EPSS, "note": "unavailable"}
+        max_possible += _W_EPSS
+
+    # 3. EPSS spike recency (0–15)
+    if spike_detected is not None:
+        if spike_detected:
+            # Decay based on how long ago the spike was
+            if days_since_spike is not None and days_since_spike >= 0:
+                # Exponential decay: spike from today = full points, decays with half-life of 14 days
+                spike_decay = math.exp(-0.693 * days_since_spike / 14.0)
+                spike_pts = spike_decay * _W_SPIKE
+            else:
+                # Spike detected but unknown timing → give 75%
+                spike_pts = 0.75 * _W_SPIKE
+        else:
+            spike_pts = 0.0
+        breakdown["spike"] = {
+            "detected": spike_detected,
+            "days_since": days_since_spike,
+            "points": round(spike_pts, 2),
+            "max": _W_SPIKE,
+        }
+        total += spike_pts
+        max_possible += _W_SPIKE
+    else:
+        breakdown["spike"] = {"detected": None, "points": 0, "max": _W_SPIKE, "note": "unavailable"}
+        max_possible += _W_SPIKE
+
+    # 4. CISA KEV (0 or 20)
+    if in_kev is not None:
+        kev_pts = _W_KEV if in_kev else 0.0
+        breakdown["kev"] = {"in_kev": in_kev, "points": round(kev_pts, 2), "max": _W_KEV}
+        total += kev_pts
+        max_possible += _W_KEV
+    else:
+        breakdown["kev"] = {"in_kev": None, "points": 0, "max": _W_KEV, "note": "unavailable"}
+        max_possible += _W_KEV
+
+    # 5. Patch availability (reduces urgency when patched)
+    if has_patch is not None:
+        if has_patch:
+            # Patched → subtract up to _W_PATCH points (less urgent)
+            patch_pts = -_W_PATCH
+        else:
+            # No patch → full urgency bonus
+            patch_pts = _W_PATCH
+        breakdown["patch"] = {"has_patch": has_patch, "points": round(patch_pts, 2), "max": _W_PATCH}
+        total += patch_pts
+        max_possible += _W_PATCH
+    else:
+        breakdown["patch"] = {"has_patch": None, "points": 0, "max": _W_PATCH, "note": "unavailable"}
+        max_possible += _W_PATCH
+
+    # 6. CVE age (newer = more urgent, exponential decay)
+    age_days = _compute_age_days(published_date)
+    if age_days is not None:
+        # Exponential decay with configurable half-life
+        age_factor = math.exp(-0.693 * age_days / _AGE_HALF_LIFE_DAYS)
+        age_pts = age_factor * _W_AGE
+        breakdown["age"] = {
+            "days": age_days,
+            "points": round(age_pts, 2),
+            "max": _W_AGE,
+        }
+        total += age_pts
+        max_possible += _W_AGE
+    else:
+        breakdown["age"] = {"days": None, "points": 0, "max": _W_AGE, "note": "unavailable"}
+        max_possible += _W_AGE
+
+    # Normalize to 0–100
+    # max_possible includes patch as positive contribution
+    # Minimum possible contribution from patch is -_W_PATCH
+    # Theoretical range: [-_W_PATCH, sum_of_all_weights]
+    total_weights = _W_CVSS + _W_EPSS + _W_SPIKE + _W_KEV + _W_PATCH + _W_AGE
+    # Shift total so minimum is 0: add _W_PATCH
+    adjusted_total = total + _W_PATCH
+    adjusted_max = total_weights + _W_PATCH  # max range
+    score = (adjusted_total / adjusted_max) * 100.0 if adjusted_max > 0 else 0.0
+    score = max(0.0, min(100.0, score))
+
+    label = _urgency_label(score)
+
+    return {
+        "score": round(score, 1),
+        "label": label,
+        "breakdown": breakdown,
+        "signals_available": sum(
+            1 for v in breakdown.values() if isinstance(v, dict) and v.get("note") != "unavailable"
+        ),
+        "signals_total": len(breakdown),
+    }
+
+
+def _compute_age_days(published_date: str | None) -> int | None:
+    """Compute days since publication from an ISO date string."""
+    if not published_date:
+        return None
+    try:
+        # NVD uses ISO format: 2024-01-15T00:00:00.000
+        pub = datetime.fromisoformat(published_date.replace("Z", "+00:00"))
+        if pub.tzinfo is None:
+            pub = pub.replace(tzinfo=timezone.utc)
+        now = datetime.now(timezone.utc)
+        return max(0, (now - pub).days)
+    except (ValueError, TypeError):
+        return None
+
+
+def _urgency_label(score: float) -> str:
+    """Map a 0–100 score to a human-readable urgency label."""
+    if score >= 85:
+        return "CRITICAL"
+    elif score >= 70:
+        return "HIGH"
+    elif score >= 50:
+        return "MEDIUM"
+    elif score >= 30:
+        return "LOW"
+    else:
+        return "INFORMATIONAL"
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+
+def compute_temporal_priority(cve_id: str) -> dict[str, Any]:
+    """Fetch all signals and compute the temporal priority score."""
+    cve_id = cve_id.strip().upper()
+
+    # Fetch all signals (graceful degradation on each)
+    nvd = fetch_nvd_data(cve_id)
+    epss = fetch_epss_data(cve_id)
+    kev = fetch_kev_status(cve_id)
+
+    result = compute_score(
+        cvss_score=nvd["cvss_score"],
+        current_epss=epss["current_epss"],
+        spike_detected=epss["spike_detected"],
+        days_since_spike=epss.get("days_since_spike"),
+        in_kev=kev["in_kev"],
+        has_patch=nvd["has_patch"],
+        published_date=nvd["published_date"],
+    )
+
+    result["cve_id"] = cve_id
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Text rendering
+# ---------------------------------------------------------------------------
+
+
+def render_text(result: dict[str, Any]) -> str:
+    """Render the temporal priority result as human-readable text."""
+    lines: list[str] = []
+    score = result["score"]
+    label = result["label"]
+    cve_id = result.get("cve_id", "UNKNOWN")
+
+    # Header
+    lines.append(f"Temporal Priority Score for {cve_id}")
+    lines.append("=" * 50)
+    lines.append(f"  Score : {score:.1f} / 100  [{label}]")
+    lines.append(f"  Signals available: {result['signals_available']}/{result['signals_total']}")
+    lines.append("")
+
+    # Breakdown
+    lines.append("Signal Breakdown:")
+    lines.append("-" * 50)
+
+    breakdown = result.get("breakdown", {})
+
+    # CVSS
+    cvss = breakdown.get("cvss", {})
+    if cvss.get("raw") is not None:
+        lines.append(f"  CVSS base score   : {cvss['raw']:.1f}/10.0  → {cvss['points']:.1f}/{cvss['max']} pts")
+    else:
+        lines.append(f"  CVSS base score   : unavailable  → 0/{cvss.get('max', _W_CVSS)} pts")
+
+    # EPSS
+    epss_info = breakdown.get("epss", {})
+    if epss_info.get("raw") is not None:
+        lines.append(
+            f"  EPSS probability  : {epss_info['raw']:.4f}  → {epss_info['points']:.1f}/{epss_info['max']} pts"
+        )
+    else:
+        lines.append(f"  EPSS probability  : unavailable  → 0/{epss_info.get('max', _W_EPSS)} pts")
+
+    # Spike
+    spike = breakdown.get("spike", {})
+    if spike.get("detected") is not None:
+        if spike["detected"]:
+            days_str = f" ({spike['days_since']}d ago)" if spike.get("days_since") is not None else ""
+            lines.append(f"  EPSS spike        : ⚠️  YES{days_str}  → {spike['points']:.1f}/{spike['max']} pts")
+        else:
+            lines.append(f"  EPSS spike        : none  → 0/{spike['max']} pts")
+    else:
+        lines.append(f"  EPSS spike        : unavailable  → 0/{spike.get('max', _W_SPIKE)} pts")
+
+    # KEV
+    kev_info = breakdown.get("kev", {})
+    if kev_info.get("in_kev") is not None:
+        if kev_info["in_kev"]:
+            lines.append(f"  CISA KEV          : 🚨 IN CATALOG  → {kev_info['points']:.1f}/{kev_info['max']} pts")
+        else:
+            lines.append(f"  CISA KEV          : not listed  → 0/{kev_info['max']} pts")
+    else:
+        lines.append(f"  CISA KEV          : unavailable  → 0/{kev_info.get('max', _W_KEV)} pts")
+
+    # Patch
+    patch = breakdown.get("patch", {})
+    if patch.get("has_patch") is not None:
+        if patch["has_patch"]:
+            lines.append(f"  Patch available   : ✅ yes  → {patch['points']:.1f}/{patch['max']} pts (reduces urgency)")
+        else:
+            lines.append(f"  Patch available   : ❌ no   → +{patch['points']:.1f}/{patch['max']} pts (unpatched bonus)")
+    else:
+        lines.append(f"  Patch available   : unavailable  → 0/{patch.get('max', _W_PATCH)} pts")
+
+    # Age
+    age = breakdown.get("age", {})
+    if age.get("days") is not None:
+        lines.append(f"  CVE age           : {age['days']}d  → {age['points']:.1f}/{age['max']} pts")
+    else:
+        lines.append(f"  CVE age           : unavailable  → 0/{age.get('max', _W_AGE)} pts")
+
+    lines.append("")
+    lines.append("-" * 50)
+
+    # Urgency bar
+    bar_len = 20
+    filled = int(round(score / 100.0 * bar_len))
+    bar = "█" * filled + "░" * (bar_len - filled)
+    lines.append(f"  [{bar}] {score:.1f}%")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool entry point
+# ---------------------------------------------------------------------------
+
+
+def get_temporal_priority(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands SDK handler for the temporal-priority tool."""
+    tool_use_id = tool["toolUseId"]
+    tool_input = tool.get("input", {}) or {}
+    cve_id = tool_input.get("cve_id")
+
+    if not isinstance(cve_id, str) or not cve_id.strip():
+        result: ToolResult = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": "Invalid CVE ID. Must be a non-empty string like 'CVE-2024-3094'."}],
+        }
+        log_tool_output_size("get_temporal_priority", result)
+        return result
+
+    if not re.match(r"^CVE-\d{4}-\d{4,}$", cve_id.strip(), re.IGNORECASE):
+        result = {
+            "toolUseId": tool_use_id,
+            "status": "error",
+            "content": [{"text": f"Invalid CVE format: '{cve_id}'. Expected format: CVE-YYYY-NNNNN."}],
+        }
+        log_tool_output_size("get_temporal_priority", result)
+        return result
+
+    import json
+
+    payload = compute_temporal_priority(cve_id)
+    result = {
+        "toolUseId": tool_use_id,
+        "status": "success",
+        "content": [{"text": json.dumps(payload, indent=2)}],
+    }
+    log_tool_output_size("get_temporal_priority", result)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(val: Any) -> float | None:
+    """Safely convert a value to float, returning None on failure."""
+    if val is None:
+        return None
+    try:
+        return float(val)
+    except (ValueError, TypeError):
+        return None

--- a/tests/test_temporal_priority.py
+++ b/tests/test_temporal_priority.py
@@ -1,0 +1,1079 @@
+"""
+Comprehensive test suite for the get_temporal_priority tool module.
+
+Tests cover: TOOL_SPEC contract, input validation, HTTP retry logic,
+NVD data fetching, EPSS data fetching, KEV status checking, CVSS extraction,
+patch detection, spike analysis, score computation, age calculation,
+urgency labels, text rendering, handler integration, CLI subcommand, and edge cases.
+
+All tests are 100% mocked — no real HTTP calls.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.get_temporal_priority import (
+    TOOL_SPEC,
+    _analyse_spike,
+    _check_patch_refs,
+    _compute_age_days,
+    _extract_cvss,
+    _http_get,
+    _safe_float,
+    _urgency_label,
+    compute_score,
+    compute_temporal_priority,
+    fetch_epss_data,
+    fetch_kev_status,
+    fetch_nvd_data,
+    get_temporal_priority,
+    render_text,
+)
+
+# ===========================================================================
+# TOOL_SPEC contract tests
+# ===========================================================================
+
+
+class TestToolSpec:
+    """Verify TOOL_SPEC follows Strands SDK conventions."""
+
+    def test_has_name(self):
+        assert TOOL_SPEC["name"] == "get_temporal_priority"
+
+    def test_has_description(self):
+        assert "temporal priority" in TOOL_SPEC["description"].lower()
+        assert len(TOOL_SPEC["description"]) > 50
+
+    def test_input_schema_has_cve_id(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert "cve_id" in schema["properties"]
+        assert "cve_id" in schema["required"]
+
+    def test_input_schema_type_object(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["type"] == "object"
+
+
+# ===========================================================================
+# Input validation tests
+# ===========================================================================
+
+
+class TestInputValidation:
+    """Test handler input validation."""
+
+    def test_empty_cve_id(self):
+        tool_use = {"toolUseId": "test-1", "input": {"cve_id": ""}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid CVE ID" in result["content"][0]["text"]
+
+    def test_none_cve_id(self):
+        tool_use = {"toolUseId": "test-2", "input": {"cve_id": None}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+
+    def test_missing_cve_id(self):
+        tool_use = {"toolUseId": "test-3", "input": {}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+
+    def test_invalid_format(self):
+        tool_use = {"toolUseId": "test-4", "input": {"cve_id": "not-a-cve"}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+        assert "Invalid CVE format" in result["content"][0]["text"]
+
+    def test_numeric_only(self):
+        tool_use = {"toolUseId": "test-5", "input": {"cve_id": "12345"}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+
+    def test_too_short_number(self):
+        tool_use = {"toolUseId": "test-6", "input": {"cve_id": "CVE-2024-12"}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+
+    @patch("manus_agent.tools.get_temporal_priority.compute_temporal_priority")
+    def test_valid_cve_id(self, mock_compute):
+        mock_compute.return_value = {"cve_id": "CVE-2024-3094", "score": 75.0, "label": "HIGH"}
+        tool_use = {"toolUseId": "test-7", "input": {"cve_id": "CVE-2024-3094"}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "success"
+
+
+# ===========================================================================
+# HTTP retry tests
+# ===========================================================================
+
+
+class TestHttpRetry:
+    """Test HTTP retry/back-off logic."""
+
+    @patch("manus_agent.tools.get_temporal_priority.time.sleep")
+    @patch("manus_agent.tools.get_temporal_priority.requests.get")
+    def test_success_on_first_try(self, mock_get, mock_sleep):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+        result = _http_get("https://example.com")
+        assert result == mock_resp
+        mock_sleep.assert_not_called()
+
+    @patch("manus_agent.tools.get_temporal_priority.time.sleep")
+    @patch("manus_agent.tools.get_temporal_priority.requests.get")
+    def test_retry_on_429(self, mock_get, mock_sleep):
+        resp_429 = MagicMock()
+        resp_429.status_code = 429
+
+        resp_200 = MagicMock()
+        resp_200.status_code = 200
+        resp_200.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [resp_429, resp_200]
+        result = _http_get("https://example.com")
+        assert result == resp_200
+        assert mock_sleep.call_count == 1
+
+    @patch("manus_agent.tools.get_temporal_priority._MAX_RETRIES", 2)
+    @patch("manus_agent.tools.get_temporal_priority.time.sleep")
+    @patch("manus_agent.tools.get_temporal_priority.requests.get")
+    def test_all_retries_exhausted(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ConnectionError("timeout")
+        with pytest.raises(req.exceptions.ConnectionError):
+            _http_get("https://example.com")
+        assert mock_sleep.call_count == 1  # retries - 1
+
+    @patch("manus_agent.tools.get_temporal_priority.time.sleep")
+    @patch("manus_agent.tools.get_temporal_priority.requests.get")
+    def test_retry_on_connection_error(self, mock_get, mock_sleep):
+        import requests as req
+
+        resp_ok = MagicMock()
+        resp_ok.status_code = 200
+        resp_ok.raise_for_status = MagicMock()
+        mock_get.side_effect = [req.exceptions.ConnectionError("fail"), resp_ok]
+        result = _http_get("https://example.com")
+        assert result == resp_ok
+
+    @patch("manus_agent.tools.get_temporal_priority.time.sleep")
+    @patch("manus_agent.tools.get_temporal_priority.requests.get")
+    def test_passes_params_and_headers(self, mock_get, mock_sleep):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.raise_for_status = MagicMock()
+        mock_get.return_value = resp
+        _http_get("https://example.com/api", params={"q": "x"}, headers={"X-Key": "abc"})
+        mock_get.assert_called_once_with(
+            "https://example.com/api",
+            params={"q": "x"},
+            headers={"X-Key": "abc"},
+            timeout=20,
+        )
+
+
+# ===========================================================================
+# NVD data fetching tests
+# ===========================================================================
+
+
+class TestFetchNvdData:
+    """Test NVD data fetching and parsing."""
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_successful_fetch(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {"cvssMetricV31": [{"cvssData": {"baseScore": 9.8}}]},
+                        "published": "2024-03-29T00:00:00.000",
+                        "references": [{"url": "https://patch.example.com", "tags": ["Patch"]}],
+                    }
+                }
+            ]
+        }
+        mock_http.return_value = mock_resp
+        result = fetch_nvd_data("CVE-2024-3094")
+        assert result["cvss_score"] == 9.8
+        assert result["published_date"] == "2024-03-29T00:00:00.000"
+        assert result["has_patch"] is True
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_no_vulnerabilities(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_http.return_value = mock_resp
+        result = fetch_nvd_data("CVE-9999-0000")
+        assert result["cvss_score"] is None
+        assert result["published_date"] is None
+        assert result["has_patch"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_http_error_graceful(self, mock_http):
+        import requests as req
+
+        mock_http.side_effect = req.exceptions.ConnectionError("timeout")
+        result = fetch_nvd_data("CVE-2024-3094")
+        assert result["cvss_score"] is None
+        assert result["has_patch"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_no_patch_refs(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {"cvssMetricV31": [{"cvssData": {"baseScore": 7.5}}]},
+                        "published": "2024-01-01T00:00:00.000",
+                        "references": [{"url": "https://example.com", "tags": ["Third Party Advisory"]}],
+                    }
+                }
+            ]
+        }
+        mock_http.return_value = mock_resp
+        result = fetch_nvd_data("CVE-2024-1234")
+        assert result["has_patch"] is False
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    @patch.dict("os.environ", {"NVD_API_KEY": "test-key-123"})
+    def test_uses_api_key(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_http.return_value = mock_resp
+        fetch_nvd_data("CVE-2024-3094")
+        call_kwargs = mock_http.call_args
+        assert call_kwargs[1]["headers"]["apiKey"] == "test-key-123"
+
+
+# ===========================================================================
+# CVSS extraction tests
+# ===========================================================================
+
+
+class TestExtractCvss:
+    """Test CVSS score extraction from NVD metrics."""
+
+    def test_v31_preferred(self):
+        cve_item = {
+            "metrics": {
+                "cvssMetricV31": [{"cvssData": {"baseScore": 9.8}}],
+                "cvssMetricV30": [{"cvssData": {"baseScore": 8.5}}],
+            }
+        }
+        assert _extract_cvss(cve_item) == 9.8
+
+    def test_v30_fallback(self):
+        cve_item = {"metrics": {"cvssMetricV30": [{"cvssData": {"baseScore": 7.2}}]}}
+        assert _extract_cvss(cve_item) == 7.2
+
+    def test_v2_fallback(self):
+        cve_item = {"metrics": {"cvssMetricV2": [{"cvssData": {"baseScore": 6.0}}]}}
+        assert _extract_cvss(cve_item) == 6.0
+
+    def test_no_metrics(self):
+        cve_item = {"metrics": {}}
+        assert _extract_cvss(cve_item) is None
+
+    def test_empty_cve_item(self):
+        assert _extract_cvss({}) is None
+
+
+# ===========================================================================
+# Patch reference detection tests
+# ===========================================================================
+
+
+class TestCheckPatchRefs:
+    """Test patch reference detection in NVD references."""
+
+    def test_patch_found(self):
+        cve_item = {"references": [{"url": "https://github.com/fix", "tags": ["Patch"]}]}
+        assert _check_patch_refs(cve_item) is True
+
+    def test_no_patch(self):
+        cve_item = {"references": [{"url": "https://blog.example.com", "tags": ["Third Party Advisory"]}]}
+        assert _check_patch_refs(cve_item) is False
+
+    def test_no_references(self):
+        cve_item = {"references": []}
+        assert _check_patch_refs(cve_item) is False
+
+    def test_empty_cve_item(self):
+        assert _check_patch_refs({}) is False
+
+    def test_multiple_refs_one_patch(self):
+        cve_item = {
+            "references": [
+                {"url": "https://blog.example.com", "tags": ["Third Party Advisory"]},
+                {"url": "https://github.com/commit/abc", "tags": ["Patch", "Third Party Advisory"]},
+            ]
+        }
+        assert _check_patch_refs(cve_item) is True
+
+
+# ===========================================================================
+# EPSS data fetching tests
+# ===========================================================================
+
+
+class TestFetchEpssData:
+    """Test EPSS data fetching and spike analysis."""
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_successful_fetch(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "epss": "0.95",
+                    "time-series": [
+                        {"date": "2024-03-01", "epss": "0.10", "percentile": "0.80"},
+                        {"date": "2024-03-02", "epss": "0.95", "percentile": "0.99"},
+                    ],
+                }
+            ]
+        }
+        mock_http.return_value = mock_resp
+        result = fetch_epss_data("CVE-2024-3094")
+        assert result["current_epss"] == 0.95
+        assert result["spike_detected"] is True
+        assert result["max_jump"] == pytest.approx(0.85, abs=0.01)
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_no_data(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_http.return_value = mock_resp
+        result = fetch_epss_data("CVE-9999-0000")
+        assert result["current_epss"] is None
+        assert result["spike_detected"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_http_error_graceful(self, mock_http):
+        import requests as req
+
+        mock_http.side_effect = req.exceptions.Timeout("timeout")
+        result = fetch_epss_data("CVE-2024-3094")
+        assert result["current_epss"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_no_spike(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "epss": "0.05",
+                    "time-series": [
+                        {"date": "2024-03-01", "epss": "0.04", "percentile": "0.50"},
+                        {"date": "2024-03-02", "epss": "0.05", "percentile": "0.51"},
+                    ],
+                }
+            ]
+        }
+        mock_http.return_value = mock_resp
+        result = fetch_epss_data("CVE-2024-1234")
+        assert result["current_epss"] == 0.05
+        assert result["spike_detected"] is False
+
+
+# ===========================================================================
+# Spike analysis tests
+# ===========================================================================
+
+
+class TestAnalyseSpike:
+    """Test EPSS spike detection logic."""
+
+    def test_no_series(self):
+        result = _analyse_spike([])
+        assert result["spike_detected"] is False
+        assert result["max_jump"] == 0.0
+
+    def test_single_point(self):
+        result = _analyse_spike([{"date": "2024-01-01", "epss": "0.5"}])
+        assert result["spike_detected"] is False
+
+    def test_large_spike(self):
+        series = [
+            {"date": "2024-01-01", "epss": "0.01"},
+            {"date": "2024-01-02", "epss": "0.50"},
+        ]
+        result = _analyse_spike(series)
+        assert result["spike_detected"] is True
+        assert result["max_jump"] == pytest.approx(0.49, abs=0.01)
+
+    def test_below_threshold(self):
+        series = [
+            {"date": "2024-01-01", "epss": "0.01"},
+            {"date": "2024-01-02", "epss": "0.02"},
+        ]
+        result = _analyse_spike(series)
+        assert result["spike_detected"] is False
+        assert result["max_jump"] == pytest.approx(0.01, abs=0.001)
+
+    def test_days_since_spike_computed(self):
+        # Use a date far in the past
+        series = [
+            {"date": "2020-01-01", "epss": "0.01"},
+            {"date": "2020-01-02", "epss": "0.80"},
+        ]
+        result = _analyse_spike(series)
+        assert result["spike_detected"] is True
+        assert result["days_since_spike"] is not None
+        assert result["days_since_spike"] > 1000
+
+    def test_descending_series_no_spike(self):
+        series = [
+            {"date": "2024-01-01", "epss": "0.90"},
+            {"date": "2024-01-02", "epss": "0.80"},
+            {"date": "2024-01-03", "epss": "0.70"},
+        ]
+        result = _analyse_spike(series)
+        assert result["spike_detected"] is False
+        assert result["max_jump"] == 0.0
+
+
+# ===========================================================================
+# KEV status tests
+# ===========================================================================
+
+
+class TestFetchKevStatus:
+    """Test CISA KEV catalog lookup."""
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_cve_in_kev(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {"cveID": "CVE-2024-3094", "dateAdded": "2024-03-30"},
+                {"cveID": "CVE-2021-44228", "dateAdded": "2021-12-10"},
+            ]
+        }
+        mock_http.return_value = mock_resp
+        result = fetch_kev_status("CVE-2024-3094")
+        assert result["in_kev"] is True
+        assert result["date_added"] == "2024-03-30"
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_cve_not_in_kev(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": [{"cveID": "CVE-2021-44228", "dateAdded": "2021-12-10"}]}
+        mock_http.return_value = mock_resp
+        result = fetch_kev_status("CVE-2024-9999")
+        assert result["in_kev"] is False
+        assert result["date_added"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_http_error_graceful(self, mock_http):
+        import requests as req
+
+        mock_http.side_effect = req.exceptions.ConnectionError("fail")
+        result = fetch_kev_status("CVE-2024-3094")
+        assert result["in_kev"] is None
+
+    @patch("manus_agent.tools.get_temporal_priority._http_get")
+    def test_case_insensitive_match(self, mock_http):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": [{"cveID": "cve-2024-3094", "dateAdded": "2024-03-30"}]}
+        mock_http.return_value = mock_resp
+        result = fetch_kev_status("CVE-2024-3094")
+        assert result["in_kev"] is True
+
+
+# ===========================================================================
+# Score computation tests
+# ===========================================================================
+
+
+class TestComputeScore:
+    """Test the core scoring logic."""
+
+    def test_all_signals_max(self):
+        """All signals at maximum = CRITICAL."""
+        result = compute_score(
+            cvss_score=10.0,
+            current_epss=1.0,
+            spike_detected=True,
+            days_since_spike=0,
+            in_kev=True,
+            has_patch=False,
+            published_date=datetime.now(timezone.utc).isoformat(),
+        )
+        assert result["score"] >= 85
+        assert result["label"] == "CRITICAL"
+        assert result["signals_available"] == 6
+
+    def test_all_signals_min(self):
+        """All signals at minimum = low score."""
+        result = compute_score(
+            cvss_score=0.0,
+            current_epss=0.0,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=False,
+            has_patch=True,
+            published_date="2010-01-01T00:00:00.000",
+        )
+        assert result["score"] < 30
+        assert result["label"] in ("LOW", "INFORMATIONAL")
+
+    def test_kev_adds_significant_weight(self):
+        """KEV membership should significantly increase score."""
+        base = compute_score(
+            cvss_score=7.0,
+            current_epss=0.3,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=False,
+            has_patch=False,
+            published_date="2024-01-01T00:00:00.000",
+        )
+        with_kev = compute_score(
+            cvss_score=7.0,
+            current_epss=0.3,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=True,
+            has_patch=False,
+            published_date="2024-01-01T00:00:00.000",
+        )
+        assert with_kev["score"] > base["score"]
+        assert with_kev["score"] - base["score"] > 10
+
+    def test_patch_reduces_urgency(self):
+        """Having a patch should reduce the score."""
+        unpatched = compute_score(
+            cvss_score=8.0,
+            current_epss=0.5,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=False,
+            has_patch=False,
+            published_date="2024-06-01T00:00:00.000",
+        )
+        patched = compute_score(
+            cvss_score=8.0,
+            current_epss=0.5,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=False,
+            has_patch=True,
+            published_date="2024-06-01T00:00:00.000",
+        )
+        assert unpatched["score"] > patched["score"]
+
+    def test_no_signals_available(self):
+        """All signals unavailable should still produce a valid score."""
+        result = compute_score(
+            cvss_score=None,
+            current_epss=None,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        assert 0 <= result["score"] <= 100
+        assert result["signals_available"] == 0
+        assert result["signals_total"] == 6
+
+    def test_score_clamped_0_100(self):
+        """Score should always be between 0 and 100."""
+        result = compute_score(
+            cvss_score=10.0,
+            current_epss=1.0,
+            spike_detected=True,
+            days_since_spike=0,
+            in_kev=True,
+            has_patch=False,
+            published_date=datetime.now(timezone.utc).isoformat(),
+        )
+        assert 0 <= result["score"] <= 100
+
+    def test_spike_with_recent_date(self):
+        """Recent spike should contribute more than old spike."""
+        recent = compute_score(
+            cvss_score=7.0,
+            current_epss=0.5,
+            spike_detected=True,
+            days_since_spike=1,
+            in_kev=False,
+            has_patch=False,
+            published_date="2024-06-01T00:00:00.000",
+        )
+        old = compute_score(
+            cvss_score=7.0,
+            current_epss=0.5,
+            spike_detected=True,
+            days_since_spike=90,
+            in_kev=False,
+            has_patch=False,
+            published_date="2024-06-01T00:00:00.000",
+        )
+        assert recent["score"] > old["score"]
+
+    def test_breakdown_structure(self):
+        """Breakdown should have all 6 signal keys."""
+        result = compute_score(
+            cvss_score=7.5,
+            current_epss=0.3,
+            spike_detected=False,
+            days_since_spike=None,
+            in_kev=False,
+            has_patch=False,
+            published_date="2024-01-01T00:00:00.000",
+        )
+        breakdown = result["breakdown"]
+        assert "cvss" in breakdown
+        assert "epss" in breakdown
+        assert "spike" in breakdown
+        assert "kev" in breakdown
+        assert "patch" in breakdown
+        assert "age" in breakdown
+
+
+# ===========================================================================
+# Age computation tests
+# ===========================================================================
+
+
+class TestComputeAgeDays:
+    """Test CVE age calculation."""
+
+    def test_recent_date(self):
+        recent = datetime.now(timezone.utc).isoformat()
+        days = _compute_age_days(recent)
+        assert days is not None
+        assert days <= 1
+
+    def test_old_date(self):
+        days = _compute_age_days("2020-01-01T00:00:00.000")
+        assert days is not None
+        assert days > 1000
+
+    def test_none_date(self):
+        assert _compute_age_days(None) is None
+
+    def test_empty_string(self):
+        assert _compute_age_days("") is None
+
+    def test_invalid_format(self):
+        assert _compute_age_days("not-a-date") is None
+
+    def test_with_z_suffix(self):
+        days = _compute_age_days("2023-06-15T12:00:00Z")
+        assert days is not None
+        assert days > 300
+
+
+# ===========================================================================
+# Urgency label tests
+# ===========================================================================
+
+
+class TestUrgencyLabel:
+    """Test urgency label mapping."""
+
+    def test_critical(self):
+        assert _urgency_label(90) == "CRITICAL"
+        assert _urgency_label(85) == "CRITICAL"
+
+    def test_high(self):
+        assert _urgency_label(75) == "HIGH"
+        assert _urgency_label(70) == "HIGH"
+
+    def test_medium(self):
+        assert _urgency_label(60) == "MEDIUM"
+        assert _urgency_label(50) == "MEDIUM"
+
+    def test_low(self):
+        assert _urgency_label(40) == "LOW"
+        assert _urgency_label(30) == "LOW"
+
+    def test_informational(self):
+        assert _urgency_label(20) == "INFORMATIONAL"
+        assert _urgency_label(0) == "INFORMATIONAL"
+
+
+# ===========================================================================
+# Text rendering tests
+# ===========================================================================
+
+
+class TestRenderText:
+    """Test human-readable text output."""
+
+    def test_renders_score(self):
+        result = {
+            "cve_id": "CVE-2024-3094",
+            "score": 85.5,
+            "label": "CRITICAL",
+            "signals_available": 6,
+            "signals_total": 6,
+            "breakdown": {
+                "cvss": {"raw": 9.8, "points": 24.5, "max": 25},
+                "epss": {"raw": 0.95, "points": 24.4, "max": 25},
+                "spike": {"detected": True, "days_since": 2, "points": 12.0, "max": 15},
+                "kev": {"in_kev": True, "points": 20.0, "max": 20},
+                "patch": {"has_patch": False, "points": 10.0, "max": 10},
+                "age": {"days": 30, "points": 4.5, "max": 5},
+            },
+        }
+        text = render_text(result)
+        assert "CVE-2024-3094" in text
+        assert "85.5" in text
+        assert "CRITICAL" in text
+        assert "9.8" in text
+
+    def test_renders_unavailable_signals(self):
+        result = {
+            "cve_id": "CVE-2024-0000",
+            "score": 10.0,
+            "label": "INFORMATIONAL",
+            "signals_available": 0,
+            "signals_total": 6,
+            "breakdown": {
+                "cvss": {"raw": None, "points": 0, "max": 25, "note": "unavailable"},
+                "epss": {"raw": None, "points": 0, "max": 25, "note": "unavailable"},
+                "spike": {"detected": None, "points": 0, "max": 15, "note": "unavailable"},
+                "kev": {"in_kev": None, "points": 0, "max": 20, "note": "unavailable"},
+                "patch": {"has_patch": None, "points": 0, "max": 10, "note": "unavailable"},
+                "age": {"days": None, "points": 0, "max": 5, "note": "unavailable"},
+            },
+        }
+        text = render_text(result)
+        assert "unavailable" in text
+        assert "0/6" in text
+
+    def test_renders_kev_alert(self):
+        result = {
+            "cve_id": "CVE-2024-3094",
+            "score": 80.0,
+            "label": "HIGH",
+            "signals_available": 4,
+            "signals_total": 6,
+            "breakdown": {
+                "cvss": {"raw": 9.8, "points": 24.5, "max": 25},
+                "epss": {"raw": None, "points": 0, "max": 25, "note": "unavailable"},
+                "spike": {"detected": None, "points": 0, "max": 15, "note": "unavailable"},
+                "kev": {"in_kev": True, "points": 20.0, "max": 20},
+                "patch": {"has_patch": True, "points": -10.0, "max": 10},
+                "age": {"days": 100, "points": 3.4, "max": 5},
+            },
+        }
+        text = render_text(result)
+        assert "IN CATALOG" in text
+
+    def test_renders_progress_bar(self):
+        result = {
+            "cve_id": "CVE-2024-1234",
+            "score": 50.0,
+            "label": "MEDIUM",
+            "signals_available": 6,
+            "signals_total": 6,
+            "breakdown": {
+                "cvss": {"raw": 5.0, "points": 12.5, "max": 25},
+                "epss": {"raw": 0.1, "points": 7.9, "max": 25},
+                "spike": {"detected": False, "days_since": None, "points": 0, "max": 15},
+                "kev": {"in_kev": False, "points": 0, "max": 20},
+                "patch": {"has_patch": False, "points": 10, "max": 10},
+                "age": {"days": 60, "points": 3.9, "max": 5},
+            },
+        }
+        text = render_text(result)
+        assert "█" in text
+        assert "░" in text
+
+
+# ===========================================================================
+# Integration: compute_temporal_priority
+# ===========================================================================
+
+
+class TestComputeTemporalPriority:
+    """Test the full orchestration pipeline."""
+
+    @patch("manus_agent.tools.get_temporal_priority.fetch_kev_status")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_epss_data")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_nvd_data")
+    def test_full_pipeline(self, mock_nvd, mock_epss, mock_kev):
+        mock_nvd.return_value = {
+            "cvss_score": 9.8,
+            "published_date": "2024-03-29T00:00:00.000",
+            "has_patch": False,
+        }
+        mock_epss.return_value = {
+            "current_epss": 0.95,
+            "spike_detected": True,
+            "max_jump": 0.8,
+            "days_since_spike": 2,
+        }
+        mock_kev.return_value = {"in_kev": True, "date_added": "2024-03-30"}
+
+        result = compute_temporal_priority("CVE-2024-3094")
+        assert result["cve_id"] == "CVE-2024-3094"
+        assert result["score"] >= 80
+        assert result["label"] in ("CRITICAL", "HIGH")
+        assert result["signals_available"] == 6
+
+    @patch("manus_agent.tools.get_temporal_priority.fetch_kev_status")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_epss_data")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_nvd_data")
+    def test_all_sources_fail(self, mock_nvd, mock_epss, mock_kev):
+        mock_nvd.return_value = {"cvss_score": None, "published_date": None, "has_patch": None}
+        mock_epss.return_value = {
+            "current_epss": None,
+            "spike_detected": None,
+            "max_jump": None,
+            "days_since_spike": None,
+        }
+        mock_kev.return_value = {"in_kev": None, "date_added": None}
+
+        result = compute_temporal_priority("CVE-9999-0000")
+        assert result["cve_id"] == "CVE-9999-0000"
+        assert 0 <= result["score"] <= 100
+        assert result["signals_available"] == 0
+
+    @patch("manus_agent.tools.get_temporal_priority.fetch_kev_status")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_epss_data")
+    @patch("manus_agent.tools.get_temporal_priority.fetch_nvd_data")
+    def test_case_normalization(self, mock_nvd, mock_epss, mock_kev):
+        mock_nvd.return_value = {"cvss_score": 5.0, "published_date": None, "has_patch": None}
+        mock_epss.return_value = {
+            "current_epss": None,
+            "spike_detected": None,
+            "max_jump": None,
+            "days_since_spike": None,
+        }
+        mock_kev.return_value = {"in_kev": None, "date_added": None}
+
+        result = compute_temporal_priority("  cve-2024-3094  ")
+        assert result["cve_id"] == "CVE-2024-3094"
+
+
+# ===========================================================================
+# Handler integration tests
+# ===========================================================================
+
+
+class TestHandler:
+    """Test the Strands tool handler."""
+
+    @patch("manus_agent.tools.get_temporal_priority.compute_temporal_priority")
+    def test_success_response(self, mock_compute):
+        mock_compute.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "score": 92.0,
+            "label": "CRITICAL",
+            "signals_available": 6,
+            "signals_total": 6,
+            "breakdown": {},
+        }
+        tool_use = {"toolUseId": "h-1", "input": {"cve_id": "CVE-2024-3094"}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "h-1"
+        data = json.loads(result["content"][0]["text"])
+        assert data["score"] == 92.0
+
+    @patch("manus_agent.tools.get_temporal_priority.compute_temporal_priority")
+    def test_whitespace_handling(self, mock_compute):
+        mock_compute.return_value = {"cve_id": "CVE-2024-3094", "score": 50.0}
+        tool_use = {"toolUseId": "h-2", "input": {"cve_id": "  CVE-2024-3094  "}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "success"
+
+    def test_integer_input_rejected(self):
+        tool_use = {"toolUseId": "h-3", "input": {"cve_id": 12345}}
+        result = get_temporal_priority(tool_use)
+        assert result["status"] == "error"
+
+
+# ===========================================================================
+# CLI subcommand tests
+# ===========================================================================
+
+
+class TestCliSubcommand:
+    """Test the manus-agent temporal-priority CLI dispatch."""
+
+    @patch("manus_agent.tools.get_temporal_priority.compute_temporal_priority")
+    def test_text_output(self, mock_compute, capsys):
+        from manus_agent.cli import _run_temporal_priority
+
+        mock_compute.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "score": 85.0,
+            "label": "CRITICAL",
+            "signals_available": 6,
+            "signals_total": 6,
+            "breakdown": {
+                "cvss": {"raw": 9.8, "points": 24.5, "max": 25},
+                "epss": {"raw": 0.95, "points": 24.4, "max": 25},
+                "spike": {"detected": True, "days_since": 2, "points": 12.0, "max": 15},
+                "kev": {"in_kev": True, "points": 20.0, "max": 20},
+                "patch": {"has_patch": False, "points": 10.0, "max": 10},
+                "age": {"days": 30, "points": 4.5, "max": 5},
+            },
+        }
+        rc = _run_temporal_priority(["CVE-2024-3094"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "CVE-2024-3094" in captured.out
+        assert "85.0" in captured.out
+
+    @patch("manus_agent.tools.get_temporal_priority.compute_temporal_priority")
+    def test_json_output(self, mock_compute, capsys):
+        from manus_agent.cli import _run_temporal_priority
+
+        mock_compute.return_value = {
+            "cve_id": "CVE-2024-3094",
+            "score": 85.0,
+            "label": "CRITICAL",
+        }
+        rc = _run_temporal_priority(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["score"] == 85.0
+
+    def test_invalid_cve_format(self, capsys):
+        from manus_agent.cli import _run_temporal_priority
+
+        rc = _run_temporal_priority(["not-a-cve"])
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "Invalid CVE format" in captured.err
+
+    def test_empty_cve_triggers_error(self):
+        from manus_agent.cli import _run_temporal_priority
+
+        with pytest.raises(SystemExit):
+            _run_temporal_priority([])
+
+    def test_subcommand_registered(self):
+        from manus_agent.cli import _SUBCOMMANDS
+
+        assert "temporal-priority" in _SUBCOMMANDS
+
+
+# ===========================================================================
+# Safe float helper tests
+# ===========================================================================
+
+
+class TestSafeFloat:
+    """Test the _safe_float helper."""
+
+    def test_valid_string(self):
+        assert _safe_float("0.95") == 0.95
+
+    def test_valid_int(self):
+        assert _safe_float(5) == 5.0
+
+    def test_none(self):
+        assert _safe_float(None) is None
+
+    def test_invalid_string(self):
+        assert _safe_float("abc") is None
+
+    def test_empty_string(self):
+        assert _safe_float("") is None
+
+
+# ===========================================================================
+# Edge cases
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Test boundary conditions and edge cases."""
+
+    def test_cvss_zero(self):
+        result = compute_score(
+            cvss_score=0.0,
+            current_epss=None,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        assert result["breakdown"]["cvss"]["points"] == 0
+
+    def test_cvss_ten(self):
+        result = compute_score(
+            cvss_score=10.0,
+            current_epss=None,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        assert result["breakdown"]["cvss"]["points"] == 25.0
+
+    def test_epss_at_one(self):
+        result = compute_score(
+            cvss_score=None,
+            current_epss=1.0,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        assert result["breakdown"]["epss"]["points"] == 25.0
+
+    def test_epss_above_one_clamped(self):
+        """EPSS > 1.0 should be clamped."""
+        result = compute_score(
+            cvss_score=None,
+            current_epss=1.5,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        assert result["breakdown"]["epss"]["points"] == 25.0
+
+    def test_spike_without_days(self):
+        """Spike detected but days_since unknown → 75% points."""
+        result = compute_score(
+            cvss_score=None,
+            current_epss=None,
+            spike_detected=True,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date=None,
+        )
+        expected = 0.75 * 15  # _W_SPIKE default is 15
+        assert result["breakdown"]["spike"]["points"] == pytest.approx(expected, abs=0.1)
+
+    def test_very_old_cve_low_age_score(self):
+        """Very old CVE should have minimal age contribution."""
+        result = compute_score(
+            cvss_score=None,
+            current_epss=None,
+            spike_detected=None,
+            days_since_spike=None,
+            in_kev=None,
+            has_patch=None,
+            published_date="2000-01-01T00:00:00.000",
+        )
+        assert result["breakdown"]["age"]["points"] < 0.1


### PR DESCRIPTION
## Summary

Implements the `get_temporal_priority` tool and `manus-agent temporal-priority` CLI subcommand — a 0–100 CVE urgency scorer that combines six signals to answer: *"given everything I know today, how urgent is this CVE?"*

This was documented in the README with full usage examples but had **zero implementation** (no tool file, no CLI dispatch, no tests).

## Signals & Scoring

| Signal | Weight | Logic |
|--------|--------|-------|
| CVSS base score | 25 pts | Linear: 0→0, 10→25 |
| Current EPSS | 25 pts | Non-linear (√): amplifies mid-range probabilities |
| EPSS spike recency | 15 pts | Exponential decay (half-life 14d) from spike date |
| CISA KEV membership | 20 pts | Binary: in catalog = full points |
| Patch availability | 10 pts | Unpatched = +10 bonus; patched = −10 (reduces urgency) |
| CVE age | 5 pts | Exponential decay (half-life 180d) from publish date |

Final score normalized to 0–100 with labels: CRITICAL (≥85), HIGH (≥70), MEDIUM (≥50), LOW (≥30), INFORMATIONAL (<30).

## Usage

```bash
manus-agent temporal-priority CVE-2024-3094
manus-agent temporal-priority CVE-2024-3094 --output json | jq .score
```

## Design Decisions

- **Zero new dependencies** — uses only `requests` (already in deps)
- **Graceful degradation** — if any data source is unavailable, remaining signals still produce a partial score
- **Retry/back-off** on all HTTP calls (configurable via `TEMPORAL_PRIORITY_MAX_RETRIES`, `TEMPORAL_PRIORITY_RETRY_DELAY`)
- **NVD_API_KEY** support for higher rate limits
- **Strands TOOL_SPEC interface** — follows the module-based pattern used by other tools
- **Configurable weights** via environment variables (`TEMPORAL_PRIORITY_W_CVSS`, etc.)

## Test Coverage

90 new tests (100% mocked, no real HTTP):
- TOOL_SPEC contract (4)
- Input validation (7)
- HTTP retry/back-off (5)
- NVD data fetching (5)
- CVSS extraction (5)
- Patch reference detection (5)
- EPSS data fetching (4)
- Spike analysis (6)
- KEV status checking (4)
- Score computation (9)
- Age calculation (6)
- Urgency labels (5)
- Text rendering (4)
- Integration pipeline (3)
- Handler (3)
- CLI subcommand (5)
- Safe float helper (5)
- Edge cases (6)

**Full suite: 1248 passed, 0 failures** (baseline 1158 + 90 new)

## Duplicate Check

Checked all 50 open PRs (#136–#185) and 30 most recent merged PRs. No existing open or merged PR implements `temporal-priority`. Closest PRs:
- #170 (open, `cve-enrich`) — single-CVE enrichment dump, not a scoring algorithm
- #45 (merged, `epss-trend`) — EPSS time-series only, no composite scoring
- #57 (merged, `exploit-complexity`) — complexity scorer (1–5), different dimension entirely

## Files Changed

- `src/manus_agent/tools/get_temporal_priority.py` (new) — tool implementation
- `src/manus_agent/cli.py` — added `temporal-priority` to `_SUBCOMMANDS` + parser/runner
- `tests/test_temporal_priority.py` (new) — 90 tests
