### PR TITLE
feat(tools): get_cve_timeline — CVE lifecycle event timeline reconstructor + CLI subcommand (+59 tests)

### DIFF
--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "cve-timeline",
 }
 
 
@@ -2050,6 +2051,82 @@ def _build_run_parser() -> argparse.ArgumentParser:
     return parser
 
 
+# ---------------------------------------------------------------------------
+# cve-timeline subcommand
+# ---------------------------------------------------------------------------
+
+
+def _build_cve_timeline_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="manus-agent cve-timeline",
+        description=(
+            "Reconstruct the full event timeline for a CVE: NVD publish date \u2192 \n"
+            "EPSS history \u2192 CISA KEV add date \u2192 GitHub advisory dates.\n"
+            "Useful for understanding how quickly a vulnerability was weaponised and fixed."
+        ),
+        add_help=True,
+    )
+    p.add_argument("cve_id", metavar="CVE-ID", help="CVE identifier, e.g. CVE-2021-44228")
+    p.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    return p
+
+
+def _run_cve_timeline(argv: list[str]) -> int:
+    parser = _build_cve_timeline_parser()
+    args = parser.parse_args(argv)
+    cve_id = args.cve_id.strip()
+    if not cve_id:
+        parser.error("CVE-ID is required")
+
+    try:
+        from manus_agent.tools.get_cve_timeline import build_timeline
+    except ImportError as exc:  # pragma: no cover
+        print(f"[error] missing dependencies: {exc}", file=sys.stderr)
+        return 1
+
+    try:
+        result = build_timeline(cve_id)
+    except Exception as exc:
+        print(f"[error] Timeline assembly failed: {exc}", file=sys.stderr)
+        return 1
+
+    if not result["events"]:
+        print(f"[warning] No timeline events found for {cve_id.upper()}", file=sys.stderr)
+        return 1
+
+    if args.output == "json":
+        import json
+
+        print(json.dumps(result, indent=2))
+        return 0
+
+    # Text output
+    print(f"CVE Timeline: {result['cve_id']}")
+    print(f"Sources queried: {', '.join(result['sources_queried'])}")
+    print(f"Sources with data: {', '.join(result['sources_with_data'])}")
+    if result["span_days"] is not None:
+        print(f"Timeline span: {result['span_days']} days")
+    print()
+    print(f"{'Date':<12} {'Source':<18} {'Event':<28} Detail")
+    print(f"{'─' * 12} {'─' * 18} {'─' * 28} {'─' * 50}")
+    for ev in result["events"]:
+        date_str = ev.get("date", "unknown")
+        source = ev.get("source", "")
+        event_name = ev.get("event", "")
+        detail = ev.get("detail", "")
+        # Truncate detail for text display
+        if len(detail) > 80:
+            detail = detail[:77] + "..."
+        print(f"{date_str:<12} {source:<18} {event_name:<28} {detail}")
+
+    return 0
+
+
 def _build_init_parser() -> argparse.ArgumentParser:
     """Build the `init` subcommand parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2345,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "cve-timeline":
+        idx = argv.index("cve-timeline")
+        sys.exit(_run_cve_timeline(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/get_cve_timeline.py
+++ b/src/manus_agent/tools/get_cve_timeline.py
@@ -1,0 +1,477 @@
+"""
+Tool for reconstructing the full event timeline of a CVE.
+
+Assembles chronological lifecycle events from multiple sources:
+- NVD (published, last modified dates, CVSS assignment)
+- EPSS (first score appearance, current score)
+- CISA KEV (date added to Known Exploited Vulnerabilities catalog)
+- GitHub Advisory Database (advisory publish/update dates)
+- VulnCheck KEV (additional exploitation context)
+
+Useful for understanding how quickly a vulnerability was weaponised and fixed,
+and for communicating risk timelines to stakeholders.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+from strands.types.tools import ToolResult, ToolUse
+
+from manus_agent.tools.tool_output_logger import log_tool_output_size
+
+# ---------------------------------------------------------------------------
+# Retry / back-off constants
+# ---------------------------------------------------------------------------
+_MAX_RETRIES = int(os.environ.get("CVE_TIMELINE_MAX_RETRIES", "3"))
+_RETRY_BASE_DELAY = float(os.environ.get("CVE_TIMELINE_RETRY_BASE_DELAY", "2"))
+_RETRYABLE_STATUS = {429, 500, 502, 503, 504}
+
+TOOL_SPEC = {
+    "name": "get_cve_timeline",
+    "description": (
+        "Reconstructs the full event timeline for a CVE by querying multiple "
+        "sources: NVD publish/modify dates, EPSS first-seen score, CISA KEV "
+        "addition date, and GitHub advisory dates. Returns a chronological list "
+        "of events that shows how quickly a vulnerability was disclosed, scored, "
+        "weaponised, and (if applicable) added to mandatory-patch catalogs. "
+        "Use after get_nvd_data for a temporal view of vulnerability lifecycle."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "cve_id": {
+                    "type": "string",
+                    "description": "The CVE identifier (e.g., 'CVE-2021-44228').",
+                },
+            },
+            "required": ["cve_id"],
+        }
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# HTTP helper with retry
+# ---------------------------------------------------------------------------
+
+
+def _get_with_retry(
+    url: str,
+    *,
+    headers: dict[str, str] | None = None,
+    params: dict[str, Any] | None = None,
+    timeout: int = 20,
+) -> requests.Response:
+    """GET with exponential back-off retry on transient errors."""
+    last_exc: Exception | None = None
+    for attempt in range(_MAX_RETRIES):
+        if attempt > 0:
+            time.sleep(_RETRY_BASE_DELAY * (2 ** (attempt - 1)))
+        try:
+            resp = requests.get(url, headers=headers, params=params, timeout=timeout)
+            if resp.status_code in _RETRYABLE_STATUS and attempt < _MAX_RETRIES - 1:
+                last_exc = requests.exceptions.HTTPError(response=resp)
+                continue
+            resp.raise_for_status()
+            return resp
+        except requests.exceptions.RequestException as exc:
+            last_exc = exc
+            if attempt >= _MAX_RETRIES - 1:
+                break
+    raise last_exc  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Source fetchers — each returns a list of event dicts
+# ---------------------------------------------------------------------------
+
+
+def _fetch_nvd_events(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch NVD published/modified dates and CVSS info."""
+    events: list[dict[str, Any]] = []
+    headers: dict[str, str] = {}
+    api_key = os.environ.get("NVD_API_KEY", "").strip()
+    if api_key:
+        headers["apiKey"] = api_key
+
+    try:
+        resp = _get_with_retry(
+            "https://services.nvd.nist.gov/rest/json/cves/2.0",
+            headers=headers,
+            params={"cveId": cve_id.upper()},
+            timeout=20,
+        )
+        data = resp.json()
+    except Exception:
+        return events
+
+    vulnerabilities = data.get("vulnerabilities", [])
+    if not vulnerabilities:
+        return events
+
+    cve_data = vulnerabilities[0].get("cve", {})
+
+    # Published date
+    published = cve_data.get("published", "")
+    if published:
+        events.append(
+            {
+                "date": published[:10],
+                "timestamp": published,
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": f"{cve_id.upper()} record created in NVD",
+            }
+        )
+
+    # Last modified date (only if different from published)
+    last_modified = cve_data.get("lastModified", "")
+    if last_modified and last_modified[:10] != published[:10]:
+        events.append(
+            {
+                "date": last_modified[:10],
+                "timestamp": last_modified,
+                "source": "NVD",
+                "event": "NVD record updated",
+                "detail": "NVD entry last modified (re-analysis, score change, or reference update)",
+            }
+        )
+
+    # CVSS score assignment
+    metrics = cve_data.get("metrics", {})
+    cvss_score = None
+    cvss_version = None
+    # Try CVSS 3.1, then 3.0, then 2.0
+    for version_key, ver_label in [
+        ("cvssMetricV31", "3.1"),
+        ("cvssMetricV30", "3.0"),
+        ("cvssMetricV2", "2.0"),
+    ]:
+        metric_list = metrics.get(version_key, [])
+        if metric_list:
+            cvss_data = metric_list[0].get("cvssData", {})
+            cvss_score = cvss_data.get("baseScore")
+            cvss_version = ver_label
+            severity = cvss_data.get("baseSeverity", "")
+            if cvss_score and published:
+                events.append(
+                    {
+                        "date": published[:10],
+                        "timestamp": published,
+                        "source": "NVD",
+                        "event": f"CVSS {cvss_version} assigned",
+                        "detail": f"Base score: {cvss_score} ({severity})",
+                    }
+                )
+            break
+
+    return events
+
+
+def _fetch_epss_events(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch EPSS first-seen date and current score."""
+    events: list[dict[str, Any]] = []
+    try:
+        resp = _get_with_retry(
+            "https://api.first.org/data/v1/epss",
+            params={"cve": cve_id.upper(), "scope": "time-series"},
+            timeout=20,
+        )
+        data = resp.json()
+    except Exception:
+        return events
+
+    entries = data.get("data", [])
+    if not entries:
+        return events
+
+    entry = entries[0]
+    time_series = entry.get("time-series", [])
+
+    if time_series:
+        # Sort by date to find earliest
+        sorted_series = sorted(time_series, key=lambda x: x.get("date", ""))
+        earliest = sorted_series[0]
+        latest = sorted_series[-1]
+
+        events.append(
+            {
+                "date": earliest["date"],
+                "timestamp": earliest["date"] + "T00:00:00Z",
+                "source": "EPSS",
+                "event": "EPSS tracking started",
+                "detail": f"First EPSS score: {float(earliest.get('epss', 0)):.4f} "
+                f"(percentile: {float(earliest.get('percentile', 0)):.2%})",
+            }
+        )
+
+        # Current/latest score
+        current_epss = float(entry.get("epss", latest.get("epss", 0)))
+        current_percentile = float(entry.get("percentile", latest.get("percentile", 0)))
+        current_date = entry.get("date", latest.get("date", ""))
+        if current_date and current_date != earliest["date"]:
+            events.append(
+                {
+                    "date": current_date,
+                    "timestamp": current_date + "T00:00:00Z",
+                    "source": "EPSS",
+                    "event": "EPSS current score",
+                    "detail": f"Score: {current_epss:.4f} (percentile: {current_percentile:.2%})",
+                }
+            )
+
+    return events
+
+
+def _fetch_kev_events(cve_id: str) -> list[dict[str, Any]]:
+    """Check CISA KEV catalog for the CVE's addition date."""
+    events: list[dict[str, Any]] = []
+    try:
+        resp = _get_with_retry(
+            "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json",
+            timeout=20,
+        )
+        data = resp.json()
+    except Exception:
+        return events
+
+    cve_upper = cve_id.upper()
+    for vuln in data.get("vulnerabilities", []):
+        if vuln.get("cveID", "").upper() == cve_upper:
+            date_added = vuln.get("dateAdded", "")
+            due_date = vuln.get("dueDate", "")
+            short_desc = vuln.get("shortDescription", "")
+            if date_added:
+                detail = "Added to CISA Known Exploited Vulnerabilities catalog"
+                if short_desc:
+                    detail += f" — {short_desc[:120]}"
+                events.append(
+                    {
+                        "date": date_added,
+                        "timestamp": date_added + "T00:00:00Z",
+                        "source": "CISA KEV",
+                        "event": "Added to CISA KEV",
+                        "detail": detail,
+                    }
+                )
+            if due_date:
+                events.append(
+                    {
+                        "date": due_date,
+                        "timestamp": due_date + "T00:00:00Z",
+                        "source": "CISA KEV",
+                        "event": "KEV remediation deadline",
+                        "detail": f"Federal agencies must remediate by {due_date}",
+                    }
+                )
+            break
+
+    return events
+
+
+def _fetch_github_advisory_events(cve_id: str) -> list[dict[str, Any]]:
+    """Query GitHub Advisory Database for advisory publish/update dates."""
+    events: list[dict[str, Any]] = []
+    github_token = os.environ.get("GITHUB_TOKEN", "").strip()
+
+    # Use the REST API search endpoint (no auth required, but token helps rate limits)
+    headers: dict[str, str] = {"Accept": "application/vnd.github+json"}
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    try:
+        resp = _get_with_retry(
+            "https://api.github.com/advisories",
+            headers=headers,
+            params={"cve_id": cve_id.upper(), "per_page": "5"},
+            timeout=20,
+        )
+        advisories = resp.json()
+    except Exception:
+        return events
+
+    if not isinstance(advisories, list) or not advisories:
+        return events
+
+    advisory = advisories[0]
+    ghsa_id = advisory.get("ghsa_id", "")
+    published_at = advisory.get("published_at", "")
+    updated_at = advisory.get("updated_at", "")
+    severity = advisory.get("severity", "")
+
+    if published_at:
+        detail = f"GitHub Security Advisory {ghsa_id} published"
+        if severity:
+            detail += f" (severity: {severity})"
+        events.append(
+            {
+                "date": published_at[:10],
+                "timestamp": published_at,
+                "source": "GitHub Advisory",
+                "event": "GHSA published",
+                "detail": detail,
+            }
+        )
+
+    if updated_at and updated_at[:10] != published_at[:10]:
+        events.append(
+            {
+                "date": updated_at[:10],
+                "timestamp": updated_at,
+                "source": "GitHub Advisory",
+                "event": "GHSA updated",
+                "detail": f"Advisory {ghsa_id} last updated",
+            }
+        )
+
+    return events
+
+
+def _fetch_vulncheck_kev_events(cve_id: str) -> list[dict[str, Any]]:
+    """Fetch VulnCheck KEV data for additional exploitation context."""
+    events: list[dict[str, Any]] = []
+    api_key = os.environ.get("VULNCHECK_API_KEY", "").strip()
+    if not api_key:
+        return events
+
+    headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
+    try:
+        resp = _get_with_retry(
+            "https://api.vulncheck.com/v3/index/vulncheck-kev",
+            headers=headers,
+            params={"cve": cve_id.upper()},
+            timeout=20,
+        )
+        data = resp.json()
+    except Exception:
+        return events
+
+    entries = data.get("data", [])
+    if not entries:
+        return events
+
+    entry = entries[0]
+    date_added = entry.get("date_added", "")
+    if date_added:
+        events.append(
+            {
+                "date": date_added[:10],
+                "timestamp": date_added if "T" in date_added else date_added + "T00:00:00Z",
+                "source": "VulnCheck KEV",
+                "event": "VulnCheck KEV entry",
+                "detail": "Confirmed exploitation tracked by VulnCheck",
+            }
+        )
+
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Main assembly logic
+# ---------------------------------------------------------------------------
+
+
+def build_timeline(cve_id: str) -> dict[str, Any]:
+    """
+    Assemble a chronological timeline for the given CVE from all available sources.
+
+    Returns a dict with:
+      - cve_id: normalised CVE ID
+      - events: sorted list of event dicts (date, source, event, detail)
+      - sources_queried: list of source names attempted
+      - sources_with_data: list of sources that returned events
+      - span_days: days between earliest and latest event (or None)
+    """
+    cve_id = cve_id.strip().upper()
+    all_events: list[dict[str, Any]] = []
+    sources_with_data: list[str] = []
+
+    # Fetch from each source
+    source_fetchers = [
+        ("NVD", _fetch_nvd_events),
+        ("EPSS", _fetch_epss_events),
+        ("CISA KEV", _fetch_kev_events),
+        ("GitHub Advisory", _fetch_github_advisory_events),
+        ("VulnCheck KEV", _fetch_vulncheck_kev_events),
+    ]
+
+    sources_queried = [name for name, _ in source_fetchers]
+
+    for source_name, fetcher in source_fetchers:
+        events = fetcher(cve_id)
+        if events:
+            sources_with_data.append(source_name)
+            all_events.extend(events)
+
+    # Sort events chronologically by date (then by source for ties)
+    source_priority = {
+        "NVD": 0,
+        "EPSS": 1,
+        "CISA KEV": 2,
+        "GitHub Advisory": 3,
+        "VulnCheck KEV": 4,
+    }
+    all_events.sort(key=lambda e: (e.get("date", "9999-99-99"), source_priority.get(e.get("source", ""), 99)))
+
+    # Calculate span
+    span_days: int | None = None
+    if len(all_events) >= 2:
+        try:
+            earliest = datetime.strptime(all_events[0]["date"], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            latest = datetime.strptime(all_events[-1]["date"], "%Y-%m-%d").replace(tzinfo=timezone.utc)
+            span_days = (latest - earliest).days
+        except (ValueError, KeyError):
+            pass
+
+    return {
+        "cve_id": cve_id,
+        "events": all_events,
+        "sources_queried": sources_queried,
+        "sources_with_data": sources_with_data,
+        "span_days": span_days,
+        "event_count": len(all_events),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool handler
+# ---------------------------------------------------------------------------
+
+
+def handler(tool: ToolUse, **kwargs: Any) -> ToolResult:
+    """Strands SDK tool handler for get_cve_timeline."""
+    tool_input = tool["input"]
+    cve_id = tool_input.get("cve_id", "").strip()
+
+    if not cve_id:
+        return {
+            "toolUseId": tool["toolUseId"],
+            "status": "error",
+            "content": [{"text": "cve_id is required"}],
+        }
+
+    try:
+        result = build_timeline(cve_id)
+    except Exception as exc:
+        return {
+            "toolUseId": tool["toolUseId"],
+            "status": "error",
+            "content": [{"text": f"Timeline assembly failed: {exc}"}],
+        }
+
+    import json
+
+    output_text = json.dumps(result, indent=2)
+    log_tool_output_size("get_cve_timeline", output_text)
+
+    return {
+        "toolUseId": tool["toolUseId"],
+        "status": "success",
+        "content": [{"text": output_text}],
+    }

--- a/tests/test_cve_timeline.py
+++ b/tests/test_cve_timeline.py
@@ -1,0 +1,1128 @@
+"""Comprehensive test suite for get_cve_timeline tool and CLI subcommand."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.get_cve_timeline import (
+    _fetch_epss_events,
+    _fetch_github_advisory_events,
+    _fetch_kev_events,
+    _fetch_nvd_events,
+    _fetch_vulncheck_kev_events,
+    _get_with_retry,
+    build_timeline,
+    handler,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+CVE_ID = "CVE-2021-44228"
+
+
+@pytest.fixture
+def nvd_response():
+    """Minimal NVD API response for Log4Shell."""
+    return {
+        "vulnerabilities": [
+            {
+                "cve": {
+                    "id": CVE_ID,
+                    "published": "2021-12-10T10:15:00.000",
+                    "lastModified": "2023-11-07T03:38:00.000",
+                    "metrics": {
+                        "cvssMetricV31": [
+                            {
+                                "cvssData": {
+                                    "baseScore": 10.0,
+                                    "baseSeverity": "CRITICAL",
+                                }
+                            }
+                        ]
+                    },
+                }
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def epss_response():
+    """Minimal EPSS time-series response."""
+    return {
+        "data": [
+            {
+                "cve": CVE_ID,
+                "epss": "0.97547",
+                "percentile": "0.99998",
+                "date": "2024-06-15",
+                "time-series": [
+                    {"date": "2022-01-01", "epss": "0.85000", "percentile": "0.98000"},
+                    {"date": "2022-06-01", "epss": "0.92000", "percentile": "0.99000"},
+                    {"date": "2024-06-15", "epss": "0.97547", "percentile": "0.99998"},
+                ],
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def kev_response():
+    """Minimal CISA KEV response containing the CVE."""
+    return {
+        "vulnerabilities": [
+            {
+                "cveID": CVE_ID,
+                "dateAdded": "2021-12-10",
+                "dueDate": "2021-12-24",
+                "shortDescription": "Apache Log4j2 Remote Code Execution Vulnerability",
+            },
+            {
+                "cveID": "CVE-2022-9999",
+                "dateAdded": "2022-05-01",
+                "dueDate": "2022-05-15",
+                "shortDescription": "Other vulnerability",
+            },
+        ]
+    }
+
+
+@pytest.fixture
+def github_advisory_response():
+    """Minimal GitHub advisory response."""
+    return [
+        {
+            "ghsa_id": "GHSA-jfh8-c2jp-5v3q",
+            "published_at": "2021-12-10T00:00:00Z",
+            "updated_at": "2024-01-15T12:00:00Z",
+            "severity": "critical",
+        }
+    ]
+
+
+@pytest.fixture
+def vulncheck_kev_response():
+    """Minimal VulnCheck KEV response."""
+    return {
+        "data": [
+            {
+                "cve": CVE_ID,
+                "date_added": "2021-12-11T00:00:00Z",
+            }
+        ]
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: _get_with_retry
+# ---------------------------------------------------------------------------
+
+
+class TestGetWithRetry:
+    """Tests for the HTTP retry helper."""
+
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_success_first_attempt(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = _get_with_retry("https://example.com/api")
+        assert result == mock_resp
+        assert mock_get.call_count == 1
+
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_retry_on_429(self, mock_get, mock_sleep):
+        fail_resp = MagicMock()
+        fail_resp.status_code = 429
+        fail_resp.raise_for_status = MagicMock(side_effect=Exception("Rate limited"))
+
+        ok_resp = MagicMock()
+        ok_resp.status_code = 200
+        ok_resp.raise_for_status = MagicMock()
+
+        mock_get.side_effect = [fail_resp, ok_resp]
+        result = _get_with_retry("https://example.com/api")
+        assert result == ok_resp
+        assert mock_get.call_count == 2
+        mock_sleep.assert_called_once()
+
+    @patch("manus_agent.tools.get_cve_timeline._MAX_RETRIES", 2)
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_all_retries_exhausted_raises(self, mock_get, mock_sleep):
+        import requests as req
+
+        fail_resp = MagicMock()
+        fail_resp.status_code = 503
+        mock_get.return_value = fail_resp
+        fail_resp.raise_for_status.side_effect = req.exceptions.HTTPError(response=fail_resp)
+
+        with pytest.raises(req.exceptions.HTTPError):
+            _get_with_retry("https://example.com/api")
+        assert mock_get.call_count == 2
+
+    @patch("manus_agent.tools.get_cve_timeline._MAX_RETRIES", 2)
+    @patch("manus_agent.tools.get_cve_timeline.time.sleep")
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_connection_error_retries(self, mock_get, mock_sleep):
+        import requests as req
+
+        mock_get.side_effect = req.exceptions.ConnectionError("timeout")
+
+        with pytest.raises(req.exceptions.ConnectionError):
+            _get_with_retry("https://example.com/api")
+        assert mock_get.call_count == 2
+
+    @patch("manus_agent.tools.get_cve_timeline.requests.get")
+    def test_custom_headers_and_params(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        _get_with_retry(
+            "https://example.com/api",
+            headers={"X-Custom": "test"},
+            params={"q": "value"},
+            timeout=30,
+        )
+        mock_get.assert_called_once_with(
+            "https://example.com/api",
+            headers={"X-Custom": "test"},
+            params={"q": "value"},
+            timeout=30,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_nvd_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchNvdEvents:
+    """Tests for NVD event fetcher."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_full_nvd_response(self, mock_get, nvd_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = nvd_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events(CVE_ID)
+        assert len(events) == 3  # published, modified, CVSS
+        assert events[0]["event"] == "CVE published"
+        assert events[0]["date"] == "2021-12-10"
+        assert events[0]["source"] == "NVD"
+        assert events[1]["event"] == "NVD record updated"
+        assert events[1]["date"] == "2023-11-07"
+        assert events[2]["event"] == "CVSS 3.1 assigned"
+        assert "10.0" in events[2]["detail"]
+        assert "CRITICAL" in events[2]["detail"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_published_only_no_modified_dup(self, mock_get):
+        """When lastModified == published date, skip duplicate."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": CVE_ID,
+                        "published": "2021-12-10T10:15:00.000",
+                        "lastModified": "2021-12-10T10:15:00.000",
+                        "metrics": {},
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["event"] == "CVE published"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_no_vulnerabilities(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("Network error")
+        events = _fetch_nvd_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_cvss_v2_fallback(self, mock_get):
+        """Falls back to CVSS 2.0 when 3.x not available."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": CVE_ID,
+                        "published": "2015-01-01T00:00:00.000",
+                        "lastModified": "2015-01-01T00:00:00.000",
+                        "metrics": {
+                            "cvssMetricV2": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 7.5,
+                                        "baseSeverity": "HIGH",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events(CVE_ID)
+        cvss_events = [e for e in events if "CVSS" in e["event"]]
+        assert len(cvss_events) == 1
+        assert "2.0" in cvss_events[0]["event"]
+        assert "7.5" in cvss_events[0]["detail"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"NVD_API_KEY": "test-key-123"})
+    def test_nvd_uses_api_key(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        _fetch_nvd_events(CVE_ID)
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs["headers"]["apiKey"] == "test-key-123"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_nvd_no_api_key(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"vulnerabilities": []}
+        mock_get.return_value = mock_resp
+
+        _fetch_nvd_events(CVE_ID)
+        call_kwargs = mock_get.call_args[1]
+        assert "apiKey" not in call_kwargs.get("headers", {})
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_epss_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchEpssEvents:
+    """Tests for EPSS event fetcher."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_full_epss_response(self, mock_get, epss_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = epss_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events(CVE_ID)
+        assert len(events) == 2  # first seen + current
+        assert events[0]["event"] == "EPSS tracking started"
+        assert events[0]["date"] == "2022-01-01"
+        assert "0.8500" in events[0]["detail"]
+        assert events[1]["event"] == "EPSS current score"
+        assert events[1]["date"] == "2024-06-15"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_epss_single_datapoint(self, mock_get):
+        """Single data point means only first-seen, no current."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "cve": CVE_ID,
+                    "epss": "0.50000",
+                    "percentile": "0.90000",
+                    "date": "2024-01-01",
+                    "time-series": [
+                        {"date": "2024-01-01", "epss": "0.50000", "percentile": "0.90000"},
+                    ],
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["event"] == "EPSS tracking started"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_epss_no_data(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_epss_empty_time_series(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "data": [
+                {
+                    "cve": CVE_ID,
+                    "epss": "0.5",
+                    "percentile": "0.9",
+                    "date": "2024-01-01",
+                    "time-series": [],
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_epss_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_epss_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("Timeout")
+        events = _fetch_epss_events(CVE_ID)
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_kev_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchKevEvents:
+    """Tests for CISA KEV event fetcher."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_cve_in_kev(self, mock_get, kev_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = kev_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_events(CVE_ID)
+        assert len(events) == 2  # dateAdded + dueDate
+        assert events[0]["event"] == "Added to CISA KEV"
+        assert events[0]["date"] == "2021-12-10"
+        assert "Apache Log4j2" in events[0]["detail"]
+        assert events[1]["event"] == "KEV remediation deadline"
+        assert events[1]["date"] == "2021-12-24"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_cve_not_in_kev(self, mock_get, kev_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = kev_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_events("CVE-2099-0001")
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_kev_case_insensitive_match(self, mock_get, kev_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = kev_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_events("cve-2021-44228")
+        assert len(events) == 2
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_kev_no_due_date(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cveID": CVE_ID,
+                    "dateAdded": "2021-12-10",
+                    "dueDate": "",
+                    "shortDescription": "Test",
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["event"] == "Added to CISA KEV"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_kev_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("Connection refused")
+        events = _fetch_kev_events(CVE_ID)
+        assert events == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_github_advisory_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchGitHubAdvisoryEvents:
+    """Tests for GitHub advisory event fetcher."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_full_advisory(self, mock_get, github_advisory_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = github_advisory_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_events(CVE_ID)
+        assert len(events) == 2  # published + updated
+        assert events[0]["event"] == "GHSA published"
+        assert events[0]["date"] == "2021-12-10"
+        assert "GHSA-jfh8-c2jp-5v3q" in events[0]["detail"]
+        assert "critical" in events[0]["detail"]
+        assert events[1]["event"] == "GHSA updated"
+        assert events[1]["date"] == "2024-01-15"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_advisory_same_publish_update_date(self, mock_get):
+        """No duplicate event when published_at == updated_at."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = [
+            {
+                "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+                "published_at": "2024-01-01T00:00:00Z",
+                "updated_at": "2024-01-01T12:00:00Z",
+                "severity": "high",
+            }
+        ]
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["event"] == "GHSA published"
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_no_advisories(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_advisory_not_a_list(self, mock_get):
+        """Handle unexpected response format gracefully."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"message": "Not Found"}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_github_advisory_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_advisory_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("403 Forbidden")
+        events = _fetch_github_advisory_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"GITHUB_TOKEN": "ghp_test123"})
+    def test_github_token_sent_in_header(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        _fetch_github_advisory_events(CVE_ID)
+        call_kwargs = mock_get.call_args[1]
+        assert "Bearer ghp_test123" in call_kwargs["headers"]["Authorization"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {}, clear=True)
+    def test_no_github_token(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = []
+        mock_get.return_value = mock_resp
+
+        _fetch_github_advisory_events(CVE_ID)
+        call_kwargs = mock_get.call_args[1]
+        assert "Authorization" not in call_kwargs["headers"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: _fetch_vulncheck_kev_events
+# ---------------------------------------------------------------------------
+
+
+class TestFetchVulnCheckKevEvents:
+    """Tests for VulnCheck KEV event fetcher."""
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    def test_vulncheck_with_data(self, mock_get, vulncheck_kev_response):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = vulncheck_kev_response
+        mock_get.return_value = mock_resp
+
+        events = _fetch_vulncheck_kev_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["event"] == "VulnCheck KEV entry"
+        assert events[0]["date"] == "2021-12-11"
+        assert events[0]["source"] == "VulnCheck KEV"
+
+    @patch.dict("os.environ", {}, clear=True)
+    def test_vulncheck_no_api_key_returns_empty(self):
+        events = _fetch_vulncheck_kev_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    def test_vulncheck_no_data(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": []}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_vulncheck_kev_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    def test_vulncheck_api_failure_returns_empty(self, mock_get):
+        mock_get.side_effect = Exception("Timeout")
+        events = _fetch_vulncheck_kev_events(CVE_ID)
+        assert events == []
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    @patch.dict("os.environ", {"VULNCHECK_API_KEY": "vc-test-key"})
+    def test_vulncheck_date_without_time_suffix(self, mock_get):
+        """date_added without T is handled."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"data": [{"cve": CVE_ID, "date_added": "2022-03-15"}]}
+        mock_get.return_value = mock_resp
+
+        events = _fetch_vulncheck_kev_events(CVE_ID)
+        assert len(events) == 1
+        assert events[0]["date"] == "2022-03-15"
+        assert "T00:00:00Z" in events[0]["timestamp"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_timeline (integration)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTimeline:
+    """Tests for the main timeline assembly function."""
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_full_timeline_assembly(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = [
+            {
+                "date": "2021-12-10",
+                "timestamp": "2021-12-10T10:15:00Z",
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": "test",
+            }
+        ]
+        mock_epss.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "EPSS",
+                "event": "EPSS tracking started",
+                "detail": "test",
+            }
+        ]
+        mock_kev.return_value = [
+            {
+                "date": "2021-12-10",
+                "timestamp": "2021-12-10T00:00:00Z",
+                "source": "CISA KEV",
+                "event": "Added to CISA KEV",
+                "detail": "test",
+            }
+        ]
+        mock_gh.return_value = [
+            {
+                "date": "2021-12-10",
+                "timestamp": "2021-12-10T00:00:00Z",
+                "source": "GitHub Advisory",
+                "event": "GHSA published",
+                "detail": "test",
+            }
+        ]
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        assert result["cve_id"] == CVE_ID
+        assert result["event_count"] == 4
+        assert len(result["events"]) == 4
+        assert "NVD" in result["sources_with_data"]
+        assert "EPSS" in result["sources_with_data"]
+        assert "CISA KEV" in result["sources_with_data"]
+        assert "GitHub Advisory" in result["sources_with_data"]
+        assert "VulnCheck KEV" not in result["sources_with_data"]
+        assert result["sources_queried"] == ["NVD", "EPSS", "CISA KEV", "GitHub Advisory", "VulnCheck KEV"]
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_events_sorted_chronologically(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = [
+            {
+                "date": "2022-03-01",
+                "timestamp": "2022-03-01T00:00:00Z",
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": "",
+            }
+        ]
+        mock_epss.return_value = [
+            {
+                "date": "2022-04-01",
+                "timestamp": "2022-04-01T00:00:00Z",
+                "source": "EPSS",
+                "event": "EPSS tracking started",
+                "detail": "",
+            }
+        ]
+        mock_kev.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "CISA KEV",
+                "event": "Added to CISA KEV",
+                "detail": "",
+            }
+        ]
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        dates = [e["date"] for e in result["events"]]
+        assert dates == sorted(dates)
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_same_date_sorted_by_source_priority(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        """Events on the same date are ordered by source priority."""
+        mock_nvd.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": "",
+            }
+        ]
+        mock_epss.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "EPSS",
+                "event": "EPSS tracking started",
+                "detail": "",
+            }
+        ]
+        mock_kev.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "CISA KEV",
+                "event": "Added to CISA KEV",
+                "detail": "",
+            }
+        ]
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        sources = [e["source"] for e in result["events"]]
+        assert sources == ["NVD", "EPSS", "CISA KEV"]
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_span_days_calculation(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = [
+            {"date": "2022-01-01", "timestamp": "", "source": "NVD", "event": "CVE published", "detail": ""}
+        ]
+        mock_epss.return_value = [
+            {"date": "2022-01-31", "timestamp": "", "source": "EPSS", "event": "EPSS tracking started", "detail": ""}
+        ]
+        mock_kev.return_value = []
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        assert result["span_days"] == 30
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_no_events_returns_empty(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = []
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        assert result["events"] == []
+        assert result["event_count"] == 0
+        assert result["span_days"] is None
+        assert result["sources_with_data"] == []
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_cve_id_normalised_to_uppercase(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = []
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline("  cve-2021-44228  ")
+        assert result["cve_id"] == "CVE-2021-44228"
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_single_event_span_is_none(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = [
+            {"date": "2022-01-01", "timestamp": "", "source": "NVD", "event": "CVE published", "detail": ""}
+        ]
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        assert result["span_days"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: handler (Strands tool interface)
+# ---------------------------------------------------------------------------
+
+
+class TestHandler:
+    """Tests for the Strands SDK tool handler."""
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_handler_success(self, mock_build):
+        mock_build.return_value = {
+            "cve_id": CVE_ID,
+            "events": [{"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test"}],
+            "sources_queried": ["NVD"],
+            "sources_with_data": ["NVD"],
+            "span_days": None,
+            "event_count": 1,
+        }
+
+        tool_use = {"toolUseId": "test-123", "input": {"cve_id": CVE_ID}}
+        result = handler(tool_use)
+        assert result["status"] == "success"
+        assert result["toolUseId"] == "test-123"
+        content_text = result["content"][0]["text"]
+        parsed = json.loads(content_text)
+        assert parsed["cve_id"] == CVE_ID
+        assert len(parsed["events"]) == 1
+
+    def test_handler_missing_cve_id(self):
+        tool_use = {"toolUseId": "test-456", "input": {"cve_id": ""}}
+        result = handler(tool_use)
+        assert result["status"] == "error"
+        assert "required" in result["content"][0]["text"]
+
+    def test_handler_no_cve_id_key(self):
+        tool_use = {"toolUseId": "test-789", "input": {}}
+        result = handler(tool_use)
+        assert result["status"] == "error"
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_handler_exception(self, mock_build):
+        mock_build.side_effect = RuntimeError("Something broke")
+        tool_use = {"toolUseId": "test-err", "input": {"cve_id": CVE_ID}}
+        result = handler(tool_use)
+        assert result["status"] == "error"
+        assert "Something broke" in result["content"][0]["text"]
+
+
+# ---------------------------------------------------------------------------
+# Tests: CLI subcommand (_run_cve_timeline)
+# ---------------------------------------------------------------------------
+
+
+class TestCLISubcommand:
+    """Tests for the cve-timeline CLI subcommand."""
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_cli_text_output(self, mock_build, capsys):
+        mock_build.return_value = {
+            "cve_id": CVE_ID,
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "Record created"},
+                {"date": "2022-01-01", "source": "EPSS", "event": "EPSS tracking started", "detail": "Score: 0.85"},
+            ],
+            "sources_queried": ["NVD", "EPSS", "CISA KEV", "GitHub Advisory", "VulnCheck KEV"],
+            "sources_with_data": ["NVD", "EPSS"],
+            "span_days": 22,
+            "event_count": 2,
+        }
+
+        from manus_agent.cli import _run_cve_timeline
+
+        exit_code = _run_cve_timeline([CVE_ID])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert CVE_ID in captured.out
+        assert "NVD" in captured.out
+        assert "EPSS" in captured.out
+        assert "22 days" in captured.out
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_cli_json_output(self, mock_build, capsys):
+        mock_build.return_value = {
+            "cve_id": CVE_ID,
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test"},
+            ],
+            "sources_queried": ["NVD"],
+            "sources_with_data": ["NVD"],
+            "span_days": None,
+            "event_count": 1,
+        }
+
+        from manus_agent.cli import _run_cve_timeline
+
+        exit_code = _run_cve_timeline([CVE_ID, "--output", "json"])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        parsed = json.loads(captured.out)
+        assert parsed["cve_id"] == CVE_ID
+        assert len(parsed["events"]) == 1
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_cli_no_events_returns_error(self, mock_build, capsys):
+        mock_build.return_value = {
+            "cve_id": CVE_ID,
+            "events": [],
+            "sources_queried": ["NVD"],
+            "sources_with_data": [],
+            "span_days": None,
+            "event_count": 0,
+        }
+
+        from manus_agent.cli import _run_cve_timeline
+
+        exit_code = _run_cve_timeline([CVE_ID])
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "No timeline events found" in captured.err
+
+    def test_cli_missing_cve_id_exits(self):
+        from manus_agent.cli import _run_cve_timeline
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_cve_timeline([])
+        assert exc_info.value.code == 2  # argparse error
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_cli_exception_returns_error(self, mock_build, capsys):
+        mock_build.side_effect = RuntimeError("Connection failed")
+
+        from manus_agent.cli import _run_cve_timeline
+
+        exit_code = _run_cve_timeline([CVE_ID])
+        assert exit_code == 1
+        captured = capsys.readouterr()
+        assert "Timeline assembly failed" in captured.err
+
+    @patch("manus_agent.tools.get_cve_timeline.build_timeline")
+    def test_cli_no_span_days(self, mock_build, capsys):
+        """When span_days is None, no span line is printed."""
+        mock_build.return_value = {
+            "cve_id": CVE_ID,
+            "events": [
+                {"date": "2021-12-10", "source": "NVD", "event": "CVE published", "detail": "test"},
+            ],
+            "sources_queried": ["NVD"],
+            "sources_with_data": ["NVD"],
+            "span_days": None,
+            "event_count": 1,
+        }
+
+        from manus_agent.cli import _run_cve_timeline
+
+        exit_code = _run_cve_timeline([CVE_ID])
+        assert exit_code == 0
+        captured = capsys.readouterr()
+        assert "Timeline span" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Tests: TOOL_SPEC structure
+# ---------------------------------------------------------------------------
+
+
+class TestToolSpec:
+    """Tests for the TOOL_SPEC definition."""
+
+    def test_tool_spec_name(self):
+        from manus_agent.tools.get_cve_timeline import TOOL_SPEC
+
+        assert TOOL_SPEC["name"] == "get_cve_timeline"
+
+    def test_tool_spec_has_description(self):
+        from manus_agent.tools.get_cve_timeline import TOOL_SPEC
+
+        assert len(TOOL_SPEC["description"]) > 50
+
+    def test_tool_spec_input_schema(self):
+        from manus_agent.tools.get_cve_timeline import TOOL_SPEC
+
+        schema = TOOL_SPEC["inputSchema"]["json"]
+        assert schema["type"] == "object"
+        assert "cve_id" in schema["properties"]
+        assert schema["required"] == ["cve_id"]
+
+    def test_tool_spec_cve_id_is_string(self):
+        from manus_agent.tools.get_cve_timeline import TOOL_SPEC
+
+        assert TOOL_SPEC["inputSchema"]["json"]["properties"]["cve_id"]["type"] == "string"
+
+
+# ---------------------------------------------------------------------------
+# Tests: Edge cases and integration details
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    """Additional edge case tests."""
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_partial_source_failure_still_returns_data(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        """Even if some sources fail, we still get data from working ones."""
+        mock_nvd.return_value = [
+            {"date": "2022-01-01", "timestamp": "", "source": "NVD", "event": "CVE published", "detail": ""}
+        ]
+        mock_epss.return_value = []  # failed or no data
+        mock_kev.return_value = []  # not in KEV
+        mock_gh.return_value = []  # no advisory
+        mock_vc.return_value = []  # no key
+
+        result = build_timeline(CVE_ID)
+        assert result["event_count"] == 1
+        assert result["sources_with_data"] == ["NVD"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_nvd_cvss_v30_when_v31_missing(self, mock_get):
+        """Uses CVSS 3.0 when 3.1 is unavailable."""
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cve": {
+                        "id": CVE_ID,
+                        "published": "2020-01-01T00:00:00.000",
+                        "lastModified": "2020-01-01T00:00:00.000",
+                        "metrics": {
+                            "cvssMetricV30": [
+                                {
+                                    "cvssData": {
+                                        "baseScore": 9.8,
+                                        "baseSeverity": "CRITICAL",
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_nvd_events(CVE_ID)
+        cvss_events = [e for e in events if "CVSS" in e["event"]]
+        assert len(cvss_events) == 1
+        assert "3.0" in cvss_events[0]["event"]
+
+    @patch("manus_agent.tools.get_cve_timeline._get_with_retry")
+    def test_kev_long_description_truncated_in_detail(self, mock_get):
+        """Long shortDescription is truncated."""
+        long_desc = "A" * 200
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {
+                    "cveID": CVE_ID,
+                    "dateAdded": "2022-01-01",
+                    "dueDate": "",
+                    "shortDescription": long_desc,
+                }
+            ]
+        }
+        mock_get.return_value = mock_resp
+
+        events = _fetch_kev_events(CVE_ID)
+        assert len(events) == 1
+        # shortDescription[:120] is used in detail
+        assert len(events[0]["detail"]) < 200
+
+    @patch("manus_agent.tools.get_cve_timeline._fetch_vulncheck_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_github_advisory_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_kev_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_epss_events")
+    @patch("manus_agent.tools.get_cve_timeline._fetch_nvd_events")
+    def test_events_contain_required_keys(self, mock_nvd, mock_epss, mock_kev, mock_gh, mock_vc):
+        mock_nvd.return_value = [
+            {
+                "date": "2022-01-01",
+                "timestamp": "2022-01-01T00:00:00Z",
+                "source": "NVD",
+                "event": "CVE published",
+                "detail": "test detail",
+            }
+        ]
+        mock_epss.return_value = []
+        mock_kev.return_value = []
+        mock_gh.return_value = []
+        mock_vc.return_value = []
+
+        result = build_timeline(CVE_ID)
+        for event in result["events"]:
+            assert "date" in event
+            assert "source" in event
+            assert "event" in event
+            assert "detail" in event
+            assert "timestamp" in event


### PR DESCRIPTION
## Summary

Implements the `get_cve_timeline` tool and `manus-agent cve-timeline` CLI subcommand — a **README-documented but completely unimplemented** feature that reconstructs the full chronological lifecycle of a CVE from multiple sources.

## What it does

Given a CVE ID, assembles a timeline of events from 5 sources:

| Source | Events extracted |
|--------|-----------------|
| **NVD** | Published date, last modified date, CVSS score assignment |
| **EPSS** | First tracking date + initial score, current score |
| **CISA KEV** | Date added to KEV catalog, remediation deadline |
| **GitHub Advisory** | GHSA published date, last updated date |
| **VulnCheck KEV** | Exploitation confirmation date |

Events are sorted chronologically with source-priority tiebreaking for same-day events. The output includes timeline span (days between first and last event), sources queried vs. sources with data, and graceful degradation when any source is unavailable.

## CLI Usage

```bash
# Text output (table format)
manus-agent cve-timeline CVE-2021-44228

# JSON output
manus-agent cve-timeline CVE-2021-44228 --output json
```

## Design

- **Zero new dependencies** — uses `requests` only (already a project dependency)
- **Retry/back-off** on all HTTP calls (configurable via env vars)
- **NVD_API_KEY** + **VULNCHECK_API_KEY** + **GITHUB_TOKEN** support
- **Graceful degradation** — each source fails independently; partial results still returned
- **Strands TOOL_SPEC interface** — integrates with the agent framework
- **59 fully mocked tests** — no real HTTP calls

## Test Results

```
1217 passed, 3 deselected, 3 warnings in 25.58s
```

(Baseline 1158 + 59 new tests, 0 failures)

## Files Changed

- `src/manus_agent/tools/get_cve_timeline.py` (new) — tool implementation
- `src/manus_agent/cli.py` — CLI dispatch + parser + `_SUBCOMMANDS` registration
- `tests/test_cve_timeline.py` (new) — 59 tests covering all source fetchers, retry logic, timeline assembly, CLI output, edge cases

## Duplicate Check

Checked all 50 open PRs (#142–#191) and 30 merged PRs. No existing PR covers CVE lifecycle timeline reconstruction. Closest PRs checked:
- #190 (exposure_window — time-to-patch calculation, not multi-source timeline)
- #186 (temporal_priority — single urgency score, not event chronology)
- #170 (cve-enrich — single-CVE enrichment dump, not temporal ordering)
- #45 (merged, epss-trend — EPSS history only, single source)
