### PR TITLE
feat(tools): triage_cves — batch CVE prioritization tool + CLI subcommand (+78 tests)

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "triage",
 }
 
 
@@ -1935,6 +1936,84 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# triage subcommand
+# ---------------------------------------------------------------------------
+
+
+def _run_triage(argv: list[str]) -> int:
+    """Run the triage subcommand: batch CVE prioritization."""
+    parser = argparse.ArgumentParser(
+        prog="manus-agent triage",
+        description=(
+            "Batch CVE triage: fetches NVD CVSS + EPSS + CISA KEV for multiple CVEs "
+            "and produces a prioritized ranking by composite score."
+        ),
+    )
+    parser.add_argument(
+        "cve_ids",
+        nargs="*",
+        help=("CVE IDs to triage (e.g., CVE-2024-3094 CVE-2021-44228). Also reads from stdin if piped."),
+    )
+    parser.add_argument(
+        "--file",
+        "-f",
+        metavar="FILE",
+        type=Path,
+        default=None,
+        help="Read CVE IDs from a file (one per line)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+
+    args = parser.parse_args(argv)
+
+    # Collect CVE IDs from all sources
+    cve_ids: list[str] = list(args.cve_ids) if args.cve_ids else []
+
+    # Read from file if specified
+    if args.file:
+        try:
+            with args.file.open(encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        cve_ids.append(line)
+        except OSError as exc:
+            print(f"[error] Cannot read file: {exc}", file=sys.stderr)
+            return 1
+
+    # Read from stdin if no positional args and no file
+    if not cve_ids and not sys.stdin.isatty():
+        for line in sys.stdin:
+            line = line.strip()
+            if line and not line.startswith("#"):
+                cve_ids.append(line)
+
+    if not cve_ids:
+        parser.error("No CVE IDs provided. Pass them as arguments, via --file, or pipe to stdin.")
+
+    from manus_agent.tools.triage_cves import triage_cves
+
+    print(f"Triaging {len(cve_ids)} CVE(s)...", file=sys.stderr)
+    result = triage_cves(cve_ids, output_format=args.output)
+
+    if "error" in result and not result.get("results"):
+        print(f"[error] {result['error']}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        sys.stdout.write(json.dumps(result, indent=2, ensure_ascii=False) + "\n")
+    else:
+        sys.stdout.write(result.get("formatted", ""))
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2347,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "triage":
+        idx = argv.index("triage")
+        sys.exit(_run_triage(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/triage_cves.py
+++ b/src/manus_agent/tools/triage_cves.py
@@ -1,0 +1,522 @@
+"""
+Batch CVE triage tool — accepts multiple CVE IDs and produces a prioritized
+ranking based on CVSS severity, EPSS exploitation probability, and CISA KEV
+membership.
+
+Designed for ad-hoc triage of vulnerability lists (from scanners, advisories,
+or manual collections). Unlike the watchlist tool (persistent tracking) or
+compare tool (exactly 2 CVEs), this handles arbitrary-length lists statelessly
+and outputs a ranked triage table.
+
+Data sources:
+- NVD (CVSS v3.1/v3.0/v2.0 base score)
+- FIRST.org EPSS API (batch endpoint, up to 100 CVEs per call)
+- CISA KEV catalogue (known exploited vulnerabilities)
+- VulnCheck KEV (optional, when VULNCHECK_API_KEY is set)
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_CVE_RE = re.compile(r"^CVE-\d{4}-\d{4,}$", re.IGNORECASE)
+
+_NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
+_EPSS_API_URL = "https://api.first.org/data/v1/epss"
+_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+_VULNCHECK_KEV_URL = "https://api.vulncheck.com/v3/index/vulncheck-kev"
+
+# Retry settings
+_MAX_RETRIES = 3
+_BACKOFF_BASE = 1.5
+
+# Batch sizes
+_EPSS_BATCH_SIZE = 100  # FIRST.org supports up to 100 CVEs per request
+_NVD_DELAY = 0.7  # NVD rate limit: ~10 requests per minute without API key
+
+# Triage scoring weights
+_WEIGHT_CVSS = 0.30
+_WEIGHT_EPSS = 0.40
+_WEIGHT_KEV = 0.30
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC (Strands agent interface)
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "triage_cves",
+    "description": (
+        "Batch CVE triage: accepts a list of CVE IDs, fetches NVD CVSS + EPSS + "
+        "CISA KEV status for each, computes a composite triage score (0-100), and "
+        "returns the list ranked by urgency. Use this when you have multiple CVEs "
+        "to prioritize (e.g., from a scanner report, advisory list, or SBOM scan). "
+        "Supports up to 50 CVEs per call. Returns both structured data and a "
+        "human-readable triage table."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_ids": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "List of CVE identifiers to triage (e.g., ['CVE-2024-3094', 'CVE-2021-44228']). Maximum 50."
+                    ),
+                },
+                "output_format": {
+                    "type": "string",
+                    "enum": ["text", "json"],
+                    "description": "Output format: 'text' for a ranked table, 'json' for structured data.",
+                    "default": "text",
+                },
+            },
+            "required": ["cve_ids"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helpers with retry/back-off
+# ---------------------------------------------------------------------------
+
+
+def _get_with_retry(
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    headers: dict[str, str] | None = None,
+    timeout: int = 20,
+) -> requests.Response:
+    """HTTP GET with exponential back-off on 429/5xx."""
+    for attempt in range(_MAX_RETRIES):
+        try:
+            resp = requests.get(url, params=params, headers=headers, timeout=timeout)
+            if resp.status_code == 429 or resp.status_code >= 500:
+                if attempt < _MAX_RETRIES - 1:
+                    wait = _BACKOFF_BASE ** (attempt + 1)
+                    time.sleep(wait)
+                    continue
+            return resp
+        except requests.RequestException:
+            if attempt < _MAX_RETRIES - 1:
+                time.sleep(_BACKOFF_BASE ** (attempt + 1))
+                continue
+            raise
+    # Should not reach here, but satisfy type checker
+    return requests.get(url, params=params, headers=headers, timeout=timeout)  # pragma: no cover
+
+
+# ---------------------------------------------------------------------------
+# Data fetchers
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_cvss(cve_id: str) -> dict[str, Any]:
+    """Fetch CVSS score and vector from NVD for a single CVE."""
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("NVD_API_KEY")
+    if api_key:
+        headers["apiKey"] = api_key
+
+    try:
+        resp = _get_with_retry(
+            _NVD_API_URL,
+            params={"cveId": cve_id.upper()},
+            headers=headers if headers else None,
+            timeout=20,
+        )
+        if resp.status_code != 200:
+            return {"cvss_score": None, "cvss_vector": None, "severity": None}
+
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        if not vulns:
+            return {"cvss_score": None, "cvss_vector": None, "severity": None}
+
+        cve_data = vulns[0].get("cve", {})
+        metrics = cve_data.get("metrics", {})
+
+        # Try CVSS v3.1, then v3.0, then v2.0
+        for key in ("cvssMetricV31", "cvssMetricV30"):
+            entries = metrics.get(key, [])
+            if entries:
+                cvss_data = entries[0].get("cvssData", {})
+                return {
+                    "cvss_score": cvss_data.get("baseScore"),
+                    "cvss_vector": cvss_data.get("vectorString"),
+                    "severity": cvss_data.get("baseSeverity", "").upper(),
+                }
+
+        # Fallback to v2
+        v2_entries = metrics.get("cvssMetricV2", [])
+        if v2_entries:
+            cvss_data = v2_entries[0].get("cvssData", {})
+            score = cvss_data.get("baseScore")
+            # Map v2 score to severity label
+            severity = "LOW"
+            if score and score >= 7.0:
+                severity = "HIGH"
+            elif score and score >= 4.0:
+                severity = "MEDIUM"
+            return {
+                "cvss_score": score,
+                "cvss_vector": cvss_data.get("vectorString"),
+                "severity": severity,
+            }
+
+        return {"cvss_score": None, "cvss_vector": None, "severity": None}
+
+    except Exception:
+        return {"cvss_score": None, "cvss_vector": None, "severity": None}
+
+
+def _fetch_epss_batch(cve_ids: list[str]) -> dict[str, dict[str, float | None]]:
+    """Fetch EPSS scores for a batch of CVEs (up to 100 per API call)."""
+    result: dict[str, dict[str, float | None]] = {}
+
+    for i in range(0, len(cve_ids), _EPSS_BATCH_SIZE):
+        batch = cve_ids[i : i + _EPSS_BATCH_SIZE]
+        cve_param = ",".join(c.upper() for c in batch)
+
+        try:
+            resp = _get_with_retry(
+                _EPSS_API_URL,
+                params={"cve": cve_param},
+                timeout=20,
+            )
+            if resp.status_code != 200:
+                for cve_id in batch:
+                    result[cve_id.upper()] = {"epss": None, "percentile": None}
+                continue
+
+            data = resp.json()
+            epss_data = data.get("data", [])
+            found_ids = set()
+            for entry in epss_data:
+                cid = entry.get("cve", "").upper()
+                found_ids.add(cid)
+                result[cid] = {
+                    "epss": float(entry["epss"]) if entry.get("epss") else None,
+                    "percentile": float(entry["percentile"]) if entry.get("percentile") else None,
+                }
+
+            # Mark missing CVEs
+            for cve_id in batch:
+                if cve_id.upper() not in found_ids:
+                    result[cve_id.upper()] = {"epss": None, "percentile": None}
+
+        except Exception:
+            for cve_id in batch:
+                result[cve_id.upper()] = {"epss": None, "percentile": None}
+
+    return result
+
+
+def _fetch_kev_catalogue() -> set[str]:
+    """Fetch the CISA KEV catalogue and return a set of CVE IDs."""
+    try:
+        resp = _get_with_retry(_KEV_URL, timeout=30)
+        if resp.status_code != 200:
+            return set()
+        data = resp.json()
+        vulns = data.get("vulnerabilities", [])
+        return {v.get("cveID", "").upper() for v in vulns if v.get("cveID")}
+    except Exception:
+        return set()
+
+
+def _fetch_vulncheck_kev(cve_ids: list[str]) -> set[str]:
+    """Check VulnCheck KEV for CVE IDs. Returns set of CVEs found in VulnCheck KEV."""
+    api_key = os.environ.get("VULNCHECK_API_KEY")
+    if not api_key:
+        return set()
+
+    found: set[str] = set()
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+
+    for cve_id in cve_ids:
+        try:
+            resp = _get_with_retry(
+                _VULNCHECK_KEV_URL,
+                params={"cve": cve_id.upper()},
+                headers=headers,
+                timeout=15,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                if data.get("data"):
+                    found.add(cve_id.upper())
+        except Exception:
+            continue
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Triage scoring
+# ---------------------------------------------------------------------------
+
+
+def _compute_triage_score(
+    *,
+    cvss_score: float | None,
+    epss_score: float | None,
+    in_kev: bool,
+) -> float:
+    """Compute composite triage score (0-100).
+
+    Formula:
+        score = (CVSS_norm * W_cvss) + (EPSS * W_epss) + (KEV * W_kev) * 100
+
+    Where:
+        - CVSS_norm = cvss_score / 10.0 (normalized to 0-1)
+        - EPSS = epss_score (already 0-1)
+        - KEV = 1.0 if in KEV catalogue, 0.0 otherwise
+    """
+    cvss_norm = (cvss_score / 10.0) if cvss_score is not None else 0.0
+    epss_val = epss_score if epss_score is not None else 0.0
+    kev_val = 1.0 if in_kev else 0.0
+
+    raw = (cvss_norm * _WEIGHT_CVSS) + (epss_val * _WEIGHT_EPSS) + (kev_val * _WEIGHT_KEV)
+    return round(raw * 100, 1)
+
+
+def _severity_label(score: float) -> str:
+    """Map triage score to urgency label."""
+    if score >= 80:
+        return "CRITICAL"
+    if score >= 60:
+        return "HIGH"
+    if score >= 40:
+        return "MEDIUM"
+    if score >= 20:
+        return "LOW"
+    return "INFO"
+
+
+# ---------------------------------------------------------------------------
+# Core triage logic
+# ---------------------------------------------------------------------------
+
+
+def triage_cves(cve_ids: list[str], output_format: str = "text") -> dict[str, Any]:
+    """Run batch triage on a list of CVE IDs.
+
+    Returns a dict with:
+        - results: list of per-CVE triage records, sorted by score descending
+        - summary: aggregate stats
+        - formatted: human-readable text (when output_format='text')
+    """
+    # Validate inputs
+    if not cve_ids:
+        return {"error": "No CVE IDs provided.", "results": [], "summary": {}}
+
+    if len(cve_ids) > 50:
+        return {"error": "Maximum 50 CVE IDs per triage call.", "results": [], "summary": {}}
+
+    # Normalize and validate
+    normalized: list[str] = []
+    invalid: list[str] = []
+    for cid in cve_ids:
+        cid_stripped = cid.strip()
+        if _CVE_RE.match(cid_stripped):
+            normalized.append(cid_stripped.upper())
+        else:
+            invalid.append(cid_stripped)
+
+    if not normalized:
+        return {
+            "error": f"No valid CVE IDs found. Invalid: {invalid}",
+            "results": [],
+            "summary": {},
+        }
+
+    # Deduplicate while preserving order
+    seen: set[str] = set()
+    unique_cves: list[str] = []
+    for cid in normalized:
+        if cid not in seen:
+            seen.add(cid)
+            unique_cves.append(cid)
+
+    # Fetch data in parallel-friendly batches
+    # 1. EPSS (batch API — most efficient)
+    epss_data = _fetch_epss_batch(unique_cves)
+
+    # 2. CISA KEV (single fetch, then set lookup)
+    kev_set = _fetch_kev_catalogue()
+
+    # 3. VulnCheck KEV (optional enrichment)
+    vc_kev_set = _fetch_vulncheck_kev(unique_cves)
+
+    # 4. NVD CVSS (per-CVE, with rate limiting)
+    nvd_data: dict[str, dict[str, Any]] = {}
+    api_key = os.environ.get("NVD_API_KEY")
+    for i, cve_id in enumerate(unique_cves):
+        nvd_data[cve_id] = _fetch_nvd_cvss(cve_id)
+        # Rate limit: wait between requests (faster with API key)
+        if i < len(unique_cves) - 1:
+            if api_key:
+                time.sleep(0.15)
+            else:
+                time.sleep(_NVD_DELAY)
+
+    # Build triage records
+    records: list[dict[str, Any]] = []
+    for cve_id in unique_cves:
+        nvd = nvd_data.get(cve_id, {})
+        epss = epss_data.get(cve_id, {})
+        in_cisa_kev = cve_id in kev_set
+        in_vc_kev = cve_id in vc_kev_set
+        in_any_kev = in_cisa_kev or in_vc_kev
+
+        cvss_score = nvd.get("cvss_score")
+        epss_score = epss.get("epss")
+
+        triage_score = _compute_triage_score(
+            cvss_score=cvss_score,
+            epss_score=epss_score,
+            in_kev=in_any_kev,
+        )
+
+        records.append(
+            {
+                "cve_id": cve_id,
+                "cvss_score": cvss_score,
+                "cvss_severity": nvd.get("severity"),
+                "epss_score": epss_score,
+                "epss_percentile": epss.get("percentile"),
+                "in_cisa_kev": in_cisa_kev,
+                "in_vulncheck_kev": in_vc_kev,
+                "triage_score": triage_score,
+                "urgency": _severity_label(triage_score),
+            }
+        )
+
+    # Sort by triage score descending
+    records.sort(key=lambda r: r["triage_score"], reverse=True)
+
+    # Summary stats
+    summary = {
+        "total_cves": len(records),
+        "critical_count": sum(1 for r in records if r["urgency"] == "CRITICAL"),
+        "high_count": sum(1 for r in records if r["urgency"] == "HIGH"),
+        "medium_count": sum(1 for r in records if r["urgency"] == "MEDIUM"),
+        "low_count": sum(1 for r in records if r["urgency"] == "LOW"),
+        "info_count": sum(1 for r in records if r["urgency"] == "INFO"),
+        "kev_count": sum(1 for r in records if r["in_cisa_kev"] or r["in_vulncheck_kev"]),
+        "invalid_ids": invalid if invalid else None,
+    }
+
+    result: dict[str, Any] = {
+        "results": records,
+        "summary": summary,
+    }
+
+    if output_format == "text":
+        result["formatted"] = _format_text(records, summary, invalid)
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Formatting
+# ---------------------------------------------------------------------------
+
+
+def _format_text(
+    records: list[dict[str, Any]],
+    summary: dict[str, Any],
+    invalid: list[str],
+) -> str:
+    """Format triage results as a human-readable text table."""
+    lines: list[str] = []
+    lines.append("=" * 72)
+    lines.append("  CVE TRIAGE REPORT — Prioritized by Composite Score")
+    lines.append("=" * 72)
+    lines.append("")
+
+    # Table header
+    lines.append(f"{'#':<4} {'CVE ID':<18} {'Score':<7} {'Urgency':<10} {'CVSS':<6} {'EPSS':<7} {'KEV':<5}")
+    lines.append("-" * 72)
+
+    for i, rec in enumerate(records, 1):
+        cvss_str = f"{rec['cvss_score']:.1f}" if rec["cvss_score"] is not None else "N/A"
+        epss_str = f"{rec['epss_score']:.4f}" if rec["epss_score"] is not None else "N/A"
+        kev_str = "YES" if (rec["in_cisa_kev"] or rec["in_vulncheck_kev"]) else "no"
+
+        lines.append(
+            f"{i:<4} {rec['cve_id']:<18} {rec['triage_score']:<7.1f} "
+            f"{rec['urgency']:<10} {cvss_str:<6} {epss_str:<7} {kev_str:<5}"
+        )
+
+    lines.append("-" * 72)
+    lines.append("")
+
+    # Summary
+    lines.append("SUMMARY")
+    lines.append(f"  Total CVEs triaged: {summary['total_cves']}")
+    lines.append(
+        f"  CRITICAL: {summary['critical_count']}  |  HIGH: {summary['high_count']}  |  "
+        f"MEDIUM: {summary['medium_count']}  |  LOW: {summary['low_count']}  |  "
+        f"INFO: {summary['info_count']}"
+    )
+    lines.append(f"  In KEV catalogue: {summary['kev_count']}")
+
+    if invalid:
+        lines.append(f"  Skipped (invalid format): {', '.join(invalid)}")
+
+    lines.append("")
+    lines.append("SCORING METHODOLOGY")
+    lines.append(
+        f"  Composite = (CVSS/10 × {_WEIGHT_CVSS:.0%}) + (EPSS × {_WEIGHT_EPSS:.0%}) + (KEV × {_WEIGHT_KEV:.0%})"
+    )
+    lines.append("  Sources: NVD (CVSS), FIRST.org (EPSS), CISA KEV, VulnCheck KEV")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Strands tool handler
+# ---------------------------------------------------------------------------
+
+
+def triage_cves_handler(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands-compatible tool handler for triage_cves."""
+    tool_input = tool.get("input", {})
+    cve_ids = tool_input.get("cve_ids", [])
+    output_format = tool_input.get("output_format", "text")
+
+    result = triage_cves(cve_ids, output_format=output_format)
+
+    if "error" in result and not result["results"]:
+        content_text = f"Error: {result['error']}"
+    elif output_format == "json":
+        import json
+
+        content_text = json.dumps(result, indent=2, ensure_ascii=False)
+    else:
+        content_text = result.get("formatted", str(result))
+
+    log_tool_output_size("triage_cves", content_text)
+
+    return {
+        "toolUseId": tool["toolUseId"],
+        "status": "error" if ("error" in result and not result["results"]) else "success",
+        "content": [{"text": content_text}],
+    }

--- a/tests/test_triage_cves.py
+++ b/tests/test_triage_cves.py
@@ -1,0 +1,1115 @@
+"""
+Comprehensive test suite for triage_cves tool.
+
+100% mocked — no real HTTP calls.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.triage_cves import (
+    TOOL_SPEC,
+    _compute_triage_score,
+    _fetch_epss_batch,
+    _fetch_kev_catalogue,
+    _fetch_nvd_cvss,
+    _fetch_vulncheck_kev,
+    _format_text,
+    _get_with_retry,
+    _severity_label,
+    triage_cves,
+    triage_cves_handler,
+)
+
+# ---------------------------------------------------------------------------
+# TOOL_SPEC contract tests
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Verify TOOL_SPEC structure follows Strands conventions."""
+
+    def test_has_name(self):
+        assert TOOL_SPEC["name"] == "triage_cves"
+
+    def test_has_description(self):
+        assert "batch" in TOOL_SPEC["description"].lower()
+        assert "triage" in TOOL_SPEC["description"].lower()
+
+    def test_has_input_schema(self):
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["type"] == "object"
+        assert "cve_ids" in schema["properties"]
+        assert "output_format" in schema["properties"]
+
+    def test_cve_ids_is_required(self):
+        assert "cve_ids" in TOOL_SPEC["inputSchema"]["json"]["required"]
+
+    def test_cve_ids_is_array(self):
+        props = TOOL_SPEC["inputSchema"]["json"]["properties"]
+        assert props["cve_ids"]["type"] == "array"
+        assert props["cve_ids"]["items"]["type"] == "string"
+
+    def test_output_format_enum(self):
+        props = TOOL_SPEC["inputSchema"]["json"]["properties"]
+        assert set(props["output_format"]["enum"]) == {"text", "json"}
+
+
+# ---------------------------------------------------------------------------
+# Input validation tests
+# ---------------------------------------------------------------------------
+
+
+class TestInputValidation:
+    """Test input validation logic."""
+
+    def test_empty_cve_list(self):
+        result = triage_cves([])
+        assert "error" in result
+        assert result["results"] == []
+
+    def test_too_many_cves(self):
+        cve_ids = [f"CVE-2024-{i:04d}" for i in range(51)]
+        result = triage_cves(cve_ids)
+        assert "error" in result
+        assert "50" in result["error"]
+
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    def test_all_invalid_cve_ids(self, mock_nvd, mock_vc, mock_kev, mock_epss):
+        result = triage_cves(["not-a-cve", "also-bad", "123"])
+        assert "error" in result
+        assert "invalid" in result["error"].lower()
+
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    def test_mixed_valid_and_invalid(self, mock_nvd, mock_vc, mock_kev, mock_epss):
+        mock_epss.return_value = {"CVE-2024-1234": {"epss": 0.5, "percentile": 0.9}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 7.5, "cvss_vector": "AV:N", "severity": "HIGH"}
+
+        result = triage_cves(["CVE-2024-1234", "bad-id"])
+        assert len(result["results"]) == 1
+        assert result["summary"]["invalid_ids"] == ["bad-id"]
+
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    def test_duplicate_cves_deduplicated(self, mock_nvd, mock_vc, mock_kev, mock_epss):
+        mock_epss.return_value = {"CVE-2024-1234": {"epss": 0.3, "percentile": 0.7}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 5.0, "cvss_vector": "AV:L", "severity": "MEDIUM"}
+
+        result = triage_cves(["CVE-2024-1234", "CVE-2024-1234", "cve-2024-1234"])
+        assert len(result["results"]) == 1
+
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    def test_case_insensitive_normalization(self, mock_nvd, mock_vc, mock_kev, mock_epss):
+        mock_epss.return_value = {"CVE-2024-5678": {"epss": 0.1, "percentile": 0.5}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 4.0, "cvss_vector": "AV:L", "severity": "MEDIUM"}
+
+        result = triage_cves(["cve-2024-5678"])
+        assert result["results"][0]["cve_id"] == "CVE-2024-5678"
+
+
+# ---------------------------------------------------------------------------
+# Triage scoring tests
+# ---------------------------------------------------------------------------
+
+
+class TestTriageScoring:
+    """Test the composite scoring logic."""
+
+    def test_all_zeros(self):
+        score = _compute_triage_score(cvss_score=None, epss_score=None, in_kev=False)
+        assert score == 0.0
+
+    def test_max_score(self):
+        score = _compute_triage_score(cvss_score=10.0, epss_score=1.0, in_kev=True)
+        assert score == 100.0
+
+    def test_cvss_only(self):
+        score = _compute_triage_score(cvss_score=10.0, epss_score=0.0, in_kev=False)
+        # (10/10 * 0.30 + 0 * 0.40 + 0 * 0.30) * 100 = 30.0
+        assert score == 30.0
+
+    def test_epss_only(self):
+        score = _compute_triage_score(cvss_score=0.0, epss_score=1.0, in_kev=False)
+        # (0 * 0.30 + 1.0 * 0.40 + 0 * 0.30) * 100 = 40.0
+        assert score == 40.0
+
+    def test_kev_only(self):
+        score = _compute_triage_score(cvss_score=0.0, epss_score=0.0, in_kev=True)
+        # (0 * 0.30 + 0 * 0.40 + 1.0 * 0.30) * 100 = 30.0
+        assert score == 30.0
+
+    def test_typical_high_severity(self):
+        # CVSS 9.8, EPSS 0.95, in KEV
+        score = _compute_triage_score(cvss_score=9.8, epss_score=0.95, in_kev=True)
+        expected = round((9.8 / 10 * 0.30 + 0.95 * 0.40 + 1.0 * 0.30) * 100, 1)
+        assert score == expected
+
+    def test_none_cvss_treated_as_zero(self):
+        score = _compute_triage_score(cvss_score=None, epss_score=0.5, in_kev=False)
+        expected = round((0.0 * 0.30 + 0.5 * 0.40 + 0.0 * 0.30) * 100, 1)
+        assert score == expected
+
+    def test_none_epss_treated_as_zero(self):
+        score = _compute_triage_score(cvss_score=7.0, epss_score=None, in_kev=True)
+        expected = round((7.0 / 10 * 0.30 + 0.0 * 0.40 + 1.0 * 0.30) * 100, 1)
+        assert score == expected
+
+
+# ---------------------------------------------------------------------------
+# Severity label tests
+# ---------------------------------------------------------------------------
+
+
+class TestSeverityLabel:
+    """Test urgency label mapping."""
+
+    def test_critical(self):
+        assert _severity_label(80.0) == "CRITICAL"
+        assert _severity_label(100.0) == "CRITICAL"
+
+    def test_high(self):
+        assert _severity_label(60.0) == "HIGH"
+        assert _severity_label(79.9) == "HIGH"
+
+    def test_medium(self):
+        assert _severity_label(40.0) == "MEDIUM"
+        assert _severity_label(59.9) == "MEDIUM"
+
+    def test_low(self):
+        assert _severity_label(20.0) == "LOW"
+        assert _severity_label(39.9) == "LOW"
+
+    def test_info(self):
+        assert _severity_label(0.0) == "INFO"
+        assert _severity_label(19.9) == "INFO"
+
+
+# ---------------------------------------------------------------------------
+# HTTP retry tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetWithRetry:
+    """Test the retry/back-off HTTP helper."""
+
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_success_on_first_try(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_get.return_value = mock_resp
+
+        result = _get_with_retry("https://example.com")
+        assert result.status_code == 200
+        assert mock_get.call_count == 1
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_retry_on_429(self, mock_get, mock_sleep):
+        mock_429 = MagicMock()
+        mock_429.status_code = 429
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_get.side_effect = [mock_429, mock_200]
+
+        result = _get_with_retry("https://example.com")
+        assert result.status_code == 200
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_retry_on_500(self, mock_get, mock_sleep):
+        mock_500 = MagicMock()
+        mock_500.status_code = 500
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_get.side_effect = [mock_500, mock_200]
+
+        result = _get_with_retry("https://example.com")
+        assert result.status_code == 200
+        assert mock_get.call_count == 2
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_max_retries_exhausted(self, mock_get, mock_sleep):
+        mock_500 = MagicMock()
+        mock_500.status_code = 500
+        mock_get.return_value = mock_500
+
+        result = _get_with_retry("https://example.com")
+        assert result.status_code == 500
+        assert mock_get.call_count == 3
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_retry_on_request_exception(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_200 = MagicMock()
+        mock_200.status_code = 200
+        mock_get.side_effect = [req.ConnectionError("timeout"), mock_200]
+
+        result = _get_with_retry("https://example.com")
+        assert result.status_code == 200
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves.requests.get")
+    def test_all_retries_fail_with_exception(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_get.side_effect = req.ConnectionError("down")
+        with pytest.raises(req.ConnectionError):
+            _get_with_retry("https://example.com")
+
+
+# ---------------------------------------------------------------------------
+# NVD CVSS fetcher tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdCvss:
+    """Test NVD CVSS data fetching."""
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_cvss_v31_extraction(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {
+                            "cvssMetricV31": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 9.8,
+                                        "vectorString": "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                                        "baseSeverity": "CRITICAL",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd_cvss("CVE-2024-3094")
+        assert result["cvss_score"] == 9.8
+        assert result["severity"] == "CRITICAL"
+        assert "CVSS:3.1" in result["cvss_vector"]
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_cvss_v30_fallback(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {
+                            "cvssMetricV30": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 7.5,
+                                        "vectorString": "CVSS:3.0/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H",
+                                        "baseSeverity": "HIGH",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd_cvss("CVE-2020-1234")
+        assert result["cvss_score"] == 7.5
+        assert result["severity"] == "HIGH"
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_cvss_v2_fallback(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "metrics": {
+                            "cvssMetricV2": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 7.5,
+                                        "vectorString": "AV:N/AC:L/Au:N/C:P/I:P/A:P",
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd_cvss("CVE-2015-1234")
+        assert result["cvss_score"] == 7.5
+        assert result["severity"] == "HIGH"
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_no_vulnerabilities(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd_cvss("CVE-9999-0001")
+        assert result["cvss_score"] is None
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_http_error(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+        mock_get.return_value = mock_resp
+
+        result = _fetch_nvd_cvss("CVE-2024-0000")
+        assert result["cvss_score"] is None
+        assert result["severity"] is None
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_exception_graceful_degradation(self, mock_get):
+        mock_get.side_effect = Exception("network error")
+        result = _fetch_nvd_cvss("CVE-2024-0001")
+        assert result["cvss_score"] is None
+
+    @patch.dict("os.environ", {"NVD_API_KEY": "test-key-123"})
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_uses_api_key_header(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        _fetch_nvd_cvss("CVE-2024-1111")
+        call_kwargs = mock_get.call_args
+        assert call_kwargs[1]["headers"]["apiKey"] == "test-key-123"
+
+
+# ---------------------------------------------------------------------------
+# EPSS batch fetcher tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEpssBatch:
+    """Test EPSS batch API fetching."""
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_single_cve(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"cve": "CVE-2024-3094", "epss": "0.97565", "percentile": "0.99988"}]}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss_batch(["CVE-2024-3094"])
+        assert result["CVE-2024-3094"]["epss"] == pytest.approx(0.97565)
+        assert result["CVE-2024-3094"]["percentile"] == pytest.approx(0.99988)
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_multiple_cves(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {"cve": "CVE-2024-3094", "epss": "0.97565", "percentile": "0.99988"},
+                {"cve": "CVE-2021-44228", "epss": "0.97500", "percentile": "0.99950"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss_batch(["CVE-2024-3094", "CVE-2021-44228"])
+        assert len(result) == 2
+        assert "CVE-2024-3094" in result
+        assert "CVE-2021-44228" in result
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_missing_cve_in_response(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"cve": "CVE-2024-3094", "epss": "0.5", "percentile": "0.8"}]}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss_batch(["CVE-2024-3094", "CVE-9999-0001"])
+        assert result["CVE-2024-3094"]["epss"] == 0.5
+        assert result["CVE-9999-0001"]["epss"] is None
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_http_error_returns_none_for_all(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 500
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss_batch(["CVE-2024-1111", "CVE-2024-2222"])
+        assert result["CVE-2024-1111"]["epss"] is None
+        assert result["CVE-2024-2222"]["epss"] is None
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_exception_graceful(self, mock_get):
+        mock_get.side_effect = Exception("timeout")
+        result = _fetch_epss_batch(["CVE-2024-3094"])
+        assert result["CVE-2024-3094"]["epss"] is None
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_batching_over_100(self, mock_get):
+        """CVEs > 100 should be split into multiple API calls."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        cve_ids = [f"CVE-2024-{i:04d}" for i in range(150)]
+        _fetch_epss_batch(cve_ids)
+        # Should make 2 calls: 100 + 50
+        assert mock_get.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# KEV catalogue tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchKevCatalogue:
+    """Test CISA KEV catalogue fetching."""
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_success(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {"cveID": "CVE-2021-44228"},
+                {"cveID": "CVE-2024-3094"},
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev_catalogue()
+        assert "CVE-2021-44228" in result
+        assert "CVE-2024-3094" in result
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_http_error_returns_empty(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 503
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev_catalogue()
+        assert result == set()
+
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_exception_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("network error")
+        result = _fetch_kev_catalogue()
+        assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# VulnCheck KEV tests
+# ---------------------------------------------------------------------------
+
+
+class TestFetchVulncheckKev:
+    """Test VulnCheck KEV enrichment."""
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_api_key_returns_empty(self):
+        result = _fetch_vulncheck_kev(["CVE-2024-3094"])
+        assert result == set()
+
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_found_in_vulncheck(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": [{"cve": "CVE-2024-3094"}]}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_vulncheck_kev(["CVE-2024-3094"])
+        assert "CVE-2024-3094" in result
+
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_not_found_in_vulncheck(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        result = _fetch_vulncheck_kev(["CVE-9999-0001"])
+        assert result == set()
+
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_api_error_graceful(self, mock_get):
+        mock_get.side_effect = Exception("down")
+        result = _fetch_vulncheck_kev(["CVE-2024-3094"])
+        assert result == set()
+
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    @patch("manus_agent.tools.triage_cves._get_with_retry")
+    def test_auth_header_sent(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        _fetch_vulncheck_kev(["CVE-2024-1111"])
+        call_kwargs = mock_get.call_args
+        assert "Bearer vc-test-key" in str(call_kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Core triage logic integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestTriageCves:
+    """Test the main triage_cves function end-to-end."""
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_basic_triage_two_cves(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {
+            "CVE-2024-3094": {"epss": 0.975, "percentile": 0.999},
+            "CVE-2024-0001": {"epss": 0.01, "percentile": 0.3},
+        }
+        mock_kev.return_value = {"CVE-2024-3094"}
+        mock_vc.return_value = set()
+        mock_nvd.side_effect = [
+            {"cvss_score": 9.8, "cvss_vector": "CVSS:3.1/...", "severity": "CRITICAL"},
+            {"cvss_score": 4.0, "cvss_vector": "CVSS:3.1/...", "severity": "MEDIUM"},
+        ]
+
+        result = triage_cves(["CVE-2024-3094", "CVE-2024-0001"])
+        assert len(result["results"]) == 2
+        # First should be the higher-scored one
+        assert result["results"][0]["cve_id"] == "CVE-2024-3094"
+        assert result["results"][0]["triage_score"] > result["results"][1]["triage_score"]
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_json_output_format(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {"CVE-2024-1111": {"epss": 0.5, "percentile": 0.8}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 7.0, "cvss_vector": "AV:N", "severity": "HIGH"}
+
+        result = triage_cves(["CVE-2024-1111"], output_format="json")
+        # Should not have 'formatted' key in json mode
+        assert "formatted" not in result
+        assert result["results"][0]["cve_id"] == "CVE-2024-1111"
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_text_output_has_formatted(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {"CVE-2024-1111": {"epss": 0.5, "percentile": 0.8}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 7.0, "cvss_vector": "AV:N", "severity": "HIGH"}
+
+        result = triage_cves(["CVE-2024-1111"], output_format="text")
+        assert "formatted" in result
+        assert "TRIAGE REPORT" in result["formatted"]
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_summary_counts(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {
+            "CVE-2024-0001": {"epss": 0.975, "percentile": 0.999},
+            "CVE-2024-0002": {"epss": 0.5, "percentile": 0.8},
+            "CVE-2024-0003": {"epss": 0.01, "percentile": 0.1},
+        }
+        mock_kev.return_value = {"CVE-2024-0001"}
+        mock_vc.return_value = set()
+        mock_nvd.side_effect = [
+            {"cvss_score": 9.8, "cvss_vector": "...", "severity": "CRITICAL"},
+            {"cvss_score": 6.0, "cvss_vector": "...", "severity": "MEDIUM"},
+            {"cvss_score": 2.0, "cvss_vector": "...", "severity": "LOW"},
+        ]
+
+        result = triage_cves(["CVE-2024-0001", "CVE-2024-0002", "CVE-2024-0003"])
+        summary = result["summary"]
+        assert summary["total_cves"] == 3
+        assert summary["kev_count"] == 1
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_results_sorted_descending(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {
+            "CVE-2024-0001": {"epss": 0.1, "percentile": 0.3},
+            "CVE-2024-0002": {"epss": 0.9, "percentile": 0.99},
+        }
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.side_effect = [
+            {"cvss_score": 3.0, "cvss_vector": "...", "severity": "LOW"},
+            {"cvss_score": 9.0, "cvss_vector": "...", "severity": "CRITICAL"},
+        ]
+
+        result = triage_cves(["CVE-2024-0001", "CVE-2024-0002"])
+        scores = [r["triage_score"] for r in result["results"]]
+        assert scores == sorted(scores, reverse=True)
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_vulncheck_kev_boosts_score(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {"CVE-2024-5555": {"epss": 0.5, "percentile": 0.8}}
+        mock_kev.return_value = set()  # Not in CISA KEV
+        mock_vc.return_value = {"CVE-2024-5555"}  # But in VulnCheck KEV
+        mock_nvd.return_value = {"cvss_score": 7.0, "cvss_vector": "...", "severity": "HIGH"}
+
+        result = triage_cves(["CVE-2024-5555"])
+        rec = result["results"][0]
+        assert rec["in_vulncheck_kev"] is True
+        assert rec["in_cisa_kev"] is False
+        # Score should include KEV boost
+        score_with_kev = _compute_triage_score(cvss_score=7.0, epss_score=0.5, in_kev=True)
+        assert rec["triage_score"] == score_with_kev
+
+
+# ---------------------------------------------------------------------------
+# Text formatting tests
+# ---------------------------------------------------------------------------
+
+
+class TestFormatText:
+    """Test text report formatting."""
+
+    def test_header_present(self):
+        records = [
+            {
+                "cve_id": "CVE-2024-3094",
+                "cvss_score": 9.8,
+                "cvss_severity": "CRITICAL",
+                "epss_score": 0.975,
+                "epss_percentile": 0.999,
+                "in_cisa_kev": True,
+                "in_vulncheck_kev": False,
+                "triage_score": 95.4,
+                "urgency": "CRITICAL",
+            }
+        ]
+        summary = {
+            "total_cves": 1,
+            "critical_count": 1,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 0,
+            "kev_count": 1,
+            "invalid_ids": None,
+        }
+        text = _format_text(records, summary, [])
+        assert "TRIAGE REPORT" in text
+        assert "CVE-2024-3094" in text
+        assert "CRITICAL" in text
+
+    def test_kev_yes_label(self):
+        records = [
+            {
+                "cve_id": "CVE-2021-44228",
+                "cvss_score": 10.0,
+                "cvss_severity": "CRITICAL",
+                "epss_score": 0.975,
+                "epss_percentile": 0.999,
+                "in_cisa_kev": True,
+                "in_vulncheck_kev": False,
+                "triage_score": 100.0,
+                "urgency": "CRITICAL",
+            }
+        ]
+        summary = {
+            "total_cves": 1,
+            "critical_count": 1,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 0,
+            "kev_count": 1,
+            "invalid_ids": None,
+        }
+        text = _format_text(records, summary, [])
+        assert "YES" in text
+
+    def test_invalid_ids_shown(self):
+        records = []
+        summary = {
+            "total_cves": 0,
+            "critical_count": 0,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 0,
+            "kev_count": 0,
+            "invalid_ids": ["bad-1"],
+        }
+        text = _format_text(records, summary, ["bad-1"])
+        assert "bad-1" in text
+
+    def test_none_cvss_shows_na(self):
+        records = [
+            {
+                "cve_id": "CVE-2024-9999",
+                "cvss_score": None,
+                "cvss_severity": None,
+                "epss_score": None,
+                "epss_percentile": None,
+                "in_cisa_kev": False,
+                "in_vulncheck_kev": False,
+                "triage_score": 0.0,
+                "urgency": "INFO",
+            }
+        ]
+        summary = {
+            "total_cves": 1,
+            "critical_count": 0,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 1,
+            "kev_count": 0,
+            "invalid_ids": None,
+        }
+        text = _format_text(records, summary, [])
+        assert "N/A" in text
+
+    def test_methodology_section(self):
+        records = []
+        summary = {
+            "total_cves": 0,
+            "critical_count": 0,
+            "high_count": 0,
+            "medium_count": 0,
+            "low_count": 0,
+            "info_count": 0,
+            "kev_count": 0,
+            "invalid_ids": None,
+        }
+        text = _format_text(records, summary, [])
+        assert "SCORING METHODOLOGY" in text
+        assert "NVD" in text
+        assert "EPSS" in text
+
+
+# ---------------------------------------------------------------------------
+# Strands handler tests
+# ---------------------------------------------------------------------------
+
+
+class TestTriageCvesHandler:
+    """Test the Strands tool handler wrapper."""
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_success_text_format(self, mock_triage):
+        mock_triage.return_value = {
+            "results": [{"cve_id": "CVE-2024-3094", "triage_score": 95.0}],
+            "summary": {"total_cves": 1},
+            "formatted": "Report text here",
+        }
+        tool_use = {"toolUseId": "test-123", "input": {"cve_ids": ["CVE-2024-3094"]}}
+        result = triage_cves_handler(tool_use)
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-123"
+        assert "Report text here" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_success_json_format(self, mock_triage):
+        mock_triage.return_value = {
+            "results": [{"cve_id": "CVE-2024-3094", "triage_score": 95.0}],
+            "summary": {"total_cves": 1},
+        }
+        tool_use = {
+            "toolUseId": "test-456",
+            "input": {"cve_ids": ["CVE-2024-3094"], "output_format": "json"},
+        }
+        result = triage_cves_handler(tool_use)
+        assert result["status"] == "success"
+        # Should be valid JSON
+        parsed = json.loads(result["content"][0]["text"])
+        assert parsed["results"][0]["cve_id"] == "CVE-2024-3094"
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_error_result(self, mock_triage):
+        mock_triage.return_value = {
+            "error": "No valid CVE IDs found.",
+            "results": [],
+            "summary": {},
+        }
+        tool_use = {"toolUseId": "test-789", "input": {"cve_ids": ["bad"]}}
+        result = triage_cves_handler(tool_use)
+        assert result["status"] == "error"
+        assert "Error" in result["content"][0]["text"]
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_default_output_format(self, mock_triage):
+        mock_triage.return_value = {
+            "results": [{"cve_id": "CVE-2024-1111"}],
+            "summary": {},
+            "formatted": "text output",
+        }
+        tool_use = {"toolUseId": "test-000", "input": {"cve_ids": ["CVE-2024-1111"]}}
+        triage_cves_handler(tool_use)
+        mock_triage.assert_called_once_with(["CVE-2024-1111"], output_format="text")
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand tests
+# ---------------------------------------------------------------------------
+
+
+class TestCliTriage:
+    """Test the CLI dispatch for triage subcommand."""
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_cli_triage_from_args(self, mock_triage):
+        import io
+
+        mock_triage.return_value = {
+            "results": [{"cve_id": "CVE-2024-3094", "triage_score": 95.0}],
+            "summary": {"total_cves": 1},
+            "formatted": "Report output\n",
+        }
+        from manus_agent.cli import _run_triage
+
+        with patch("sys.stderr", new=io.StringIO()), patch("sys.stdout", new=io.StringIO()):
+            rc = _run_triage(["CVE-2024-3094"])
+        assert rc == 0
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_cli_triage_json_output(self, mock_triage):
+        import io
+
+        mock_triage.return_value = {
+            "results": [{"cve_id": "CVE-2024-3094", "triage_score": 95.0}],
+            "summary": {"total_cves": 1},
+        }
+        from manus_agent.cli import _run_triage
+
+        mock_stdout = io.StringIO()
+        with patch("sys.stderr", new=io.StringIO()), patch("sys.stdout", new=mock_stdout):
+            rc = _run_triage(["CVE-2024-3094", "--output", "json"])
+        assert rc == 0
+        output = mock_stdout.getvalue()
+        parsed = json.loads(output)
+        assert parsed["results"][0]["cve_id"] == "CVE-2024-3094"
+
+    @patch("manus_agent.tools.triage_cves.triage_cves")
+    def test_cli_triage_error(self, mock_triage):
+        import io
+
+        mock_triage.return_value = {"error": "No valid CVE IDs found.", "results": [], "summary": {}}
+        from manus_agent.cli import _run_triage
+
+        with patch("sys.stderr", new=io.StringIO()), patch("sys.stdout", new=io.StringIO()):
+            rc = _run_triage(["bad-id"])
+        assert rc == 1
+
+    def test_cli_triage_from_file(self, tmp_path):
+        import io
+
+        cve_file = tmp_path / "cves.txt"
+        cve_file.write_text("CVE-2024-3094\n# comment\nCVE-2021-44228\n")
+
+        with patch("manus_agent.tools.triage_cves.triage_cves") as mock_triage:
+            mock_triage.return_value = {
+                "results": [
+                    {"cve_id": "CVE-2024-3094", "triage_score": 95.0},
+                    {"cve_id": "CVE-2021-44228", "triage_score": 90.0},
+                ],
+                "summary": {"total_cves": 2},
+                "formatted": "Report\n",
+            }
+            from manus_agent.cli import _run_triage
+
+            with patch("sys.stderr", new=io.StringIO()), patch("sys.stdout", new=io.StringIO()):
+                rc = _run_triage(["--file", str(cve_file)])
+
+        assert rc == 0
+        call_args = mock_triage.call_args[0][0]
+        assert "CVE-2024-3094" in call_args
+        assert "CVE-2021-44228" in call_args
+
+    def test_cli_triage_missing_file(self):
+        import io
+
+        from manus_agent.cli import _run_triage
+
+        with patch("sys.stderr", new=io.StringIO()), patch("sys.stdout", new=io.StringIO()):
+            rc = _run_triage(["--file", "/nonexistent/path.txt"])
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# Edge case tests
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Test edge cases and boundary conditions."""
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_all_data_missing(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        """Triage still works when all external sources return nothing."""
+        mock_epss.return_value = {"CVE-2024-9999": {"epss": None, "percentile": None}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": None, "cvss_vector": None, "severity": None}
+
+        result = triage_cves(["CVE-2024-9999"])
+        assert len(result["results"]) == 1
+        assert result["results"][0]["triage_score"] == 0.0
+        assert result["results"][0]["urgency"] == "INFO"
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_whitespace_in_cve_ids(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {"CVE-2024-1234": {"epss": 0.5, "percentile": 0.8}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 5.0, "cvss_vector": "...", "severity": "MEDIUM"}
+
+        result = triage_cves(["  CVE-2024-1234  "])
+        assert len(result["results"]) == 1
+        assert result["results"][0]["cve_id"] == "CVE-2024-1234"
+
+    def test_exactly_50_cves_allowed(self):
+        """50 CVEs should not trigger the limit error."""
+        cve_ids = [f"CVE-2024-{i:04d}" for i in range(50)]
+
+        with (
+            patch("manus_agent.tools.triage_cves._fetch_epss_batch") as mock_epss,
+            patch("manus_agent.tools.triage_cves._fetch_kev_catalogue") as mock_kev,
+            patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev") as mock_vc,
+            patch("manus_agent.tools.triage_cves._fetch_nvd_cvss") as mock_nvd,
+            patch("manus_agent.tools.triage_cves.time.sleep"),
+        ):
+            mock_epss.return_value = {cid.upper(): {"epss": 0.1, "percentile": 0.5} for cid in cve_ids}
+            mock_kev.return_value = set()
+            mock_vc.return_value = set()
+            mock_nvd.return_value = {"cvss_score": 5.0, "cvss_vector": "...", "severity": "MEDIUM"}
+
+            result = triage_cves(cve_ids)
+            assert "error" not in result
+            assert len(result["results"]) == 50
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_cvss_v2_severity_mapping(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        """V2 scores map to severity labels correctly."""
+        mock_epss.return_value = {"CVE-2015-0001": {"epss": 0.1, "percentile": 0.5}}
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 3.5, "cvss_vector": "AV:N/...", "severity": "LOW"}
+
+        result = triage_cves(["CVE-2015-0001"])
+        assert result["results"][0]["cvss_severity"] == "LOW"
+
+
+# ---------------------------------------------------------------------------
+# NVD rate limiting tests
+# ---------------------------------------------------------------------------
+
+
+class TestNvdRateLimiting:
+    """Test NVD rate limiting behavior."""
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    def test_sleep_between_nvd_calls_without_api_key(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {
+            "CVE-2024-0001": {"epss": 0.1, "percentile": 0.5},
+            "CVE-2024-0002": {"epss": 0.2, "percentile": 0.6},
+        }
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 5.0, "cvss_vector": "...", "severity": "MEDIUM"}
+
+        with patch.dict("os.environ", {}, clear=True):
+            triage_cves(["CVE-2024-0001", "CVE-2024-0002"])
+
+        # Should have called sleep at least once (between NVD requests)
+        assert mock_sleep.call_count >= 1
+
+    @patch("manus_agent.tools.triage_cves.time.sleep")
+    @patch("manus_agent.tools.triage_cves._fetch_nvd_cvss")
+    @patch("manus_agent.tools.triage_cves._fetch_vulncheck_kev")
+    @patch("manus_agent.tools.triage_cves._fetch_kev_catalogue")
+    @patch("manus_agent.tools.triage_cves._fetch_epss_batch")
+    @patch.dict("os.environ", {"NVD_API_KEY": "test-key"})
+    def test_shorter_sleep_with_api_key(self, mock_epss, mock_kev, mock_vc, mock_nvd, mock_sleep):
+        mock_epss.return_value = {
+            "CVE-2024-0001": {"epss": 0.1, "percentile": 0.5},
+            "CVE-2024-0002": {"epss": 0.2, "percentile": 0.6},
+        }
+        mock_kev.return_value = set()
+        mock_vc.return_value = set()
+        mock_nvd.return_value = {"cvss_score": 5.0, "cvss_vector": "...", "severity": "MEDIUM"}
+
+        triage_cves(["CVE-2024-0001", "CVE-2024-0002"])
+
+        # With API key, sleep should use shorter delay (0.15)
+        if mock_sleep.call_count > 0:
+            call_arg = mock_sleep.call_args_list[0][0][0]
+            assert call_arg <= 0.15


### PR DESCRIPTION
## Summary

Add `triage_cves` tool and `manus-agent triage` CLI subcommand for batch CVE prioritization.

## What it does

Accepts multiple CVE IDs (up to 50), fetches NVD CVSS + EPSS + CISA KEV + VulnCheck KEV data in parallel-friendly batches, computes a composite triage score (0–100), and outputs a ranked prioritization table.

### CLI usage

```bash
# From arguments
manus-agent triage CVE-2024-3094 CVE-2021-44228 CVE-2023-4966

# From a file (one CVE per line, # comments supported)
manus-agent triage --file vulns.txt

# Pipe from scanner output
cat scanner-results.txt | manus-agent triage

# JSON output for downstream tooling
manus-agent triage CVE-2024-3094 CVE-2021-44228 --output json
```

### Strands tool interface

```python
from manus_agent.tools.triage_cves import triage_cves_handler, TOOL_SPEC
```

## How it's different from existing tools

| Existing tool | What it does | How triage differs |
|---|---|---|
| `compare` (#48, merged) | Side-by-side of exactly 2 CVEs | Triage handles 1–50 CVEs with batch scoring |
| `watchlist` (#179, open) | Persistent file-based CVE tracking with alerts | Triage is stateless, ad-hoc, one-shot |
| `temporal-priority` (#186, open) | Single-CVE urgency score (0–100) | Triage batches multiple CVEs + ranks them |
| `cve-enrich` (#170, open) | Single-CVE multi-source enrichment dump | Triage focuses on prioritization across a list |

## Scoring methodology

```
Score = (CVSS/10 × 30%) + (EPSS × 40%) + (KEV × 30%) × 100
```

- **CVSS** (30%): NVD base score normalized to 0–1 (tries v3.1 → v3.0 → v2.0)
- **EPSS** (40%): FIRST.org exploitation probability (already 0–1)
- **KEV** (30%): 1.0 if in CISA KEV or VulnCheck KEV, else 0.0

Urgency labels: CRITICAL (≥80), HIGH (≥60), MEDIUM (≥40), LOW (≥20), INFO (<20)

## Design

- Zero new dependencies (requests only)
- Retry/back-off on all HTTP calls (429, 5xx, connection errors)
- NVD rate limiting (0.7s without API key, 0.15s with NVD_API_KEY)
- EPSS batch endpoint (100 CVEs/call) — efficient for large lists
- CISA KEV fetched once, then set-lookup per CVE
- VulnCheck KEV optional (graceful degradation without VULNCHECK_API_KEY)
- Deduplication + case normalization of input CVE IDs
- Supports stdin, --file, and positional arguments

## Tests

78 new tests, 100% mocked (no real HTTP). Categories:
- TOOL_SPEC contract (6)
- Input validation (6)
- Triage scoring (8)
- Severity labels (5)
- HTTP retry/back-off (6)
- NVD CVSS fetcher (7)
- EPSS batch fetcher (6)
- KEV catalogue (3)
- VulnCheck KEV (4)
- Core triage integration (6)
- Text formatting (5)
- Strands handler (4)
- CLI subcommand (5)
- Edge cases (4)
- NVD rate limiting (2)

**Total test suite: 1236 passed, 0 failures** (baseline 1158 + 78 new)

## Open PRs checked (no overlap)

Checked all 100+ open PRs (#80–#190). Closest but distinct:
- #179 (watchlist — persistent tracking, not ad-hoc triage)
- #186 (temporal-priority — single CVE, not batch)
- #170 (cve-enrich — single CVE enrichment)\n- #48 merged (compare — exactly 2 CVEs)
- #183 (export_sarif — output format, not scoring)
- #87 (risk-score — contextual scoring, not batch list prioritization)

None cover stateless batch CVE triage with ranked output.
