### PR TITLE
feat(tools): dep_audit — dependency vulnerability auditor + CLI subcommand (+60 tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Built on [Strands SDK](https://github.com/strands-agents/sdk-python) and integra
   - [sbom-scan](#manus-agent-sbom-scan-bomfile--sbom-scanner)
   - [temporal-priority](#manus-agent-temporal-priority-cve-id--temporal-priority-scorer)
   - [cluster-variants](#manus-agent-cluster-variants-cve-id--cve-variant-clustering)
+  - [dep-audit](#manus-agent-dep-audit-directory--dependency-vulnerability-audit)
   - [changelog](#manus-agent-changelog--manage-project-changelog)
 - [Configuration](#configuration)
 - [Python API](#python-api)
@@ -341,6 +342,54 @@ Blast-radius labels per package:
 |------|---------|-------------|
 | `--max-packages N` | `10` | Max affected packages to enrich |
 | `--output {text,json}` | `text` | Output format |
+
+---
+
+### `manus-agent dep-audit [DIRECTORY]` — Dependency vulnerability audit
+
+```bash
+# Audit current directory
+manus-agent dep-audit
+
+# Audit a specific project
+manus-agent dep-audit /path/to/project
+
+# JSON output for CI pipelines
+manus-agent dep-audit . --output json
+
+# Fast mode (skip EPSS + KEV enrichment)
+manus-agent dep-audit . --skip-epss --skip-kev
+```
+
+Scans a project's dependency manifest files and queries OSV.dev in batch for known vulnerabilities. Unlike `sbom-scan` (which requires a pre-generated CycloneDX/SPDX file), `dep-audit` works directly from raw manifest files — no SBOM generation step needed.
+
+**Supported manifest files:**
+
+| File | Ecosystem |
+|------|-----------|
+| `requirements.txt` | PyPI |
+| `package.json` / `package-lock.json` | npm |
+| `go.mod` | Go |
+| `Cargo.toml` / `Cargo.lock` | crates.io |
+| `Gemfile.lock` | RubyGems |
+| `pom.xml` | Maven |
+| `composer.json` | Packagist |
+
+**Enrichment sources:**
+
+| Source | Data |
+|--------|------|
+| OSV.dev | Vulnerability IDs, affected ranges, fixed versions |
+| FIRST EPSS | Exploitation probability scores |
+| CISA KEV | Known exploited vulnerabilities catalog |
+
+Findings are sorted by severity: CISA KEV entries first, then by EPSS score descending.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output {text,json}` | `text` | Output format |
+| `--skip-epss` | off | Skip EPSS enrichment (faster) |
+| `--skip-kev` | off | Skip CISA KEV lookup (faster) |
 
 ---
 

--- a/src/manus_agent/cli.py
+++ b/src/manus_agent/cli.py
@@ -1057,6 +1057,7 @@ _SUBCOMMANDS = {
     "poc-search",
     "changelog",
     "blast-radius",
+    "dep-audit",
 }
 
 
@@ -1935,6 +1936,117 @@ def _run_blast_radius(argv: list[str]) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# dep-audit subcommand
+# ---------------------------------------------------------------------------
+
+
+def _run_dep_audit(argv: list[str]) -> int:
+    import json as _json
+
+    parser = argparse.ArgumentParser(
+        prog="manus-agent dep-audit",
+        description=(
+            "Audit project dependencies for known vulnerabilities.\n"
+            "Parses manifest files (requirements.txt, package.json, go.mod,\n"
+            "Cargo.lock, Gemfile.lock, pom.xml, composer.json) and queries\n"
+            "OSV.dev for known CVEs. Enriches with EPSS and CISA KEV status."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "directory",
+        nargs="?",
+        default=".",
+        help="Project directory containing manifest files (default: current dir)",
+    )
+    parser.add_argument(
+        "--output",
+        choices=["text", "json"],
+        default="text",
+        help="Output format (default: text)",
+    )
+    parser.add_argument(
+        "--skip-epss",
+        action="store_true",
+        help="Skip EPSS score enrichment for faster results",
+    )
+    parser.add_argument(
+        "--skip-kev",
+        action="store_true",
+        help="Skip CISA KEV lookup for faster results",
+    )
+
+    args = parser.parse_args(argv)
+
+    try:
+        from manus_agent.tools.dep_audit import audit_dependencies
+    except ImportError as exc:  # pragma: no cover
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    directory = args.directory
+    if not os.path.isdir(directory):
+        print(f"[error] Directory not found: {directory!r}", file=sys.stderr)
+        return 1
+
+    result = audit_dependencies(
+        directory,
+        skip_epss=args.skip_epss,
+        skip_kev=args.skip_kev,
+    )
+
+    if args.output == "json":
+        print(_json.dumps(result, indent=2))
+        return 0
+
+    # Text output
+    if result["status"] == "no_manifests":
+        print(f"No supported manifest files found in {directory}")
+        print(f"Supported: {', '.join(result.get('supported_files', []))}")
+        return 1
+
+    summary = result["summary"]
+    findings = result["findings"]
+
+    print(f"\n{'='*60}")
+    print(f"  Dependency Audit Report")
+    print(f"{'='*60}")
+    print(f"  Directory:      {result['directory']}")
+    print(f"  Manifests:      {', '.join(result['manifests_parsed'])}")
+    print(f"  Packages:       {summary['total_packages']}")
+    print(f"  Vulnerabilities:{summary['unique_vulnerabilities']}")
+    print(f"  Affected pkgs:  {summary['packages_with_vulns']}")
+    print(f"  In CISA KEV:    {summary['kev_findings']}")
+    print(f"  High EPSS (≥50%): {summary['high_epss_findings']}")
+    print(f"  Scan time:      {result['elapsed_seconds']}s")
+    print(f"{'='*60}\n")
+
+    if not findings:
+        print("  ✅ No known vulnerabilities found!\n")
+        return 0
+
+    for i, f in enumerate(findings, 1):
+        kev_marker = " 🔴 KEV" if f["in_kev"] else ""
+        epss_str = f"EPSS={f['epss_score']:.1%}" if f["epss_score"] else ""
+        fixed_str = f" → fix: {f['fixed_version']}" if f["fixed_version"] else ""
+
+        print(f"  [{i}] {f['vuln_id']}{kev_marker}")
+        print(f"      Package: {f['package']}=={f['version']} ({f['ecosystem']})")
+        print(f"      Source:  {f['source_file']}")
+        if f["aliases"]:
+            print(f"      CVEs:    {', '.join(f['aliases'])}")
+        if epss_str:
+            print(f"      {epss_str}")
+        if f["summary"]:
+            print(f"      {f['summary']}")
+        if fixed_str:
+            print(f"      {fixed_str}")
+        print()
+
+    return 0
+
+
 def _build_run_parser() -> argparse.ArgumentParser:
     """Build the top-level run/interactive parser."""
     parser = argparse.ArgumentParser(
@@ -2268,6 +2380,10 @@ def main() -> None:
     if first_positional == "blast-radius":
         idx = argv.index("blast-radius")
         sys.exit(_run_blast_radius(argv[idx + 1 :]))
+
+    if first_positional == "dep-audit":
+        idx = argv.index("dep-audit")
+        sys.exit(_run_dep_audit(argv[idx + 1 :]))
 
     if first_positional == "discover":
         idx = argv.index("discover")

--- a/src/manus_agent/tools/__init__.py
+++ b/src/manus_agent/tools/__init__.py
@@ -16,6 +16,7 @@ from strands_tools import (
 
 from manus_agent.tools.http_request import http_request
 from manus_agent.tools.python_repl import python_repl
+from manus_agent.tools.dep_audit import dep_audit
 
 # Collect all tools
 ALL_TOOLS = {
@@ -30,6 +31,7 @@ ALL_TOOLS = {
     "generate_image": generate_image,
     "current_time": current_time,
     "calculator": calculator,
+    "dep_audit": dep_audit,
 }
 
 

--- a/src/manus_agent/tools/dep_audit.py
+++ b/src/manus_agent/tools/dep_audit.py
@@ -1,0 +1,629 @@
+"""Tool: dep_audit
+
+Audit a project's dependencies for known vulnerabilities by parsing local
+manifest/lockfiles and querying OSV.dev in batch.
+
+Supported manifest formats:
+  - requirements.txt (Python/pip)
+  - package.json + package-lock.json (npm)
+  - go.mod (Go)
+  - Cargo.toml + Cargo.lock (Rust)
+  - Gemfile.lock (Ruby)
+  - pom.xml (Maven/Java)
+  - composer.json (PHP)
+
+Unlike sbom-scan (which requires a pre-generated CycloneDX/SPDX file), this
+tool works directly from raw project manifests — no SBOM generation step needed.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+from strands import tool
+
+__all__ = ["dep_audit", "audit_dependencies"]
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_OSV_BATCH_URL = "https://api.osv.dev/v1/querybatch"
+_EPSS_BATCH_URL = "https://api.first.org/data/v1/epss"
+_KEV_URL = "https://www.cisa.gov/sites/default/files/feeds/known-exploited-vulnerabilities.json"
+
+_USER_AGENT = "manus-agent/dep-audit (github.com/manus-use/manus-agent)"
+_MAX_BATCH_SIZE = 1000  # OSV batch limit
+_REQUEST_TIMEOUT = 20
+
+# Ecosystem mappings for OSV.dev
+_ECOSYSTEM_MAP = {
+    "requirements.txt": "PyPI",
+    "setup.py": "PyPI",
+    "pyproject.toml": "PyPI",
+    "package.json": "npm",
+    "package-lock.json": "npm",
+    "go.mod": "Go",
+    "Cargo.toml": "crates.io",
+    "Cargo.lock": "crates.io",
+    "Gemfile.lock": "RubyGems",
+    "pom.xml": "Maven",
+    "composer.json": "Packagist",
+    "composer.lock": "Packagist",
+}
+
+# ---------------------------------------------------------------------------
+# Parsers — extract (name, version) tuples from manifest files
+# ---------------------------------------------------------------------------
+
+# PEP 508 requirement line: name[extras] == version
+_PIP_RE = re.compile(
+    r"^([A-Za-z0-9][-A-Za-z0-9_.]*)"
+    r"(?:\[[^\]]*\])?"
+    r"\s*==\s*"
+    r"([^\s;#,]+)",
+)
+
+_GO_MOD_RE = re.compile(
+    r"^\s+([^\s]+)\s+v([^\s/]+)",
+)
+
+_CARGO_DEP_RE = re.compile(
+    r'^([A-Za-z0-9_-]+)\s*=\s*"([^"]+)"',
+)
+
+_CARGO_LOCK_RE = re.compile(
+    r'name\s*=\s*"([^"]+)"\s*\n\s*version\s*=\s*"([^"]+)"',
+    re.MULTILINE,
+)
+
+_GEMFILE_LOCK_RE = re.compile(
+    r"^\s{4}([A-Za-z0-9_.-]+)\s+\(([^\s)]+)\)",
+    re.MULTILINE,
+)
+
+_MAVEN_DEP_RE = re.compile(
+    r"<groupId>([^<]+)</groupId>\s*"
+    r"<artifactId>([^<]+)</artifactId>\s*"
+    r"<version>([^<$]+)</version>",
+    re.DOTALL,
+)
+
+
+def _parse_requirements_txt(content: str) -> list[dict[str, str]]:
+    """Parse requirements.txt for pinned packages."""
+    deps = []
+    for line in content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("-"):
+            continue
+        m = _PIP_RE.match(line)
+        if m:
+            deps.append({"name": m.group(1).lower(), "version": m.group(2)})
+    return deps
+
+
+def _parse_package_json(content: str) -> list[dict[str, str]]:
+    """Parse package.json for dependencies with semver-exact versions."""
+    deps = []
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return deps
+
+    for section in ("dependencies", "devDependencies"):
+        for name, version in data.get(section, {}).items():
+            clean = re.sub(r"^[~^>=<!\s]+", "", version)
+            if clean and re.match(r"\d", clean):
+                deps.append({"name": name, "version": clean})
+    return deps
+
+
+def _parse_package_lock_json(content: str) -> list[dict[str, str]]:
+    """Parse package-lock.json (v2/v3) for resolved packages."""
+    deps = []
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return deps
+
+    # v2/v3 format
+    packages = data.get("packages", {})
+    for path, info in packages.items():
+        if not path:
+            continue
+        name = info.get("name") or path.rsplit("node_modules/", 1)[-1]
+        version = info.get("version", "")
+        if name and version:
+            deps.append({"name": name, "version": version})
+
+    # v1 fallback
+    if not deps:
+        for name, info in data.get("dependencies", {}).items():
+            version = info.get("version", "")
+            if version:
+                deps.append({"name": name, "version": version})
+
+    return deps
+
+
+def _parse_go_mod(content: str) -> list[dict[str, str]]:
+    """Parse go.mod require block."""
+    deps = []
+    in_require = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("require ("):
+            in_require = True
+            continue
+        if in_require and stripped == ")":
+            in_require = False
+            continue
+        if in_require:
+            m = _GO_MOD_RE.match(line)
+            if m:
+                deps.append({"name": m.group(1), "version": m.group(2)})
+        elif stripped.startswith("require "):
+            m = re.match(r"^require\s+([^\s]+)\s+v([^\s]+)", stripped)
+            if m:
+                deps.append({"name": m.group(1), "version": m.group(2)})
+    return deps
+
+
+def _parse_cargo_lock(content: str) -> list[dict[str, str]]:
+    """Parse Cargo.lock for package entries."""
+    deps = []
+    for m in _CARGO_LOCK_RE.finditer(content):
+        deps.append({"name": m.group(1), "version": m.group(2)})
+    return deps
+
+
+def _parse_cargo_toml(content: str) -> list[dict[str, str]]:
+    """Parse Cargo.toml [dependencies] section (simple format only)."""
+    deps = []
+    in_deps = False
+    for line in content.splitlines():
+        stripped = line.strip()
+        if re.match(r"^\[dependencies\]", stripped, re.IGNORECASE):
+            in_deps = True
+            continue
+        if stripped.startswith("[") and in_deps:
+            in_deps = False
+            continue
+        if in_deps:
+            m = _CARGO_DEP_RE.match(stripped)
+            if m:
+                deps.append({"name": m.group(1), "version": m.group(2)})
+    return deps
+
+
+def _parse_gemfile_lock(content: str) -> list[dict[str, str]]:
+    """Parse Gemfile.lock GEM specs section."""
+    deps = []
+    for m in _GEMFILE_LOCK_RE.finditer(content):
+        deps.append({"name": m.group(1), "version": m.group(2)})
+    return deps
+
+
+def _parse_pom_xml(content: str) -> list[dict[str, str]]:
+    """Parse pom.xml <dependency> blocks with literal versions."""
+    deps = []
+    for m in _MAVEN_DEP_RE.finditer(content):
+        group_id = m.group(1).strip()
+        artifact_id = m.group(2).strip()
+        version = m.group(3).strip()
+        if "${" in version:
+            continue
+        deps.append({
+            "name": f"{group_id}:{artifact_id}",
+            "version": version,
+        })
+    return deps
+
+
+def _parse_composer_json(content: str) -> list[dict[str, str]]:
+    """Parse composer.json require section."""
+    deps = []
+    try:
+        data = json.loads(content)
+    except (json.JSONDecodeError, ValueError):
+        return deps
+
+    for section in ("require", "require-dev"):
+        for name, version in data.get(section, {}).items():
+            if name == "php" or name.startswith("ext-"):
+                continue
+            clean = re.sub(r"^[~^>=<!\s|]+", "", version)
+            if clean and re.match(r"\d", clean):
+                deps.append({"name": name, "version": clean})
+    return deps
+
+
+# Dispatcher
+_PARSERS = {
+    "requirements.txt": _parse_requirements_txt,
+    "package.json": _parse_package_json,
+    "package-lock.json": _parse_package_lock_json,
+    "go.mod": _parse_go_mod,
+    "Cargo.toml": _parse_cargo_toml,
+    "Cargo.lock": _parse_cargo_lock,
+    "Gemfile.lock": _parse_gemfile_lock,
+    "pom.xml": _parse_pom_xml,
+    "composer.json": _parse_composer_json,
+}
+
+
+def _detect_and_parse(directory: str) -> list[dict[str, Any]]:
+    """Auto-detect manifest files in directory and parse them.
+
+    Returns list of dicts: {name, version, ecosystem, source_file}
+    """
+    results: list[dict[str, Any]] = []
+    dir_path = Path(directory)
+
+    if not dir_path.is_dir():
+        return results
+
+    for filename, parser in _PARSERS.items():
+        filepath = dir_path / filename
+        if filepath.exists():
+            try:
+                content = filepath.read_text(encoding="utf-8", errors="replace")
+                deps = parser(content)
+                ecosystem = _ECOSYSTEM_MAP.get(filename, "")
+                for dep in deps:
+                    results.append({
+                        "name": dep["name"],
+                        "version": dep["version"],
+                        "ecosystem": ecosystem,
+                        "source_file": filename,
+                    })
+            except (OSError, UnicodeDecodeError):
+                continue
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# OSV.dev query
+# ---------------------------------------------------------------------------
+
+
+def _osv_batch_query(
+    packages: list[dict[str, Any]],
+    timeout: int = _REQUEST_TIMEOUT,
+) -> list[list[dict[str, Any]]]:
+    """Query OSV.dev batch endpoint for vulnerability data.
+
+    Returns a list (same length as packages) where each element is a list
+    of vulnerability dicts for that package.
+    """
+    if not packages:
+        return []
+
+    queries = []
+    for pkg in packages:
+        q: dict[str, Any] = {
+            "package": {
+                "name": pkg["name"],
+                "ecosystem": pkg["ecosystem"],
+            },
+            "version": pkg["version"],
+        }
+        queries.append(q)
+
+    all_results: list[list[dict[str, Any]]] = []
+
+    for i in range(0, len(queries), _MAX_BATCH_SIZE):
+        batch = queries[i: i + _MAX_BATCH_SIZE]
+        try:
+            resp = requests.post(
+                _OSV_BATCH_URL,
+                json={"queries": batch},
+                headers={"User-Agent": _USER_AGENT},
+                timeout=timeout,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            results = data.get("results", [])
+            for r in results:
+                vulns = r.get("vulns", [])
+                all_results.append(vulns)
+        except (requests.RequestException, ValueError, KeyError):
+            all_results.extend([[] for _ in batch])
+
+    return all_results
+
+
+# ---------------------------------------------------------------------------
+# EPSS enrichment
+# ---------------------------------------------------------------------------
+
+
+def _fetch_epss_scores(cve_ids: list[str]) -> dict[str, float]:
+    """Fetch EPSS scores for a list of CVE IDs. Returns {cve_id: score}."""
+    if not cve_ids:
+        return {}
+
+    scores: dict[str, float] = {}
+
+    for i in range(0, len(cve_ids), 100):
+        batch = cve_ids[i: i + 100]
+        try:
+            resp = requests.get(
+                _EPSS_BATCH_URL,
+                params={"cve": ",".join(batch)},
+                headers={"User-Agent": _USER_AGENT},
+                timeout=_REQUEST_TIMEOUT,
+            )
+            resp.raise_for_status()
+            data = resp.json()
+            for item in data.get("data", []):
+                cve = item.get("cve", "")
+                epss = item.get("epss")
+                if cve and epss is not None:
+                    try:
+                        scores[cve] = float(epss)
+                    except (ValueError, TypeError):
+                        pass
+        except (requests.RequestException, ValueError, KeyError):
+            continue
+
+    return scores
+
+
+# ---------------------------------------------------------------------------
+# KEV enrichment
+# ---------------------------------------------------------------------------
+
+
+def _fetch_kev_set() -> set[str]:
+    """Fetch CISA KEV catalog and return set of CVE IDs."""
+    try:
+        resp = requests.get(
+            _KEV_URL,
+            headers={"User-Agent": _USER_AGENT},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return {
+            v.get("cveID", "").upper()
+            for v in data.get("vulnerabilities", [])
+            if v.get("cveID")
+        }
+    except (requests.RequestException, ValueError, KeyError):
+        return set()
+
+
+# ---------------------------------------------------------------------------
+# Core audit logic
+# ---------------------------------------------------------------------------
+
+
+def audit_dependencies(
+    directory: str,
+    *,
+    include_dev: bool = True,
+    skip_epss: bool = False,
+    skip_kev: bool = False,
+) -> dict[str, Any]:
+    """Audit dependencies in a directory for known vulnerabilities.
+
+    Args:
+        directory: Path to the project directory containing manifest files.
+        include_dev: Whether to include devDependencies (default: True).
+        skip_epss: Skip EPSS score enrichment (faster).
+        skip_kev: Skip CISA KEV lookup (faster).
+
+    Returns:
+        Dict with audit results including findings, summary, and metadata.
+    """
+    start_time = time.time()
+
+    # 1. Parse manifests
+    packages = _detect_and_parse(directory)
+    if not packages:
+        return {
+            "status": "no_manifests",
+            "message": f"No supported manifest files found in {directory}",
+            "supported_files": list(_PARSERS.keys()),
+            "packages_scanned": 0,
+            "vulnerabilities_found": 0,
+            "findings": [],
+        }
+
+    # 2. Query OSV.dev
+    osv_results = _osv_batch_query(packages)
+
+    # 3. Collect all unique CVE IDs for enrichment
+    all_cve_ids: set[str] = set()
+    findings: list[dict[str, Any]] = []
+
+    for pkg, vulns in zip(packages, osv_results):
+        if not vulns:
+            continue
+        for vuln in vulns:
+            vuln_id = vuln.get("id", "")
+            aliases = vuln.get("aliases", [])
+            cve_ids = [a for a in aliases if a.startswith("CVE-")]
+            if vuln_id.startswith("CVE-"):
+                cve_ids.append(vuln_id)
+            cve_ids = list(set(cve_ids))
+            all_cve_ids.update(cve_ids)
+
+            # Extract severity
+            severity = ""
+            for s in vuln.get("severity", []):
+                if s.get("type") == "CVSS_V3":
+                    severity = s.get("score", "")
+                    break
+
+            # Extract affected version ranges
+            affected_ranges = []
+            for affected in vuln.get("affected", []):
+                pkg_info = affected.get("package", {})
+                if (
+                    pkg_info.get("name", "").lower() == pkg["name"].lower()
+                    or pkg_info.get("name", "") == pkg["name"]
+                ):
+                    for r in affected.get("ranges", []):
+                        events = r.get("events", [])
+                        introduced = ""
+                        fixed = ""
+                        for ev in events:
+                            if "introduced" in ev:
+                                introduced = ev["introduced"]
+                            if "fixed" in ev:
+                                fixed = ev["fixed"]
+                        if introduced or fixed:
+                            affected_ranges.append({
+                                "introduced": introduced,
+                                "fixed": fixed,
+                            })
+
+            finding = {
+                "package": pkg["name"],
+                "version": pkg["version"],
+                "ecosystem": pkg["ecosystem"],
+                "source_file": pkg["source_file"],
+                "vuln_id": vuln_id,
+                "aliases": cve_ids,
+                "summary": vuln.get("summary", "")[:200],
+                "severity_vector": severity,
+                "affected_ranges": affected_ranges,
+                "fixed_version": (
+                    affected_ranges[0]["fixed"]
+                    if affected_ranges and affected_ranges[0].get("fixed")
+                    else None
+                ),
+            }
+            findings.append(finding)
+
+    # 4. EPSS enrichment
+    epss_scores: dict[str, float] = {}
+    if not skip_epss and all_cve_ids:
+        epss_scores = _fetch_epss_scores(list(all_cve_ids))
+
+    # 5. KEV enrichment
+    kev_set: set[str] = set()
+    if not skip_kev and all_cve_ids:
+        kev_set = _fetch_kev_set()
+
+    # 6. Enrich findings with EPSS + KEV
+    for finding in findings:
+        best_epss = 0.0
+        in_kev = False
+        for cve in finding["aliases"]:
+            cve_upper = cve.upper()
+            if cve_upper in epss_scores:
+                best_epss = max(best_epss, epss_scores[cve_upper])
+            if cve_upper in kev_set:
+                in_kev = True
+        finding["epss_score"] = best_epss
+        finding["in_kev"] = in_kev
+
+    # 7. Sort findings by severity: KEV first, then EPSS desc
+    findings.sort(key=lambda f: (not f["in_kev"], -f["epss_score"]))
+
+    # 8. Build summary
+    unique_vulns = len({f["vuln_id"] for f in findings})
+    unique_packages_affected = len({f["package"] for f in findings})
+    kev_count = sum(1 for f in findings if f["in_kev"])
+    high_epss_count = sum(1 for f in findings if f["epss_score"] >= 0.5)
+
+    elapsed = round(time.time() - start_time, 2)
+
+    return {
+        "status": "completed",
+        "directory": directory,
+        "packages_scanned": len(packages),
+        "vulnerabilities_found": unique_vulns,
+        "packages_affected": unique_packages_affected,
+        "kev_count": kev_count,
+        "high_epss_count": high_epss_count,
+        "elapsed_seconds": elapsed,
+        "manifests_parsed": list({p["source_file"] for p in packages}),
+        "findings": findings,
+        "summary": {
+            "total_packages": len(packages),
+            "total_findings": len(findings),
+            "unique_vulnerabilities": unique_vulns,
+            "packages_with_vulns": unique_packages_affected,
+            "kev_findings": kev_count,
+            "high_epss_findings": high_epss_count,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Strands tool interface
+# ---------------------------------------------------------------------------
+
+TOOL_SPEC = {
+    "name": "dep_audit",
+    "description": (
+        "Audit a project directory's dependencies for known vulnerabilities. "
+        "Parses manifest files (requirements.txt, package.json, go.mod, "
+        "Cargo.lock, Gemfile.lock, pom.xml, composer.json) and queries "
+        "OSV.dev for known CVEs. Enriches results with EPSS scores and "
+        "CISA KEV status. Returns findings sorted by severity."
+    ),
+    "inputSchema": {
+        "json": {
+            "type": "object",
+            "properties": {
+                "directory": {
+                    "type": "string",
+                    "description": (
+                        "Path to the project directory containing manifest files "
+                        "(e.g. requirements.txt, package.json, go.mod)."
+                    ),
+                },
+                "skip_epss": {
+                    "type": "boolean",
+                    "description": "Skip EPSS score enrichment for faster results.",
+                    "default": False,
+                },
+                "skip_kev": {
+                    "type": "boolean",
+                    "description": "Skip CISA KEV lookup for faster results.",
+                    "default": False,
+                },
+            },
+            "required": ["directory"],
+        }
+    },
+}
+
+
+@tool
+def dep_audit(
+    directory: str,
+    skip_epss: bool = False,
+    skip_kev: bool = False,
+) -> str:
+    """Audit project dependencies for known vulnerabilities.
+
+    Parses manifest files in the given directory and queries OSV.dev for
+    known CVEs affecting the declared dependencies.
+
+    Args:
+        directory: Path to project directory with manifest files.
+        skip_epss: Skip EPSS enrichment (default: False).
+        skip_kev: Skip CISA KEV lookup (default: False).
+
+    Returns:
+        JSON string with audit results.
+    """
+    result = audit_dependencies(
+        directory,
+        skip_epss=skip_epss,
+        skip_kev=skip_kev,
+    )
+    return json.dumps(result, indent=2)

--- a/tests/test_dep_audit.py
+++ b/tests/test_dep_audit.py
@@ -1,0 +1,794 @@
+"""Comprehensive test suite for dep_audit tool.
+
+Tests cover:
+- All manifest parsers (requirements.txt, package.json, package-lock.json,
+  go.mod, Cargo.toml, Cargo.lock, Gemfile.lock, pom.xml, composer.json)
+- OSV.dev batch query logic
+- EPSS score enrichment
+- CISA KEV enrichment
+- Full audit pipeline (integration)
+- CLI text and JSON output
+- Edge cases (empty files, malformed input, partial failures)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from manus_agent.tools.dep_audit import (
+    _detect_and_parse,
+    _fetch_epss_scores,
+    _fetch_kev_set,
+    _osv_batch_query,
+    _parse_cargo_lock,
+    _parse_cargo_toml,
+    _parse_composer_json,
+    _parse_gemfile_lock,
+    _parse_go_mod,
+    _parse_package_json,
+    _parse_package_lock_json,
+    _parse_pom_xml,
+    _parse_requirements_txt,
+    audit_dependencies,
+)
+
+
+# ===========================================================================
+# Parser tests
+# ===========================================================================
+
+
+class TestParseRequirementsTxt:
+    """Tests for _parse_requirements_txt."""
+
+    def test_basic_pinned(self):
+        content = "requests==2.28.0\nflask==2.3.1\n"
+        result = _parse_requirements_txt(content)
+        assert len(result) == 2
+        assert result[0] == {"name": "requests", "version": "2.28.0"}
+        assert result[1] == {"name": "flask", "version": "2.3.1"}
+
+    def test_with_extras(self):
+        content = "requests[security]==2.28.0\n"
+        result = _parse_requirements_txt(content)
+        assert len(result) == 1
+        assert result[0] == {"name": "requests", "version": "2.28.0"}
+
+    def test_comments_and_blanks(self):
+        content = "# comment\n\nrequests==2.28.0\n# another comment\n\n"
+        result = _parse_requirements_txt(content)
+        assert len(result) == 1
+        assert result[0]["name"] == "requests"
+
+    def test_flags_ignored(self):
+        content = "-r other.txt\n--index-url https://x\nrequests==2.28.0\n"
+        result = _parse_requirements_txt(content)
+        assert len(result) == 1
+
+    def test_non_pinned_skipped(self):
+        content = "requests>=2.28.0\nflask~=2.3\ndjango\n"
+        result = _parse_requirements_txt(content)
+        assert len(result) == 0
+
+    def test_name_normalized_lowercase(self):
+        content = "Flask==2.3.1\nDjango-REST-Framework==3.14.0\n"
+        result = _parse_requirements_txt(content)
+        assert result[0]["name"] == "flask"
+        assert result[1]["name"] == "django-rest-framework"
+
+    def test_version_with_markers(self):
+        content = 'requests==2.28.0; python_version>="3.7"\n'
+        result = _parse_requirements_txt(content)
+        assert len(result) == 1
+        assert result[0]["version"] == "2.28.0"
+
+    def test_empty_content(self):
+        result = _parse_requirements_txt("")
+        assert result == []
+
+
+class TestParsePackageJson:
+    """Tests for _parse_package_json."""
+
+    def test_basic_deps(self):
+        content = json.dumps({
+            "dependencies": {"express": "^4.18.0", "lodash": "4.17.21"},
+            "devDependencies": {"jest": "~29.0.0"},
+        })
+        result = _parse_package_json(content)
+        assert len(result) == 3
+        names = {r["name"] for r in result}
+        assert "express" in names
+        assert "lodash" in names
+        assert "jest" in names
+
+    def test_strips_semver_prefixes(self):
+        content = json.dumps({"dependencies": {"pkg": "^1.2.3"}})
+        result = _parse_package_json(content)
+        assert result[0]["version"] == "1.2.3"
+
+    def test_invalid_json(self):
+        result = _parse_package_json("not json{{{")
+        assert result == []
+
+    def test_no_deps_key(self):
+        content = json.dumps({"name": "my-app", "version": "1.0.0"})
+        result = _parse_package_json(content)
+        assert result == []
+
+    def test_non_semver_versions_skipped(self):
+        content = json.dumps({
+            "dependencies": {"git-dep": "git+https://github.com/x/y.git"}
+        })
+        result = _parse_package_json(content)
+        assert result == []
+
+
+class TestParsePackageLockJson:
+    """Tests for _parse_package_lock_json."""
+
+    def test_v2_format(self):
+        content = json.dumps({
+            "lockfileVersion": 2,
+            "packages": {
+                "": {"name": "root", "version": "1.0.0"},
+                "node_modules/express": {"version": "4.18.2"},
+                "node_modules/lodash": {"version": "4.17.21", "name": "lodash"},
+            },
+        })
+        result = _parse_package_lock_json(content)
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert "express" in names
+        assert "lodash" in names
+
+    def test_v1_fallback(self):
+        content = json.dumps({
+            "lockfileVersion": 1,
+            "dependencies": {
+                "express": {"version": "4.18.2"},
+                "lodash": {"version": "4.17.21"},
+            },
+        })
+        result = _parse_package_lock_json(content)
+        assert len(result) == 2
+
+    def test_invalid_json(self):
+        result = _parse_package_lock_json("broken")
+        assert result == []
+
+
+class TestParseGoMod:
+    """Tests for _parse_go_mod."""
+
+    def test_basic_require_block(self):
+        content = """module example.com/myapp
+
+go 1.21
+
+require (
+\tgithub.com/gin-gonic/gin v1.9.1
+\tgithub.com/stretchr/testify v1.8.4
+)
+"""
+        result = _parse_go_mod(content)
+        assert len(result) == 2
+        assert result[0] == {"name": "github.com/gin-gonic/gin", "version": "1.9.1"}
+        assert result[1] == {"name": "github.com/stretchr/testify", "version": "1.8.4"}
+
+    def test_single_require(self):
+        content = "module x\ngo 1.21\nrequire github.com/pkg/errors v0.9.1\n"
+        result = _parse_go_mod(content)
+        assert len(result) == 1
+        assert result[0]["name"] == "github.com/pkg/errors"
+
+    def test_empty_mod(self):
+        content = "module example.com/x\ngo 1.21\n"
+        result = _parse_go_mod(content)
+        assert result == []
+
+
+class TestParseCargoLock:
+    """Tests for _parse_cargo_lock."""
+
+    def test_basic_packages(self):
+        content = '''[[package]]
+name = "serde"
+version = "1.0.188"
+
+[[package]]
+name = "tokio"
+version = "1.32.0"
+'''
+        result = _parse_cargo_lock(content)
+        assert len(result) == 2
+        assert result[0] == {"name": "serde", "version": "1.0.188"}
+        assert result[1] == {"name": "tokio", "version": "1.32.0"}
+
+    def test_empty(self):
+        result = _parse_cargo_lock("")
+        assert result == []
+
+
+class TestParseCargoToml:
+    """Tests for _parse_cargo_toml."""
+
+    def test_basic_deps(self):
+        content = '''[package]
+name = "myapp"
+version = "0.1.0"
+
+[dependencies]
+serde = "1.0"
+tokio = "1.32"
+
+[dev-dependencies]
+criterion = "0.5"
+'''
+        result = _parse_cargo_toml(content)
+        assert len(result) == 2
+        assert result[0] == {"name": "serde", "version": "1.0"}
+        assert result[1] == {"name": "tokio", "version": "1.32"}
+
+    def test_no_deps_section(self):
+        content = "[package]\nname = \"x\"\n"
+        result = _parse_cargo_toml(content)
+        assert result == []
+
+
+class TestParseGemfileLock:
+    """Tests for _parse_gemfile_lock."""
+
+    def test_basic_gems(self):
+        content = """GEM
+  remote: https://rubygems.org/
+  specs:
+    rack (3.0.8)
+    rails (7.0.6)
+      actioncable (= 7.0.6)
+
+PLATFORMS
+  ruby
+"""
+        result = _parse_gemfile_lock(content)
+        assert len(result) == 2
+        assert result[0] == {"name": "rack", "version": "3.0.8"}
+        assert result[1] == {"name": "rails", "version": "7.0.6"}
+
+    def test_empty(self):
+        result = _parse_gemfile_lock("")
+        assert result == []
+
+
+class TestParsePomXml:
+    """Tests for _parse_pom_xml."""
+
+    def test_basic_deps(self):
+        content = """<project>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>5.3.29</version>
+    </dependency>
+  </dependencies>
+</project>"""
+        result = _parse_pom_xml(content)
+        assert len(result) == 1
+        assert result[0] == {
+            "name": "org.springframework:spring-core",
+            "version": "5.3.29",
+        }
+
+    def test_skips_property_refs(self):
+        content = """<dependency>
+      <groupId>org.x</groupId>
+      <artifactId>y</artifactId>
+      <version>${project.version}</version>
+    </dependency>"""
+        result = _parse_pom_xml(content)
+        assert result == []
+
+    def test_empty(self):
+        result = _parse_pom_xml("")
+        assert result == []
+
+
+class TestParseComposerJson:
+    """Tests for _parse_composer_json."""
+
+    def test_basic_deps(self):
+        content = json.dumps({
+            "require": {
+                "php": ">=8.0",
+                "laravel/framework": "^9.0",
+                "ext-json": "*",
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5",
+            },
+        })
+        result = _parse_composer_json(content)
+        assert len(result) == 2
+        names = {r["name"] for r in result}
+        assert "laravel/framework" in names
+        assert "phpunit/phpunit" in names
+        # php and ext- should be skipped
+        assert "php" not in names
+
+    def test_invalid_json(self):
+        result = _parse_composer_json("not json")
+        assert result == []
+
+
+# ===========================================================================
+# _detect_and_parse tests
+# ===========================================================================
+
+
+class TestDetectAndParse:
+    """Tests for _detect_and_parse."""
+
+    def test_finds_requirements_txt(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.28.0\n")
+        result = _detect_and_parse(str(tmp_path))
+        assert len(result) == 1
+        assert result[0]["ecosystem"] == "PyPI"
+        assert result[0]["source_file"] == "requirements.txt"
+
+    def test_multiple_manifests(self, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.28.0\n")
+        (tmp_path / "package.json").write_text(
+            json.dumps({"dependencies": {"express": "4.18.0"}})
+        )
+        result = _detect_and_parse(str(tmp_path))
+        assert len(result) == 2
+        ecosystems = {r["ecosystem"] for r in result}
+        assert "PyPI" in ecosystems
+        assert "npm" in ecosystems
+
+    def test_nonexistent_directory(self):
+        result = _detect_and_parse("/nonexistent/path/xyz")
+        assert result == []
+
+    def test_empty_directory(self, tmp_path):
+        result = _detect_and_parse(str(tmp_path))
+        assert result == []
+
+
+# ===========================================================================
+# OSV batch query tests
+# ===========================================================================
+
+
+class TestOsvBatchQuery:
+    """Tests for _osv_batch_query."""
+
+    def test_empty_input(self):
+        result = _osv_batch_query([])
+        assert result == []
+
+    @patch("manus_agent.tools.dep_audit.requests.post")
+    def test_successful_query(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "results": [
+                {"vulns": [{"id": "GHSA-xxx", "aliases": ["CVE-2024-1234"]}]},
+                {"vulns": []},
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_post.return_value = mock_resp
+
+        packages = [
+            {"name": "requests", "version": "2.25.0", "ecosystem": "PyPI"},
+            {"name": "flask", "version": "2.3.1", "ecosystem": "PyPI"},
+        ]
+        result = _osv_batch_query(packages)
+        assert len(result) == 2
+        assert len(result[0]) == 1
+        assert result[0][0]["id"] == "GHSA-xxx"
+        assert result[1] == []
+
+    @patch("manus_agent.tools.dep_audit.requests.post")
+    def test_request_failure_returns_empty(self, mock_post):
+        import requests as _requests
+        mock_post.side_effect = _requests.ConnectionError("Network error")
+        packages = [{"name": "x", "version": "1.0", "ecosystem": "PyPI"}]
+        result = _osv_batch_query(packages)
+        assert len(result) == 1
+        assert result[0] == []
+
+    @patch("manus_agent.tools.dep_audit.requests.post")
+    def test_batch_splitting(self, mock_post):
+        """Verifies batching works for large package lists."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+
+        # Return empty vulns for each package
+        def side_effect(*args, **kwargs):
+            body = kwargs.get("json", {})
+            n = len(body.get("queries", []))
+            mock_resp.json.return_value = {
+                "results": [{"vulns": []} for _ in range(n)]
+            }
+            return mock_resp
+
+        mock_post.side_effect = side_effect
+
+        # Create 1500 packages (should split into 2 batches)
+        packages = [
+            {"name": f"pkg-{i}", "version": "1.0", "ecosystem": "PyPI"}
+            for i in range(1500)
+        ]
+        result = _osv_batch_query(packages)
+        assert len(result) == 1500
+        assert mock_post.call_count == 2
+
+
+# ===========================================================================
+# EPSS enrichment tests
+# ===========================================================================
+
+
+class TestFetchEpssScores:
+    """Tests for _fetch_epss_scores."""
+
+    def test_empty_input(self):
+        result = _fetch_epss_scores([])
+        assert result == {}
+
+    @patch("manus_agent.tools.dep_audit.requests.get")
+    def test_successful_fetch(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "data": [
+                {"cve": "CVE-2024-1234", "epss": "0.95"},
+                {"cve": "CVE-2024-5678", "epss": "0.01"},
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = _fetch_epss_scores(["CVE-2024-1234", "CVE-2024-5678"])
+        assert result["CVE-2024-1234"] == 0.95
+        assert result["CVE-2024-5678"] == 0.01
+
+    @patch("manus_agent.tools.dep_audit.requests.get")
+    def test_failure_returns_empty(self, mock_get):
+        import requests as _requests
+        mock_get.side_effect = _requests.Timeout("timeout")
+        result = _fetch_epss_scores(["CVE-2024-1234"])
+        assert result == {}
+
+    @patch("manus_agent.tools.dep_audit.requests.get")
+    def test_batch_splitting_100(self, mock_get):
+        """EPSS API limited to 100 per request."""
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"data": []}
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        cves = [f"CVE-2024-{i:04d}" for i in range(250)]
+        _fetch_epss_scores(cves)
+        assert mock_get.call_count == 3  # 100 + 100 + 50
+
+
+# ===========================================================================
+# KEV enrichment tests
+# ===========================================================================
+
+
+class TestFetchKevSet:
+    """Tests for _fetch_kev_set."""
+
+    @patch("manus_agent.tools.dep_audit.requests.get")
+    def test_successful_fetch(self, mock_get):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "vulnerabilities": [
+                {"cveID": "CVE-2024-1234"},
+                {"cveID": "CVE-2024-5678"},
+            ]
+        }
+        mock_resp.raise_for_status = MagicMock()
+        mock_get.return_value = mock_resp
+
+        result = _fetch_kev_set()
+        assert "CVE-2024-1234" in result
+        assert "CVE-2024-5678" in result
+
+    @patch("manus_agent.tools.dep_audit.requests.get")
+    def test_failure_returns_empty(self, mock_get):
+        import requests as _requests
+        mock_get.side_effect = _requests.Timeout("timeout")
+        result = _fetch_kev_set()
+        assert result == set()
+
+
+# ===========================================================================
+# Full audit integration tests
+# ===========================================================================
+
+
+class TestAuditDependencies:
+    """Tests for audit_dependencies."""
+
+    def test_no_manifests(self, tmp_path):
+        result = audit_dependencies(str(tmp_path))
+        assert result["status"] == "no_manifests"
+        assert result["packages_scanned"] == 0
+        assert result["vulnerabilities_found"] == 0
+
+    @patch("manus_agent.tools.dep_audit._fetch_kev_set")
+    @patch("manus_agent.tools.dep_audit._fetch_epss_scores")
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_full_pipeline(self, mock_osv, mock_epss, mock_kev, tmp_path):
+        # Setup manifest
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\nflask==2.0.0\n")
+
+        # Mock OSV response
+        mock_osv.return_value = [
+            [
+                {
+                    "id": "GHSA-j8r2-6x86-q33q",
+                    "aliases": ["CVE-2023-32681"],
+                    "summary": "Requests proxy credential leak",
+                    "severity": [{"type": "CVSS_V3", "score": "CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:C/C:H/I:N/A:N"}],
+                    "affected": [
+                        {
+                            "package": {"name": "requests", "ecosystem": "PyPI"},
+                            "ranges": [{"events": [{"introduced": "0"}, {"fixed": "2.31.0"}]}],
+                        }
+                    ],
+                }
+            ],
+            [],  # No vulns for flask
+        ]
+
+        # Mock EPSS
+        mock_epss.return_value = {"CVE-2023-32681": 0.42}
+
+        # Mock KEV
+        mock_kev.return_value = set()
+
+        result = audit_dependencies(str(tmp_path))
+
+        assert result["status"] == "completed"
+        assert result["packages_scanned"] == 2
+        assert result["vulnerabilities_found"] == 1
+        assert result["packages_affected"] == 1
+        assert len(result["findings"]) == 1
+
+        finding = result["findings"][0]
+        assert finding["package"] == "requests"
+        assert finding["version"] == "2.25.0"
+        assert finding["vuln_id"] == "GHSA-j8r2-6x86-q33q"
+        assert "CVE-2023-32681" in finding["aliases"]
+        assert finding["fixed_version"] == "2.31.0"
+        assert finding["epss_score"] == 0.42
+        assert finding["in_kev"] is False
+
+    @patch("manus_agent.tools.dep_audit._fetch_kev_set")
+    @patch("manus_agent.tools.dep_audit._fetch_epss_scores")
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_kev_findings_sorted_first(self, mock_osv, mock_epss, mock_kev, tmp_path):
+        (tmp_path / "requirements.txt").write_text("pkg-a==1.0\npkg-b==1.0\n")
+
+        mock_osv.return_value = [
+            [{"id": "GHSA-aaaa", "aliases": ["CVE-2024-0001"], "summary": "A", "severity": [], "affected": []}],
+            [{"id": "GHSA-bbbb", "aliases": ["CVE-2024-0002"], "summary": "B", "severity": [], "affected": []}],
+        ]
+        mock_epss.return_value = {"CVE-2024-0001": 0.9, "CVE-2024-0002": 0.1}
+        mock_kev.return_value = {"CVE-2024-0002"}  # Only pkg-b is in KEV
+
+        result = audit_dependencies(str(tmp_path))
+        assert result["findings"][0]["vuln_id"] == "GHSA-bbbb"  # KEV first
+        assert result["findings"][0]["in_kev"] is True
+        assert result["findings"][1]["vuln_id"] == "GHSA-aaaa"
+
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_skip_epss_and_kev(self, mock_osv, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\n")
+        mock_osv.return_value = [[]]
+
+        result = audit_dependencies(str(tmp_path), skip_epss=True, skip_kev=True)
+        assert result["status"] == "completed"
+        assert result["packages_scanned"] == 1
+
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_no_vulns_found(self, mock_osv, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+        mock_osv.return_value = [[]]
+
+        result = audit_dependencies(str(tmp_path), skip_epss=True, skip_kev=True)
+        assert result["vulnerabilities_found"] == 0
+        assert result["findings"] == []
+
+
+# ===========================================================================
+# CLI tests
+# ===========================================================================
+
+
+class TestCliDepAudit:
+    """Tests for the dep-audit CLI subcommand."""
+
+    @patch("manus_agent.tools.dep_audit._fetch_kev_set")
+    @patch("manus_agent.tools.dep_audit._fetch_epss_scores")
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_json_output(self, mock_osv, mock_epss, mock_kev, tmp_path, capsys):
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\n")
+        mock_osv.return_value = [[]]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        from manus_agent.cli import _run_dep_audit
+
+        exit_code = _run_dep_audit([str(tmp_path), "--output", "json"])
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert data["status"] == "completed"
+        assert data["packages_scanned"] == 1
+
+    @patch("manus_agent.tools.dep_audit._fetch_kev_set")
+    @patch("manus_agent.tools.dep_audit._fetch_epss_scores")
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_text_output_no_vulns(self, mock_osv, mock_epss, mock_kev, tmp_path, capsys):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+        mock_osv.return_value = [[]]
+        mock_epss.return_value = {}
+        mock_kev.return_value = set()
+
+        from manus_agent.cli import _run_dep_audit
+
+        exit_code = _run_dep_audit([str(tmp_path)])
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        assert "No known vulnerabilities found" in captured.out
+
+    @patch("manus_agent.tools.dep_audit._fetch_kev_set")
+    @patch("manus_agent.tools.dep_audit._fetch_epss_scores")
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_text_output_with_vulns(self, mock_osv, mock_epss, mock_kev, tmp_path, capsys):
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\n")
+        mock_osv.return_value = [
+            [{"id": "GHSA-test", "aliases": ["CVE-2024-9999"], "summary": "Test vuln", "severity": [], "affected": []}]
+        ]
+        mock_epss.return_value = {"CVE-2024-9999": 0.75}
+        mock_kev.return_value = {"CVE-2024-9999"}
+
+        from manus_agent.cli import _run_dep_audit
+
+        exit_code = _run_dep_audit([str(tmp_path)])
+        assert exit_code == 0
+
+        captured = capsys.readouterr()
+        assert "GHSA-test" in captured.out
+        assert "KEV" in captured.out
+        assert "EPSS=75.0%" in captured.out
+
+    def test_nonexistent_directory(self, capsys):
+        from manus_agent.cli import _run_dep_audit
+
+        exit_code = _run_dep_audit(["/nonexistent/dir/xyz"])
+        assert exit_code == 1
+
+        captured = capsys.readouterr()
+        assert "not found" in captured.err.lower() or "error" in captured.err.lower()
+
+    def test_no_manifests(self, tmp_path, capsys):
+        from manus_agent.cli import _run_dep_audit
+
+        exit_code = _run_dep_audit([str(tmp_path)])
+        assert exit_code == 1
+
+        captured = capsys.readouterr()
+        assert "No supported manifest files" in captured.out
+
+    def test_skip_flags(self, tmp_path, capsys):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+
+        from manus_agent.cli import _run_dep_audit
+
+        with patch("manus_agent.tools.dep_audit._osv_batch_query") as mock_osv, \
+             patch("manus_agent.tools.dep_audit._fetch_epss_scores") as mock_epss, \
+             patch("manus_agent.tools.dep_audit._fetch_kev_set") as mock_kev:
+            mock_osv.return_value = [[]]
+            mock_epss.return_value = {}
+            mock_kev.return_value = set()
+
+            exit_code = _run_dep_audit([
+                str(tmp_path), "--skip-epss", "--skip-kev"
+            ])
+            assert exit_code == 0
+            # EPSS and KEV should not be called when skipped
+            mock_epss.assert_not_called()
+            mock_kev.assert_not_called()
+
+
+# ===========================================================================
+# Strands tool interface tests
+# ===========================================================================
+
+
+class TestStrandsToolInterface:
+    """Tests for the @tool-decorated dep_audit function."""
+
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_returns_json_string(self, mock_osv, tmp_path):
+        (tmp_path / "requirements.txt").write_text("requests==2.31.0\n")
+        mock_osv.return_value = [[]]
+
+        from manus_agent.tools.dep_audit import dep_audit as dep_audit_fn
+
+        # The @tool decorator wraps it; call the underlying function
+        result = audit_dependencies(str(tmp_path), skip_epss=True, skip_kev=True)
+        assert isinstance(result, dict)
+        assert result["status"] == "completed"
+
+
+# ===========================================================================
+# Edge case tests
+# ===========================================================================
+
+
+class TestEdgeCases:
+    """Edge case tests."""
+
+    def test_binary_file_in_manifest_location(self, tmp_path):
+        """Binary file with manifest name should not crash."""
+        (tmp_path / "requirements.txt").write_bytes(b"\x00\x01\x02\x03")
+        result = _detect_and_parse(str(tmp_path))
+        # Should return empty or handle gracefully
+        assert isinstance(result, list)
+
+    def test_very_large_requirements(self, tmp_path):
+        """Handles large manifest files."""
+        lines = [f"pkg-{i}=={i}.0.0" for i in range(500)]
+        (tmp_path / "requirements.txt").write_text("\n".join(lines))
+        result = _detect_and_parse(str(tmp_path))
+        assert len(result) == 500
+
+    @patch("manus_agent.tools.dep_audit._osv_batch_query")
+    def test_duplicate_vulns_deduped_in_summary(self, mock_osv, tmp_path):
+        """Same vuln for same package should count once in unique_vulns."""
+        (tmp_path / "requirements.txt").write_text("requests==2.25.0\n")
+        mock_osv.return_value = [
+            [
+                {"id": "GHSA-xxx", "aliases": ["CVE-2024-1111"], "summary": "A", "severity": [], "affected": []},
+                {"id": "GHSA-xxx", "aliases": ["CVE-2024-1111"], "summary": "A", "severity": [], "affected": []},
+            ]
+        ]
+
+        result = audit_dependencies(str(tmp_path), skip_epss=True, skip_kev=True)
+        # Two findings (from raw data), but unique_vulns should deduplicate
+        assert result["vulnerabilities_found"] == 1
+
+    def test_go_mod_with_indirect(self):
+        """go.mod indirect deps should still parse."""
+        content = """module example.com/x
+
+require (
+\tgithub.com/pkg/errors v0.9.1
+\tgolang.org/x/text v0.13.0 // indirect
+)
+"""
+        result = _parse_go_mod(content)
+        assert len(result) == 2


### PR DESCRIPTION
## Summary

Add a dependency vulnerability auditor that scans a project's manifest files and queries OSV.dev for known CVEs — no pre-generated SBOM file needed.

## Motivation

Currently, `sbom-scan` requires a pre-generated CycloneDX or SPDX SBOM file, adding a prerequisite step for users who just want to quickly check their dependencies for vulnerabilities. `dep-audit` fills this gap by parsing raw manifest files directly, providing a zero-setup security audit workflow:

```bash
# Just point it at your project
manus-agent dep-audit .
```

## What's included

### New tool: `dep_audit` (`src/manus_agent/tools/dep_audit.py`)

- **9 manifest parsers** across 7 ecosystems:
  - `requirements.txt` (PyPI)
  - `package.json` / `package-lock.json` (npm)
  - `go.mod` (Go)
  - `Cargo.toml` / `Cargo.lock` (crates.io)
  - `Gemfile.lock` (RubyGems)
  - `pom.xml` (Maven)
  - `composer.json` (Packagist)
- **OSV.dev batch query** — efficient single-request lookup for up to 1000 packages
- **EPSS enrichment** — exploitation probability scores via FIRST.org API
- **CISA KEV enrichment** — flags actively exploited vulnerabilities
- **Smart sorting** — KEV findings surface first, then by EPSS probability
- **Fixed version recommendations** from OSV affected ranges
- **Graceful partial failure** — individual API errors don't break the pipeline
- **Strands `@tool` interface** for direct agent use
- **Public `audit_dependencies()` function** for programmatic consumption

### New CLI subcommand: `manus-agent dep-audit`

```bash
# Audit current directory
manus-agent dep-audit

# Audit a specific project
manus-agent dep-audit /path/to/project

# JSON output (for CI/piping)
manus-agent dep-audit . --output json

# Fast mode (skip enrichment)
manus-agent dep-audit . --skip-epss --skip-kev
```

### Test suite: 60 new tests (`tests/test_dep_audit.py`)

All HTTP calls fully mocked. Covers:
- Each manifest parser (success, edge cases, malformed input)
- Auto-detection and multi-manifest handling
- OSV batch query logic (success, failure, batching)
- EPSS score fetching (success, failure, batch splitting)
- CISA KEV lookup (success, failure)
- Full audit integration pipeline
- CLI text/JSON output modes
- Edge cases (binary files, large manifests, deduplication)

## Test results

```
60 passed in 1.35s (new tests)
1218 passed, 3 deselected, 3 warnings in 25.67s (full suite)
```

## Key design decisions

1. **Direct manifest parsing vs SBOM requirement** — `sbom-scan` is the right tool when you already have a BOM; `dep-audit` is for quick project-level audits without any setup
2. **OSV.dev as primary data source** — free, comprehensive, and supports batch queries; no API key needed
3. **EPSS + KEV enrichment** — enables actionable prioritization beyond just "has a CVE"
4. **Batch APIs throughout** — efficient even for large projects (OSV batch: 1000/req, EPSS: 100/req)